### PR TITLE
fix: handle commas in category names

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -118,6 +118,14 @@ Available modes: `fast-movers`, `emerging`, `single-variant`, `high-demand-low-b
 
 **Keyword matching:** Default is `fuzzy` (matches brand names too — e.g. "smart ring" matches "Smart Color Art" pens). Use `--keyword-match-type exact` or `phrase` for precise results. Always combine with `--category` when possible to reduce noise.
 
+**Category path with commas:** Some category names contain commas (e.g. "Pacifiers, Teethers & Teething Relief"). Use ` > ` separator instead of `,` to avoid parsing errors:
+```bash
+# ❌ Wrong — comma in name breaks parsing
+--category "Baby Products,Baby Care,Pacifiers, Teethers & Teething Relief"
+# ✅ Correct — use ' > ' separator
+--category "Baby Products > Baby Care > Pacifiers, Teethers & Teething Relief"
+```
+
 ### competitors — Competitor lookup
 
 ```bash

--- a/scripts/apiclaw.py
+++ b/scripts/apiclaw.py
@@ -222,10 +222,18 @@ def output(data, fmt="json"):
 # ─── Helper: parse category string ──────────────────────────────────────────
 
 def parse_category(cat_str: str) -> list:
-    """Parse 'Pet Supplies,Dogs,Toys' or 'Pet Supplies > Dogs > Toys' into a list."""
+    """Parse category path string into a list.
+
+    Supported formats (in priority order):
+    1. ' > ' separator: 'Pet Supplies > Dogs > Toys'  (recommended, handles commas in names)
+    2. ',' separator:   'Pet Supplies,Dogs,Toys'       (legacy, breaks on names with commas)
+
+    Use ' > ' when category names contain commas, e.g.:
+    'Baby Products > Baby Care > Pacifiers, Teethers & Teething Relief'
+    """
     if not cat_str:
         return []
-    # Support both comma and ' > ' separators
+    # Prefer ' > ' separator — handles commas in category names correctly
     if " > " in cat_str:
         return [c.strip() for c in cat_str.split(" > ")]
     return [c.strip() for c in cat_str.split(",")]


### PR DESCRIPTION
## Problem
Category names containing commas (e.g. `Pacifiers, Teethers & Teething Relief`) are split incorrectly by `parse_category()`, causing API to return empty results.

## Fix
- Document ` > ` separator as the preferred format (already supported, just undocumented)
- Add clear guidance in SKILL.md with correct/incorrect examples
- Improve `parse_category()` docstring

## Example
```bash
# Before (broken): splits into 4 segments
--category "Baby Products,Baby Care,Pacifiers, Teethers & Teething Relief"

# After (works): splits into 3 segments  
--category "Baby Products > Baby Care > Pacifiers, Teethers & Teething Relief"
```