### PR TITLE
fix: correct 6 product selection mode filters

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -231,20 +231,20 @@ All interfaces return `.data` as an **array**. Use `.data[0]` to get the first r
 
 | User Intent | Mode | Key Filters |
 |-------------|------|-------------|
-| "underserved" / "has pain points" | `--mode underserved` | Sales≥300, rating≤3.7 |
-| "high demand low barrier" / "easy entry" | `--mode high-demand-low-barrier` | Sales≥300, reviews≤50 |
-| "beginner friendly" / "new seller" | `--mode beginner` | Sales≥300, $15-60, FBA |
+| "beginner friendly" / "new seller" | `--mode beginner` | Sales≥300, growth≥3%, $15-60, FBA, ≤1yr, excl. red ocean keywords |
 | "fast turnover" / "hot selling" | `--mode fast-movers` | Sales≥300, growth≥10% |
-| "emerging" / "rising" | `--mode emerging` | Sales≤600, growth≥10% |
-| "single variant" / "small but beautiful" | `--mode single-variant` | Growth≥20%, variants=1 |
-| "long tail" / "niche" | `--mode long-tail` | BSR 10K-50K, ≤$30 |
-| "new products" / "new release" | `--mode new-release` | Sales≤500, New Release tag |
+| "emerging" / "rising" | `--mode emerging` | Sales≤600, growth≥10%, ≤180d |
+| "single variant" / "small but beautiful" | `--mode single-variant` | Growth≥20%, variants=1, ≤180d |
+| "high demand low barrier" / "easy entry" | `--mode high-demand-low-barrier` | Sales≥300, reviews≤50, ≤180d |
+| "long tail" / "niche" | `--mode long-tail` | Sales≤300, BSR 10K-50K, ≤$30, sellers≤1 |
+| "underserved" / "has pain points" | `--mode underserved` | Sales≥300, rating≤3.7, ≤180d |
+| "new products" / "new release" | `--mode new-release` | Sales≤500, NR tag, FBA+FBM |
+| "FBM" / "self-fulfillment" / "low stock" | `--mode fbm-friendly` | Sales≥300, FBM, ≤180d |
 | "low price" / "cheap" | `--mode low-price` | ≤$10 |
-| "top sellers" / "best sellers" | `--mode top-bsr` | BSR≤1000 |
-| "FBM" / "self-fulfillment" | `--mode fbm-friendly` | Sales≥300, FBM |
-| "broad catalog" / "cast wide net" | `--mode broad-catalog` | BSR growth≥99%, reviews≤10 |
-| "selective catalog" | `--mode selective-catalog` | BSR growth≥99% |
-| "speculative" / "piggyback" | `--mode speculative` | Sales≥600, sellers≥3 |
+| "broad catalog" / "cast wide net" | `--mode broad-catalog` | BSR growth≥99%, reviews≤10, ≤90d |
+| "selective catalog" | `--mode selective-catalog` | BSR growth≥99%, ≤90d |
+| "speculative" / "piggyback" | `--mode speculative` | Sales≥600, sellers≥3, ≤180d |
+| "top sellers" / "best sellers" | `--mode top-bsr` | Sub-category BSR≤1000 |
 
 ---
 

--- a/scripts/apiclaw.py
+++ b/scripts/apiclaw.py
@@ -41,17 +41,20 @@ PRODUCT_MODES = {
     "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
     "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
     "high-demand-low-barrier":  {"monthlySalesMin": 300, "reviewCountMax": 50, "listingAge": "180"},
-    "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1},
+    "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
     "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
-    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"]},
-    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillment": ["FBM"]},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillment": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillment": ["FBM"], "listingAge": "180"},
     "low-price":                {"priceMax": 10},
     "broad-catalog":            {"bsrGrowthRateMin": 0.99, "reviewCountMax": 10, "listingAge": "90"},
     "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
-    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3},
-    "beginner":                 {"monthlySalesMin": 300, "priceMin": 15, "priceMax": 60, "fulfillment": ["FBA"]},
-    "top-bsr":                  {"bsrMax": 1000},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "beginner":                 {"monthlySalesMin": 300, "priceMin": 15, "priceMax": 60, "fulfillment": ["FBA"],
+                                 "salesGrowthRateMin": 0.03, "listingAge": "365",
+                                 "excludeKeywords": "Brow,Air Fryer,Body Fragrance Mist,Ornament,Ivory,Bed Comforter,Biker Shorts,Mens Dress Shoe,Charms,Dumbbell,Gaming Chair,Skipping Rope,Hoops,Plus Hoola,Kids Bike Helmet,Socks,Cushion,Camping Hammock,Double Leggings,Yoga,Hand Warmers,Trail Camera,Water Bottle,Insulated Food,Pillow,Pillows,iPhone,Dog Bark Collar,Leg Covers,Leg Cover,Laptop Stand,Pet Briefs,Brief,Hangers,Hanger,Slip Rug Pad,rossbody,Fanny Pack,Bedding,Dog Harness,Sweet Water Decor,Eyeshadow,Cotton Sleepsack,Swaddle,Chocolate Bra,Wireless Bed Sheet Set,Car Windshield Curtain,Curtains,Wallet,Green Tea,Picture Frame,Womens,Women Fan,Bottle,Essential Oil,Tumbler,YETI,Vitamin,Vitamins,Face Mask,Led Strip,Pocket,Women's Watch,Waffle Case,Gloves,Shorts,Short Yoga,StrawExpert,Wrap Around Pillowcases,Cup,Bath Mats,Bedsure,Pillowcase,Bathroom,Shower,Milk Frother,Masks,Bug Zapper,Touchless Thermometer,Cat Litter Mat,Probiotics,Smart Plug,Natural Vitality Bottle,Christmas,Sleeveless,Shape Shifting Box,Refrigerator Organizer,Hydration Multiplier,Standard Mouth,Gift Box,USB C,Superhero,Digital Caliper,Massage Gun,Fidget Toys,Garden Hose,Cookie,Blanket,Protein Bars,Caramel Cashew,String Lights,Umbrella,Wearable Blanket,Diapers,Halloween,Flying Toys,Laundry Basket,Kitchen Faucet,Citrulline Malate,Onesie,Pajamas,Nail Polish Kit,fairy finder,Allergy,Immune Supplement,Frying Pan,Tablecloth,Electric Knife,Butter Dish,Dancing Cactus,Maya Mint,ice Cream,Christmas Tree,Liquid Motion Lamp,Stuffed Animal,Plush Bed Comforter,Journal,Women's,Sleeveless Wrap,Supplement,Screen Magnifier,Foot Massager,Machine,Santa,Anime Heroes,Air Mattress,Three Barrel Curling,3D Printer Filament,Power Strip,Rechargeable Toothbrush,Hooded Bathrobe,Sleepwear,Baby Einstein,Vinyl,Plastic Plates,Doorbell,Month Planner,Wooden Balls,Arceus,Wipes,Perfume,Rings,Bore Sight,Fishing Lures,Ear Protection,Firewood Rack,Sling Bag,Resistance Bands,Belt,Backpacks,Silver Slides,Whiteboard,Sports Bra,Cover,Jade Stud,Earrings,Necklace,Snow Shovel,Computer Desk,Dog Pee Pads,Turtleneck,Glasses,Spa,Up Balancer"},
+    "top-bsr":                  {"subBsrMax": 1000},
 }
+
 
 # ─── API Client ──────────────────────────────────────────────────────────────
 
@@ -330,6 +333,10 @@ def cmd_products(args):
         params["variantCountMax"] = args.variant_count_max
     if args.keyword_match_type:
         params["keywordMatchType"] = args.keyword_match_type
+    if args.sub_bsr_max is not None:
+        params["subBsrMax"] = args.sub_bsr_max
+    if args.exclude_keywords:
+        params["excludeKeywords"] = args.exclude_keywords
     if args.listing_age:
         params["listingAge"] = args.listing_age
     if args.badges:
@@ -637,6 +644,8 @@ Examples:
     p_prod.add_argument("--variant-count-max", type=int, help="Max variant count")
     p_prod.add_argument("--keyword-match-type", choices=["fuzzy", "phrase", "exact"],
                         help="Keyword match type (default: fuzzy)")
+    p_prod.add_argument("--sub-bsr-max", type=int, help="Max sub-category BSR rank")
+    p_prod.add_argument("--exclude-keywords", help="Keywords to exclude (comma-separated)")
     p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
     p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
     p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")


### PR DESCRIPTION
## Problem
Product selection modes had missing/incorrect filter conditions compared to the official APIClaw website.

## Changes (6 modes fixed)

| Mode | Fix |
|------|-----|
| **beginner** | Added: growth≥3%, listing≤1yr, 172 red ocean exclude keywords |
| **long-tail** | Added: monthlySalesMax 300 |
| **new-release** | Added: fulfillment FBA+FBM |
| **fbm-friendly** | Added: listingAge 180 days |
| **speculative** | Added: listingAge 180 days |
| **top-bsr** | Changed: `bsrMax` → `subBsrMax` (sub-category BSR≤1000) |

## New CLI parameters
- `--sub-bsr-max`: Filter by sub-category BSR
- `--exclude-keywords`: Comma-separated keywords to exclude from results

## SKILL.md
Updated mode mapping table with corrected filter descriptions.