### PR TITLE
Add skill.json metadata and improve credential security

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -17,13 +17,18 @@ description: >
 
 - Required: `APICLAW_API_KEY`
 - Scope: used only for `https://api.apiclaw.io`
-- Storage: `config.json` in the skill root directory (next to SKILL.md)
+- Resolution order:
+  1. **Environment variable** `APICLAW_API_KEY` (preferred, most secure)
+  2. **Config file** `config.json` in the skill root directory (fallback)
 
 ```json
 { "api_key": "hms_live_xxxxxx" }
 ```
 
-When user provides a Key, write it to `config.json`. New keys may need 3-5 seconds to activate — if first call returns 403, wait 3 seconds and retry (max 2 retries).
+**Credential configuration:**
+- **Recommended:** User sets `APICLAW_API_KEY` as environment variable before invoking the skill
+- **Alternative:** If user explicitly chooses to persist the key locally, confirm with them that the key will be written to `config.json` in the skill directory (on disk), then proceed. Remind user that `.gitignore` already excludes this file.
+- **Activation delay:** New keys may need 3-5 seconds to activate — if first call returns 403, wait 3 seconds and retry (max 2 retries).
 
 **New users:** Get API Key at [apiclaw.io/api-keys](https://apiclaw.io/api-keys).
 

--- a/skill.json
+++ b/skill.json
@@ -1,0 +1,16 @@
+{
+  "name": "Amazon-analysis-skill",
+  "version": "1.0.0",
+  "description": "Amazon seller data analysis tool using APIClaw API for market research, product selection, and competitor analysis",
+  "author": "SerendipityOneInc",
+  "license": "MIT",
+  "env_vars": [
+    {
+      "name": "APICLAW_API_KEY",
+      "description": "API key for APIClaw service (obtain from apiclaw.io/api-keys)",
+      "required": true,
+      "scope": "api.apiclaw.io"
+    }
+  ],
+  "requires_python": ">=3.8"
+}


### PR DESCRIPTION
## Summary

This PR addresses the ClawHub security scan warnings by:

1. **Adding `skill.json` metadata** - Declares required `APICLAW_API_KEY` environment variable
2. **Improving credential handling in SKILL.md** - Prioritizes environment variables and requires user confirmation before writing keys to disk

## Changes

### New File: `skill.json`
- Declares `APICLAW_API_KEY` as required environment variable
- Specifies scope as `api.apiclaw.io`
- Includes version and license metadata

### Modified: `SKILL.md`
- ✅ Added credential resolution order (env var → config file)
- ✅ Changed from unconditional "write to config.json" to conditional with user confirmation
- ✅ Explicitly warns users that alternative method writes secrets to disk
- ✅ Emphasizes environment variable as recommended approach

## Security Impact

### Before
- ❌ No metadata declaration of required credentials
- ❌ SKILL.md directly instructs AI to write API keys to disk
- ❌ Users not informed about security implications

### After
- ✅ Metadata correctly declares environment variable requirement
- ✅ Requires user confirmation before persisting secrets
- ✅ Clear security guidance with recommended practices

## ClawHub Security Scan Expected Results

- **CREDENTIALS**: ~~Suspicious~~ → **Pass** (metadata matches actual requirements)
- **INSTRUCTION SCOPE**: ~~Suspicious~~ → **Pass** (no unconditional secret persistence)
- **PURPOSE & CAPABILITY**: ~~Warning~~ → **Pass** (consistent metadata)

## Test Plan

- [ ] Verify skill loads correctly in ClawHub
- [ ] Confirm security scan passes
- [ ] Test environment variable credential resolution
- [ ] Test config.json fallback with user confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)