### PR TITLE
Fix: improve credential handling security

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -35,7 +35,10 @@ credentials:
 { "api_key": "hms_live_xxxxxx" }
 ```
 
-When user provides a Key, write it to `config.json`. New keys may need 3-5 seconds to activate — if first call returns 403, wait 3 seconds and retry (max 2 retries).
+**Credential configuration:**
+- **Recommended:** User sets `APICLAW_API_KEY` as environment variable before invoking the skill
+- **Alternative:** If user explicitly chooses to persist the key locally, confirm with them that the key will be written to `config.json` in the skill directory (on disk), then proceed. Remind user that `.gitignore` already excludes this file.
+- **Activation delay:** New keys may need 3-5 seconds to activate — if first call returns 403, wait 3 seconds and retry (max 2 retries).
 
 **New users:** Get API Key at [apiclaw.io/api-keys](https://apiclaw.io/api-keys).
 


### PR DESCRIPTION
## Summary

This PR addresses the remaining ClawHub security concern from PR #6 by improving how the skill handles API key configuration.

## Changes

### Modified: `SKILL.md` (line 38)

**Before:**
```markdown
When user provides a Key, write it to `config.json`.
```

**After:**
```markdown
**Credential configuration:**
- **Recommended:** User sets `APICLAW_API_KEY` as environment variable before invoking the skill
- **Alternative:** If user explicitly chooses to persist the key locally, confirm with them that the key will be written to `config.json` in the skill directory (on disk), then proceed. Remind user that `.gitignore` already excludes this file.
- **Activation delay:** New keys may need 3-5 seconds to activate — if first call returns 403, wait 3 seconds and retry (max 2 retries).
```

## Security Impact

### Before
- ❌ SKILL.md directly instructs AI to unconditionally write API keys to disk
- ❌ Users not informed about security implications of config.json storage

### After
- ✅ Requires user confirmation before persisting secrets
- ✅ Explicitly warns that alternative method writes secrets to disk
- ✅ Clear guidance emphasizing environment variable as recommended practice

## Why This Change?

PR #6 already added:
- ✅ `credentials` declaration in SKILL.md frontmatter
- ✅ Resolution order (env var → config.json)

But the **instruction at line 38 still unconditionally directed the AI to write keys to disk**, which triggered the ClawHub "INSTRUCTION SCOPE" warning.

This PR completes the security improvements by making credential storage:
1. **Conditional** - only with explicit user consent
2. **Transparent** - users are warned about disk persistence
3. **Guided** - environment variable clearly marked as recommended

## ClawHub Security Scan Expected Result

- **INSTRUCTION SCOPE**: ~~Suspicious~~ → **Pass** (no unconditional secret persistence)

## Test Plan

- [ ] Verify skill loads correctly in ClawHub
- [ ] Confirm security scan passes
- [ ] Test that AI now asks for user confirmation before writing to config.json
- [ ] Verify environment variable method still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)