### PR TITLE
feat: update review→rating fields and add new product metrics

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -79,7 +79,7 @@ print(f"API Key saved to {config_path}")
 
 | Scenario | Load File | Reason |
 |----------|-----------|---------|
-| Need to confirm field names | `reference.md` | Avoid field name errors (e.g. ratingCount vs reviewCount)|
+| Need to confirm field names | `reference.md` | Avoid field name errors (e.g. ratingCount vs ratingMonthlyNew)|
 | Need filter parameter details | `reference.md` | Get complete Min/Max parameter list |
 | Pricing strategy analysis | `scenarios.md` | Contains pricing SOP and reference framework |
 | Daily operations analysis | `scenarios.md` | Contains monitoring and alert logic |
@@ -124,7 +124,7 @@ python scripts/apiclaw.py market --category "Pet Supplies,Dogs" --topn 10
 python scripts/apiclaw.py market --keyword "treadmill"
 ```
 
-Key output fields: `sampleAvgMonthlySales`, `sampleAvgPrice`, `topSalesRate` (concentration), `topBrandSalesRate`, `sampleNewSkuRate`, `sampleFbaRate`, `sampleBrandCount`
+Key output fields: `sampleAvgMonthlySales`, `sampleAvgPrice`, `topSalesRate` (concentration), `topBrandSalesRate`, `sampleNewSkuRate`, `sampleFbaRate`, `sampleBrandCount`, `sampleNewSkuAvgPrice` (new product avg price), `sampleNewSkuAvgMonthlySaleCnt` (new product avg sales), `sampleNewSkuAvgRatingAmt` (new product avg rating), `sampleNewSkuAvgRatingCnt` (new product avg rating count), `sampleNewSkuCount` (new product count), `sampleNewSkuRate` (new product rate)
 
 ### products — Product selection with filters
 
@@ -134,7 +134,7 @@ python scripts/apiclaw.py products --keyword "yoga mat" --mode beginner
 python scripts/apiclaw.py products --keyword "pet toys" --mode high-demand-low-barrier
 
 # Or use explicit filters
-python scripts/apiclaw.py products --keyword "yoga mat" --sales-min 300 --reviews-max 50
+python scripts/apiclaw.py products --keyword "yoga mat" --sales-min 300 --ratings-max 50
 python scripts/apiclaw.py products --keyword "yoga mat" --growth-min 0.1 --listing-age 180
 
 # Combine mode + overrides (overrides win)
@@ -155,7 +155,7 @@ python scripts/apiclaw.py competitors --asin B09V3KXJPB
 
 | ❌ Common Error | ✅ Correct Field | Description |
 |------------|------------|------|
-| `reviewCount` | `ratingCount` | Review count |
+| `reviewMonthlyNew` | `ratingMonthlyNew` | Monthly new ratings (renamed) |
 | `bsr` | `bsrRank` | BSR ranking |
 | `monthlySales` | `salesMonthly` | Monthly sales |
 
@@ -170,7 +170,7 @@ python scripts/apiclaw.py product --asin B09V3KXJPB
 python scripts/apiclaw.py product --asin B09V3KXJPB --marketplace JP
 ```
 
-Returns: title, brand, rating, ratingBreakdown, features (bullets), topReviews, specifications, variants, bestsellersRank, buyboxWinner
+Returns: title, brand, rating, ratingBreakdown, features (bullets), specifications, variants, bestsellersRank, buyboxWinner
 
 ### report — Full market analysis (composite)
 
@@ -234,7 +234,7 @@ jq '.data[:5] | .[] | .title'
 | User Intent | Mode | Filter Conditions |
 |----------|------|----------|
 | "underserved market" / "has pain points" / "can improve" | `--mode underserved` | Monthly sales≥300, rating≤3.7, within 6 months |
-| "high demand low barrier" / "easy to do" / "easy entry" | `--mode high-demand-low-barrier` | Monthly sales≥300, reviews≤50, within 6 months |
+| "high demand low barrier" / "easy to do" / "easy entry" | `--mode high-demand-low-barrier` | Monthly sales≥300, ratings≤50, within 6 months |
 | "beginner friendly" / "suitable for new sellers" / "entry level" | `--mode beginner` | Monthly sales≥300, $15-60, FBA |
 | "fast turnover" / "good sellers" / "hot selling" | `--mode fast-movers` | Monthly sales≥300, growth≥10% |
 | "emerging products" / "rising period" | `--mode emerging` | Monthly sales≤600, growth≥10%, within 6 months |
@@ -244,7 +244,7 @@ jq '.data[:5] | .[] | .title'
 | "low price products" / "cheap" | `--mode low-price` | ≤$10 |
 | "top sellers" / "best sellers" / "top seller" | `--mode top-bsr` | BSR≤1000 |
 | "self-fulfillment friendly" / "FBM" | `--mode fbm-friendly` | Monthly sales≥300, FBM |
-| "broad catalog mode" / "cast wide net" | `--mode broad-catalog` | BSR growth≥99%, reviews≤10, within 90 days |
+| "broad catalog mode" / "cast wide net" | `--mode broad-catalog` | BSR growth≥99%, ratings≤10, within 90 days |
 | "selective catalog" | `--mode selective-catalog` | BSR growth≥99%, within 90 days |
 | "speculative" / "piggyback selling opportunities" | `--mode speculative` | Monthly sales≥600, sellers≥3 |
 | "complete report" / "full report" | `report --keyword XXX` | No |
@@ -283,7 +283,7 @@ jq '.data[:5] | .[] | .title'
 | Metric | High | Medium | Low |
 |--------|------|--------|-----|
 | BSR | Top 1000 | 1000–5000 | > 5000 |
-| Reviews | < 200 | 200–1000 | > 1000 |
+| Rating count | < 200 | 200–1000 | > 1000 |
 | Rating | > 4.3 | 4.0–4.3 | < 4.0 |
 | Negative reviews (1-2 star %) | < 10% | 10–20% | > 20% |
 
@@ -309,7 +309,7 @@ When `salesMonthly` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
 | Sampling Method | [sampleType, e.g. by_sale_100] |
 | Top N | [topN value, e.g. 10] |
 | Sort | [sortBy + sortOrder, e.g. monthlySales desc] |
-| Filter Conditions | [Specific parameter values, e.g. monthlySalesMin: 300, reviewCountMax: 50] |
+| Filter Conditions | [Specific parameter values, e.g. monthlySalesMin: 300, ratingCountMax: 50] |
 
 **Data Notes**
 - Monthly sales are **estimated values** based on BSR + sampling model, not official Amazon data
@@ -319,7 +319,7 @@ When `salesMonthly` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
 
 **Rules**:
 1. Must include this block after every analysis
-2. Filter conditions should be specific to parameter values (e.g. `monthlySalesMin: 300, reviewCountMax: 50`)
+2. Filter conditions should be specific to parameter values (e.g. `monthlySalesMin: 300, ratingCountMax: 50`)
 3. If multiple interfaces used, list each one
 4. If data has limitations (e.g. missing historical trends), proactively explain
 
@@ -333,7 +333,7 @@ When `salesMonthly` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
 - Traffic source analysis
 - Historical sales trends (14-month curves)
 - Historical price / BSR charts
-- AI review sentiment analysis (use topReviews + ratingBreakdown manually)
+- Raw individual review text (topReviews removed from realtime/product; use reviews/analyze for structured insights)
 
 ### API Data Coverage Boundaries
 

--- a/references/reference.md
+++ b/references/reference.md
@@ -60,7 +60,7 @@ Response fields: `categoryId`, `categoryName`, `categoryPath`, `hasChildren`, `i
 | sampleAvgPriceMin/Max | Avg price |
 | sampleAvgBsrMin/Max | Avg BSR |
 | sampleAvgRatingMin/Max | Avg rating |
-| sampleAvgReviewCountMin/Max | Avg review count |
+| sampleAvgRatingCountMin/Max | Avg rating count |
 | sampleAvgGrossMarginMin/Max | Avg gross margin |
 | totalSkuCountMin/Max | Total SKU count |
 | sampleSkuCountMin/Max | Sample SKU count |
@@ -75,6 +75,10 @@ Response fields: `categoryId`, `categoryName`, `categoryPath`, `hasChildren`, `i
 | sampleAmzRateMin/Max | Amazon direct rate |
 | sampleNewSkuCountMin/Max | New SKU count |
 | sampleNewSkuRateMin/Max | New SKU rate |
+| sampleNewSkuAvgPriceMin/Max | New product avg price |
+| sampleNewSkuAvgMonthlySaleCntMin/Max | New product avg sales |
+| sampleNewSkuAvgRatingAmtMin/Max | New product avg rating |
+| sampleNewSkuAvgRatingCntMin/Max | New product avg rating count |
 
 ### Key response fields
 
@@ -86,11 +90,16 @@ Response fields: `categoryId`, `categoryName`, `categoryPath`, `hasChildren`, `i
 | sampleAvgMonthlySales | Average monthly units per product |
 | sampleAvgMonthlyRevenue | Average monthly revenue per product |
 | sampleAvgRating | Average rating |
-| sampleAvgReviewCount | Average reviews |
+| sampleAvgRatingCount | Average ratings |
 | sampleBrandCount | Number of brands |
 | sampleSellerCount | Number of sellers |
 | sampleFbaRate | FBA ratio (decimal) |
 | sampleNewSkuRate | New product ratio |
+| sampleNewSkuAvgPrice | New product avg price |
+| sampleNewSkuAvgMonthlySaleCnt | New product avg sales |
+| sampleNewSkuAvgRatingAmt | New product avg rating |
+| sampleNewSkuAvgRatingCnt | New product avg rating count |
+| sampleNewSkuCount | New product count |
 | **topSalesRate** | **Product concentration** — Top N share of total sales |
 | **topBrandSalesRate** | **Brand concentration** — Top N brands' share |
 | **topSellerSalesRate** | **Seller concentration** — Top N sellers' share |
@@ -110,7 +119,7 @@ Response fields: `categoryId`, `categoryName`, `categoryPath`, `hasChildren`, `i
 | seller | String | Seller filter |
 | asin | String | ASIN filter |
 | categoryPath | List\<String\> | Category filter |
-| sortBy | String | `monthlySales` / `monthlyRevenue` / `bsr` / `price` / `rating` / `reviewCount` / `listingDate` |
+| sortBy | String | `monthlySales` / `monthlyRevenue` / `bsr` / `price` / `rating` / `ratingCount` / `listingDate` |
 | sortOrder | String | `asc` / `desc` |
 | pageSize | Integer | default 20 |
 
@@ -143,12 +152,12 @@ Same as competitor-lookup plus:
 | bsrGrowthRateMin/Max | BSR growth rate |
 | priceMin/Max | Price range |
 | ratingMin/Max | Rating range |
-| reviewCountMin/Max | Review count range |
+| ratingCountMin/Max | Rating count range |
 | fbaShippingMin/Max | FBA shipping cost |
 | variantCountMin/Max | Variant count |
 | qaCountMin/Max | Q&A count |
-| monthlyNewReviewsMin/Max | Monthly new reviews |
-| reviewRateMin/Max | Review rate |
+| monthlyNewRatingsMin/Max | Monthly new ratings |
+| ratingRateMin/Max | Rating rate |
 | grossMarginMin/Max | Gross margin |
 | lqsMin/Max | Listing quality score |
 | sellerCountMin/Max | Seller count |
@@ -188,7 +197,6 @@ Same as competitor-lookup plus:
 | specifications | Key-value tech specs |
 | categories | Category path |
 | variants | Variant list with dimensions |
-| topReviews | Top reviews with title, body, rating, date, helpful_votes |
 | bestsellersRank | BSR info: `[{category, rank}, ...]` |
 | buyboxWinner | Buy Box: price, fulfillment, seller |
 | images | All image URLs |
@@ -229,7 +237,8 @@ Same as competitor-lookup plus:
 |-------|------|---------|
 | rating | Float | Rating (0-5) |
 | ratingCount | Integer | Total ratings |
-| reviewMonthlyNew | Integer | Monthly new reviews |
+| ratingMonthlyNew | Integer | Monthly new ratings |
+| ratingRate | Float | Rating rate |
 | isBestSeller | Boolean | Best Seller badge |
 | isAmazonChoice | Boolean | Amazon's Choice badge |
 | hasAPlus | Boolean | A+ content |
@@ -266,7 +275,7 @@ Same as competitor-lookup plus:
 | Metric | Source | High potential | Medium | Low potential |
 |--------|--------|---------------|--------|---------------|
 | BSR rank | bestsellersRank | Top 1000 | 1000–5000 | > 5000 |
-| Review count | reviewCount | < 200 | 200–1000 | > 1000 |
+| Rating count | ratingCount | < 200 | 200–1000 | > 1000 |
 | Rating | rating | > 4.3 | 4.0–4.3 | < 4.0 |
 | Negative review % | ratingBreakdown (1+2 star) | < 10% | 10–20% | > 20% |
 

--- a/references/scenarios.md
+++ b/references/scenarios.md
@@ -44,9 +44,9 @@ python scripts/apiclaw.py products --keyword "pet toys" --mode underserved --pag
 | Dimension | Weight | Data Source |
 |------|------|---------|
 | Demand Strength | 25% | salesMonthly |
-| Competition Difficulty | 25% | reviewCount + sellerCount |
+| Competition Difficulty | 25% | ratingCount + sellerCount |
 | Profit Margin | 20% | price × profitMargin |
-| Differentiation Opportunity | 15% | rating < 4.3 or reviewCount < 200 |
+| Differentiation Opportunity | 15% | rating < 4.3 or ratingCount < 200 |
 | User Match | 15% | Budget/Experience/Preferences |
 
 **Output Template**
@@ -62,7 +62,7 @@ python scripts/apiclaw.py products --keyword "pet toys" --mode underserved --pag
 | Preferences | ... |
 
 ## Top 5 Recommended Products
-| # | ASIN | Product | Price | Monthly Sales | Reviews | Comprehensive Score | Recommendation Reason |
+| # | ASIN | Product | Price | Monthly Sales | Ratings | Comprehensive Score | Recommendation Reason |
 |---|------|------|------|-------|-------|---------|---------|
 
 ## Action Recommendations
@@ -86,7 +86,7 @@ python scripts/apiclaw.py competitors --keyword "wireless earbuds" --page-size 5
 
 **Analysis Dimensions**:
 - Chinese sellers count ratio (vs total sellers)
-- Common traits of top Chinese sellers (price range, review count, listing time)
+- Common traits of top Chinese sellers (price range, rating count, listing time)
 - Listing strategies of successful Chinese sellers (can use `product --asin XXX` for details)
 - Replicable strategy points
 
@@ -103,7 +103,7 @@ python scripts/apiclaw.py competitors --keyword "wireless earbuds" --page-size 5
 | Top Chinese Seller Average Price | $X |
 
 ## Top 5 Chinese Seller Products
-| # | ASIN | Brand | Price | Monthly Sales | Rating | Reviews | Listing Date |
+| # | ASIN | Brand | Price | Monthly Sales | Rating | Ratings | Listing Date |
 |---|------|------|------|-------|------|------|---------|
 
 ## Success Strategy Analysis
@@ -125,17 +125,18 @@ python scripts/apiclaw.py competitors --keyword "wireless earbuds" --page-size 5
 
 ```bash
 python scripts/apiclaw.py product --asin B09V3KXJPB
-# → Analyze topReviews + ratingBreakdown
+# → Analyze ratingBreakdown from realtime/product
+# → Use reviews/analyze for structured consumer insights
 ```
 
-**Key Information Extracted from topReviews**:
+**Key Information from ratingBreakdown + analyze**:
 
 | Analysis Dimension | Focus Points |
 |---------|-------|
 | Negative review keywords | broke, defect, quality, returned, disappointed, cheap, flimsy, doesn't work |
 | Positive review highlights | easy, great value, love, perfect, amazing, sturdy, well-made, exactly as described |
 | Negative review ratio | 1-2 star ratio in ratingBreakdown (> 20% is high risk) |
-| Improvement opportunities | Specific problems repeatedly mentioned in negative reviews → Product differentiation direction |
+| Improvement opportunities | Specific problems from analyze consumerInsights → Product differentiation direction |
 
 **Output Template**
 
@@ -152,10 +153,10 @@ python scripts/apiclaw.py product --asin B09V3KXJPB
 | 1⭐ | X% | X |
 
 ## Positive Review Themes
-[Extract top 3 positive review themes from topReviews]
+[Extract top 3 positive themes from analyze consumerInsights]
 
 ## Negative Review Pain Points
-[Extract top 3 negative review themes from topReviews → These are differentiation opportunities]
+[Extract top 3 negative themes from analyze consumerInsights → These are differentiation opportunities]
 
 ## Improvement Suggestions
 [Product improvement directions based on pain points]
@@ -182,7 +183,7 @@ python scripts/apiclaw.py product --asin B08YYYYY
 | Monthly Sales | salesMonthly | Demand validation |
 | BSR | bsrRank | Ranking comparison |
 | Rating | rating | Product quality |
-| Review Count | ratingCount | Competition barrier |
+| Rating Count | ratingCount | Competition barrier |
 | Profit Margin | profitMargin | Profitability |
 | Variant Count | variantCount | Product complexity |
 | FBA Fee | fbaFee | Cost comparison |
@@ -212,7 +213,7 @@ python scripts/apiclaw.py competitors --keyword "product keyword" --page-size 20
 | Risk Dimension | Data Source | 🟢 Low Risk | 🟡 Medium Risk | 🔴 High Risk |
 |---------|---------|---------|---------|---------|
 | Competition Intensity | topSalesRate | < 40% | 40-60% | > 60% |
-| Review Barrier | Top average reviewCount | < 200 | 200-1000 | > 1000 |
+| Rating Barrier | Top average ratingCount | < 200 | 200-1000 | > 1000 |
 | Brand Barrier/Moat | topBrandSalesRate | < 30% | 30-50% | > 50% |
 | Price War Risk | Top price variance | High variance (dispersed) | Medium | Low variance (price war) |
 | Compliance Risk | categories category | Regular categories | Requires certification | High-risk categories |
@@ -239,7 +240,7 @@ python scripts/apiclaw.py competitors --keyword "product keyword" --page-size 20
 | Risk Dimension | Risk Level | Description |
 |---------|---------|------|
 | Competition Intensity | 🟢/🟡/🔴 | ... |
-| Review Barrier | 🟢/🟡/🔴 | ... |
+| Rating Barrier | 🟢/🟡/🔴 | ... |
 | Brand Barrier/Moat | 🟢/🟡/🔴 | ... |
 | Price War Risk | 🟢/🟡/🔴 | ... |
 | Compliance Risk | 🟢/🟡/🔴 | ... |
@@ -266,12 +267,12 @@ python scripts/apiclaw.py competitors --asin B09XXXXX
 |-----|---------|------|
 | API Direct Return | `salesMonthly` field | ⭐⭐⭐⭐ Most accurate (BSR model estimation) |
 | BSR Rough Estimate | Monthly sales ≈ 300,000 / BSR^0.65 | ⭐⭐ Rough (due to category differences) |
-| Review Reverse Calculation | Monthly sales ≈ reviewMonthlyNew / Review rate(1-3%) | ⭐⭐ Reference only |
+| Rating Reverse Calculation | Monthly sales ≈ ratingMonthlyNew / Rating rate(1-3%) | ⭐⭐ Reference only |
 
 **Usage Priority**:
 1. Prioritize `salesMonthly` direct return value
 2. If null, use BSR rough estimate
-3. Review reverse calculation only for cross-validation
+3. Rating reverse calculation only for cross-validation
 
 **Note**: Current API has no sales historical trends (14-month curves), only current snapshot, cannot predict growth/decline direction.
 

--- a/scripts/apiclaw.py
+++ b/scripts/apiclaw.py
@@ -40,13 +40,13 @@ PRODUCT_MODES = {
     "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
     "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
     "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
-    "high-demand-low-barrier":  {"monthlySalesMin": 300, "reviewCountMax": 50, "listingAge": "180"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180"},
     "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1},
     "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
     "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"]},
     "fbm-friendly":             {"monthlySalesMin": 300, "fulfillment": ["FBM"]},
     "low-price":                {"priceMax": 10},
-    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "reviewCountMax": 10, "listingAge": "90"},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90"},
     "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
     "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3},
     "beginner":                 {"monthlySalesMin": 300, "priceMin": 15, "priceMax": 60, "fulfillment": ["FBA"]},
@@ -287,7 +287,7 @@ def cmd_products(args):
             sys.exit(1)
 
     # Override with explicit filters
-    for attr in ("monthlySalesMin", "monthlySalesMax", "reviewCountMin", "reviewCountMax",
+    for attr in ("monthlySalesMin", "monthlySalesMax", "ratingCountMin", "ratingCountMax",
                  "priceMin", "priceMax", "ratingMin", "ratingMax", "bsrMin", "bsrMax",
                  "salesGrowthRateMin", "salesGrowthRateMax", "sellerCountMin", "sellerCountMax",
                  "variantCountMin", "variantCountMax"):
@@ -304,10 +304,10 @@ def cmd_products(args):
         params["monthlySalesMin"] = args.sales_min
     if args.sales_max is not None:
         params["monthlySalesMax"] = args.sales_max
-    if args.reviews_min is not None:
-        params["reviewCountMin"] = args.reviews_min
-    if args.reviews_max is not None:
-        params["reviewCountMax"] = args.reviews_max
+    if args.ratings_min is not None:
+        params["ratingCountMin"] = args.ratings_min
+    if args.ratings_max is not None:
+        params["ratingCountMax"] = args.ratings_max
     if args.price_min is not None:
         params["priceMin"] = args.price_min
     if args.price_max is not None:
@@ -463,7 +463,7 @@ def cmd_opportunity(args):
     search_params = {
         "keyword": keyword,
         "monthlySalesMin": 300,
-        "reviewCountMax": 50,
+        "ratingCountMax": 50,
         "sortBy": "monthlySales",
         "sortOrder": "desc",
         "pageSize": 20,
@@ -573,7 +573,7 @@ Examples:
   %(prog)s categories --keyword "pet supplies"
   %(prog)s market --category "Pet Supplies,Dogs" --topn 10
   %(prog)s products --keyword "yoga mat" --mode beginner
-  %(prog)s products --keyword "yoga mat" --sales-min 300 --reviews-max 50
+  %(prog)s products --keyword "yoga mat" --sales-min 300 --ratings-max 50
   %(prog)s competitors --keyword "wireless earbuds" --brand Anker
   %(prog)s product --asin B09V3KXJPB
   %(prog)s report --keyword "pet supplies"
@@ -612,8 +612,8 @@ Examples:
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
     p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
     p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
-    p_prod.add_argument("--reviews-min", type=int, help="Min review count")
-    p_prod.add_argument("--reviews-max", type=int, help="Max review count")
+    p_prod.add_argument("--ratings-min", type=int, help="Min rating count")
+    p_prod.add_argument("--ratings-max", type=int, help="Max rating count")
     p_prod.add_argument("--price-min", type=float, help="Min price")
     p_prod.add_argument("--price-max", type=float, help="Max price")
     p_prod.add_argument("--rating-min", type=float, help="Min rating")


### PR DESCRIPTION
## Changes

### Background
APIClaw API made two key changes:
1. Market endpoints added new product (新品) metrics
2. Review-related fields replaced with rating-related fields across non-review-analysis endpoints

### Modified Files (4 files, 56 insertions, 46 deletions)

**SKILL.md**
- Updated confused fields table, examples, mode descriptions, limitations
- Removed topReviews references

**references/reference.md**
- Replaced reviewCount/reviewMonthlyNew with ratingCount/ratingMonthlyNew
- Added 6 new sampleNewSku* response fields and 8 new filters
- Replaced sampleAvgReviewCount with sampleAvgRatingCount
- Removed topReviews from realtime/product response

**references/scenarios.md**
- Review Barrier → Rating Barrier
- Review Reverse Calculation → Rating Reverse Calculation (using ratingMonthlyNew)
- Updated Review Insights section to use analyze + ratingBreakdown instead of topReviews
- Updated AI scoring dimensions to use ratingCount

**scripts/apiclaw.py**
- CLI args: --reviews-min/max → --ratings-min/max
- Preset modes: reviewCountMax → ratingCountMax
- Opportunity workflow: reviewCountMax → ratingCountMax