### PR TITLE
feat: enforce mandatory Data Source block in Full Mode output

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -327,13 +327,15 @@ When `atLeastMonthlySales` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
 
 ---
 
-## Output Standards (Full Mode Only)
+## ⚠️ Output Standards (Full Mode — MANDATORY, DO NOT SKIP)
 
-**MUST include data source block after every Full-mode analysis:**
+> **Two blocks are REQUIRED at the end of every Full-mode analysis: ① Data Source & Conditions, ② API Usage. Missing either one = violating the skill contract.**
+
+### ① Data Source & Conditions (Full Mode Only)
 
 ```markdown
 ---
-**Data Source & Conditions**
+📋 **Data Source & Conditions**
 | Item | Value |
 |----|-----|
 | Data Source | APIClaw API |
@@ -356,6 +358,7 @@ When `atLeastMonthlySales` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
 2. Filter conditions MUST list specific parameter values
 3. If multiple interfaces used, list each one
 4. If data has limitations, proactively explain
+5. ⚠️ **Self-check:** scan your response — if you don't see `📋 **Data Source & Conditions**`, ADD IT before replying
 
 ### ⚠️ API Usage Summary (All Modes — MANDATORY, DO NOT SKIP)
 


### PR DESCRIPTION
## Changes

- Add ⚠️ MANDATORY marker to Output Standards section title
- Add summary reminder at top: **two blocks required** (① Data Source & Conditions, ② API Usage)
- Add self-check rule for Data Source block (scan for 📋 marker)
- Add 📋 emoji to Data Source template for visual consistency with 📊 API Usage
- Restructure as numbered subsections

## Why

Follow-up to #16. The AI agent was still skipping the Data Source & Conditions block even after API Usage enforcement was added. Same root cause — the original 'MUST' language is not strong enough for LLMs. This applies the same enforcement pattern.

## Impact

+6 lines / -3 lines, no structural changes.