### PR TITLE
fix(apiclaw): correct API parameters and field names — verified with live testing

### DIFF
--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -24,12 +24,12 @@ New keys need 3-5 seconds to activate. If 403, wait and retry.
 
 | # | Endpoint | What It Does | Key Output |
 |---|----------|-------------|------------|
-| 1 | `categories` | Browse Amazon category tree | categoryName, productCount, hasChildren |
-| 2 | `markets/search` | Market-level aggregate metrics | avg sales, avg price, brand count, concentration, FBA rate |
-| 3 | `products/search` | Product search with 14 preset strategies | ASIN, title, price, BSR, monthly sales, rating, reviews |
+| 1 | `categories` | Browse Amazon category tree | categoryName, categoryPath, productCount, hasChildren |
+| 2 | `markets/search` | Market-level aggregate metrics | sampleAvgMonthlySales, sampleAvgPrice, sampleBrandCount, topSalesRate, sampleFbaRate |
+| 3 | `products/search` | Product search with 14 preset strategies | asin, title, price, bsrRank, atLeastMonthlySales, rating, ratingCount |
 | 4 | `products/competitor-lookup` | Competitor analysis by keyword/ASIN | competitive products with sales, revenue, seller info |
-| 5 | `realtime/product` | Live single-ASIN detail | price, BSR, reviews, features, variants, buy box |
-| 6 | `reviews/analyze` | AI-powered review insights | sentiment, pain points, buying factors, user profiles |
+| 5 | `realtime/product` | Live single-ASIN detail | title, rating, features, variants, bestsellersRank, buyboxWinner |
+| 6 | `reviews/analyze` | AI-powered review insights | sentimentDistribution, consumerInsights (painPoints, buyingFactors, etc.) |
 
 ## Endpoint Details
 
@@ -37,17 +37,20 @@ New keys need 3-5 seconds to activate. If 403, wait and retry.
 Browse or search Amazon's category hierarchy.
 ```
 POST /openapi/v2/categories
-{"keyword": "pet supplies"}         # search by keyword
-{"parentCategoryName": "Pet Supplies"}  # browse children
+{"categoryKeyword": "pet supplies"}                    # search by keyword
+{"parentCategoryPath": ["Pet Supplies"]}               # browse children
 ```
+⚠️ Use `categoryKeyword` (not `keyword`) and `parentCategoryPath` (not `parentCategoryName`).
 
-### 2. Market
+### 2. Markets
 Category-level market metrics — answer "Is this market worth entering?"
 ```
 POST /openapi/v2/markets/search
-{"category": "Pet Supplies,Dogs,Toys", "topN": 10}
+{"categoryPath": ["Pet Supplies", "Dogs", "Toys"], "topN": "10"}
 ```
-Returns: avg monthly sales, avg price, brand count, seller count, concentration ratios, new SKU rate, FBA rate.
+⚠️ `topN` must be a **string** (`"3"`, `"5"`, `"10"`, `"20"`), NOT an integer.
+
+Returns: sampleAvgMonthlySales, sampleAvgPrice, sampleBrandCount, sampleSellerCount, topSalesRate (concentration), sampleNewSkuRate, sampleFbaRate.
 
 ### 3. Products
 Product search with filters or 14 built-in selection modes.
@@ -57,7 +60,7 @@ POST /openapi/v2/products/search
 ```
 **14 modes**: beginner, fast-movers, emerging, long-tail, underserved, new-release, fbm-friendly, low-price, single-variant, high-demand-low-barrier, broad-catalog, selective-catalog, speculative, top-bsr.
 
-Monthly sales field: `atLeastMonthlySales` (lower-bound estimate).
+Key fields: `atLeastMonthlySales` (lower-bound estimate), `bsrRank` (integer), `ratingCount` (not reviewCount), `price`, `profitMargin`, `fbaFee`.
 
 ### 4. Competitors
 Competitor discovery by keyword, brand, or specific ASIN.
@@ -66,46 +69,105 @@ POST /openapi/v2/products/competitor-lookup
 {"keyword": "wireless earbuds"}
 {"asin": "B09V3KXJPB"}
 ```
+Returns same product fields as `products/search`.
 
 ### 5. Realtime Product
-Live data for a single ASIN — current price, BSR, reviews, features, variants.
+Live data for a single ASIN — current listing content and pricing.
 ```
 POST /openapi/v2/realtime/product
 {"asin": "B09V3KXJPB"}
 ```
-⚠️ Does NOT return monthly sales or profit margin. Use products/competitors for those.
+
+Key response fields:
+| Field | Type | Note |
+|-------|------|------|
+| `title`, `brand` | String | Basic info |
+| `rating`, `ratingCount` | Float/Int | Rating data |
+| `ratingBreakdown` | Object | `{five_star: {percentage, count}, ...}` |
+| `features` | List | Bullet points |
+| `bestsellersRank` | Array | `[{category, rank}, ...]` — NOT a single integer |
+| `buyboxWinner` | Object | `{price, fulfillment, seller}` — price is nested here |
+| `topReviews` | List | Top reviews with title, body, rating |
+| `variants` | List | All variants with dimensions |
+
+⚠️ Does **NOT** return: `atLeastMonthlySales`, `profitMargin`, `fbaFee`, `sellerCount`. Use `products/competitor-lookup` for those.
+⚠️ Price is nested: `buyboxWinner.price`, NOT top-level `price`.
 
 ### 6. Review Analysis
 AI-powered consumer insights from customer reviews.
 ```
 POST /openapi/v2/reviews/analyze
-{"asin": "B09V3KXJPB"}
-{"asins": ["B09V3KXJPB", "B08YYYYY"]}          # compare products
-{"category": "Pet Supplies,Dogs,Toys", "period": "90d"}  # category-level
+
+# Single or multiple ASINs (mode + asins required)
+{"mode": "asin", "asins": ["B09V3KXJPB"]}
+{"mode": "asin", "asins": ["B09V3KXJPB", "B08YYYYY"]}
+
+# Category-level insights
+{"mode": "category", "categoryPath": "Pet Supplies,Dogs,Toys", "period": "90d"}
+
+# Filter to specific dimensions
+{"mode": "asin", "asins": ["B09V3KXJPB"], "labelType": "painPoints"}
 ```
-11 insight dimensions: painPoints, improvements, buyingFactors, issues, positives, scenarios, keywords, userProfiles, usageTimes, usageLocations, behaviors.
+
+⚠️ `mode` is **required** (`"asin"` or `"category"`).
+⚠️ Use `asins` (plural, array), NOT `asin` (singular string).
+
+11 insight dimensions (labelType): `painPoints`, `improvements`, `buyingFactors`, `issues`, `positives`, `scenarios`, `keywords`, `userProfiles`, `usageTimes`, `usageLocations`, `behaviors`.
+
+Returns: `totalReviews`, `avgRating`, `sentimentDistribution`, `ratingDistribution`, `consumerInsights`, `topKeywords`, `verifiedRatio`.
+
+## ⚠️ Field Differences Across Endpoints
+
+The 4 endpoint types return **different fields**. Do NOT assume they share the same structure.
+
+| Data | `markets` | `products`/`competitors` | `realtime/product` | `reviews/analyze` |
+|------|-----------|--------------------------|--------------------|--------------------|
+| Monthly Sales | sampleAvgMonthlySales | ✅ atLeastMonthlySales | ❌ | ❌ |
+| Price | sampleAvgPrice | price | buyboxWinner.price | ❌ |
+| BSR | sampleAvgBsr | bsrRank (integer) | bestsellersRank (array) | ❌ |
+| Rating | sampleAvgRating | rating | rating | avgRating |
+| Review Count | sampleAvgReviewCount | ratingCount | ratingCount | totalReviews |
+| Sentiment | ❌ | ❌ | ❌ | ✅ sentimentDistribution |
+| Consumer Insights | ❌ | ❌ | ❌ | ✅ consumerInsights |
+| Pain Points | ❌ | ❌ | ❌ (manual from topReviews) | ✅ AI-analyzed |
+| Profit Margin | ❌ | profitMargin | ❌ | ❌ |
+| FBA Fee | ❌ | fbaFee | ❌ | ❌ |
+| Features/Bullets | ❌ | ❌ | ✅ features | ❌ |
+| Variants | ❌ | variantCount (integer) | variants (full list) | ❌ |
 
 ## What Each Endpoint Is Best For
 
 | Need | Use This |
 |------|----------|
-| Sales & competition data | `products` / `competitors` |
+| Sales, pricing, competition data | `products/search` or `products/competitor-lookup` |
 | Live pricing, reviews, listing content | `realtime/product` |
 | Category-level market sizing | `markets/search` |
-| Consumer pain points & insights | `reviews/analyze` |
+| Consumer pain points, sentiment, buying factors | `reviews/analyze` |
 | Category browsing / validation | `categories` |
+| Full product picture | Combine `products` (quantitative) + `realtime` (qualitative) + `reviews` (insights) |
+
+## Known Quirks
+
+1. `topN` and `newProductPeriod` are **strings** — use `"10"` not `10`
+2. `listingAge` is a **string** — use `"180"` not `180`
+3. All response `.data` is an **array** — use `.data[0]` not `.data.fieldName`
+4. `ratingCount` not `reviewCount` — the field is called `ratingCount` everywhere
+5. `bsrRank` (integer) in products/competitors vs `bestsellersRank` (array) in realtime
+6. Rate limit: 100 req/min, 10 req/sec burst
 
 ## Credits
 
 - Each API call consumes credits
-- Response includes `_credits.consumed` and `_credits.remaining`
+- Response includes `meta.creditsConsumed` and `meta.creditsRemaining`
+- Minimum 50 reviews required for `reviews/analyze` (returns `INSUFFICIENT_REVIEWS` error otherwise)
 - Plans & rates: [apiclaw.io/pricing](https://apiclaw.io/pricing)
 
 ## Data Notes
 
-- **Monthly sales** (`atLeastMonthlySales`) is a lower-bound estimate — variance across tools is normal
+- **Monthly sales** (`atLeastMonthlySales`) is a lower-bound estimate — actual may be higher
 - **Realtime vs database**: `realtime/product` is live; `products`/`competitors` have ~T+1 delay
 - **Currently Amazon US only** (amazon.com) — more marketplaces planned
+- **Sales estimation fallback**: When `atLeastMonthlySales` is null → Monthly sales ≈ 300,000 / BSR^0.65
 
 ## Go Deeper
 
@@ -119,5 +181,5 @@ clawhub install Amazon-analysis-skill
 
 - **Website**: [apiclaw.io](https://apiclaw.io)
 - **API Docs**: [api.apiclaw.io/api-docs](https://api.apiclaw.io/api-docs)
-- **GitHub**: [github.com/SerendipityOneInc](https://github.com/SerendipityOneInc/Amazon-analysis-skill)
+- **GitHub**: [github.com/SerendipityOneInc](https://github.com/SerendipityOneInc/APIClaw-Skills)
 - **Support**: support@apiclaw.io

--- a/apiclaw/references/openapi-reference.md
+++ b/apiclaw/references/openapi-reference.md
@@ -1,114 +1,126 @@
-# APIClaw OpenAPI Quick Reference
+# APIClaw API Quick Reference
 
-> Load this only when you need exact field names, parameter types, or response structure.
+> Concise field reference for all 6 endpoints. Load when you need exact parameter/field names.
+>
+> **OpenAPI Spec (live)**: https://apiclaw.io/api/v1/openapi-spec
 
 Base URL: `https://api.apiclaw.io/openapi/v2`
-Auth: `Authorization: Bearer $APICLAW_API_KEY`
-All endpoints: POST with JSON body
+Auth: `Bearer $APICLAW_API_KEY`
+Method: All POST with JSON body
 
 ---
 
 ## 1. categories
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| keyword | string | Search categories by keyword |
-| parentCategoryName | string | Get child categories |
+| Parameter | Type | Note |
+|-----------|------|------|
+| categoryKeyword | String | Search by keyword |
+| categoryPath | String | Exact path lookup |
+| parentCategoryPath | List\<String\> | Browse children |
+| _(no params)_ | — | Returns root categories |
 
-Response fields: `categoryName`, `categoryPath`, `productCount`, `hasChildren`
+Response: `categoryId`, `categoryName`, `categoryPath`, `hasChildren`, `isRoot`, `level`, `productCount`, `link`
 
 ---
 
 ## 2. markets/search
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| category | string | Category path (comma or ` > ` separated) |
-| topN | int | Top N for concentration metrics (default 10) |
-| sampleType | string | Sample type |
-| dateRange | string | Date range |
-| sortBy | string | Sort field |
-| sortOrder | string | asc / desc |
+| Parameter | Type | Note |
+|-----------|------|------|
+| categoryPath | List\<String\> | e.g. `["Pet Supplies", "Dogs"]` |
+| categoryKeyword | String | Keyword match across levels |
+| topN | **String** | `"3"` / `"5"` / `"10"` / `"20"` ⚠️ must be string |
+| newProductPeriod | **String** | `"1"` / `"3"` / `"6"` / `"12"` ⚠️ must be string |
+| sampleType | String | `by_sale_100` / `by_bsr_100` / `avg` |
+| dateRange | String | default `30d` |
+| pageSize | Integer | default 20 |
+| sortBy | String | default `sampleAvgMonthlySaleAmt` |
+| sortOrder | String | `asc` / `desc` |
 
-Key response fields: `sampleAvgMonthlySales`, `sampleAvgPrice`, `sampleAvgBsr`, `sampleAvgRating`, `sampleAvgReviewCount`, `sampleBrandCount`, `topSalesRate`, `topBrandSalesRate`, `sampleNewSkuRate`, `sampleFbaRate`, `sampleAvgMonthlyRevenue`
-
----
-
-## 3. products/search
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| keyword | string | Search keyword |
-| category | string | Category path |
-| mode | string | Preset mode (14 options) |
-| keywordMatchType | string | fuzzy / exact / phrase |
-| salesMin / salesMax | int | Monthly sales range |
-| priceMin / priceMax | float | Price range |
-| reviewsMin / reviewsMax | int | Review count range |
-| ratingMin / ratingMax | float | Rating range |
-| bsrMin / bsrMax | int | BSR range |
-| growthMin | float | Growth rate minimum |
-| pageSize | int | Results per page |
-| sortBy | string | Sort field |
-| sortOrder | string | asc / desc |
-
-Product fields: `asin`, `title`, `brand`, `price`, `bsrRank`, `atLeastMonthlySales`, `rating`, `ratingCount`, `variantCount`, `buyboxSeller`, `profitMargin`, `fbaFee`, `salesRevenue`, `sellerCount`
-
-**14 modes**: beginner, fast-movers, emerging, long-tail, underserved, new-release, fbm-friendly, low-price, single-variant, high-demand-low-barrier, broad-catalog, selective-catalog, speculative, top-bsr
+Key response fields: `sampleAvgMonthlySales`, `sampleAvgPrice`, `sampleAvgMonthlyRevenue`, `sampleBrandCount`, `sampleSellerCount`, `sampleFbaRate`, `sampleNewSkuRate`, `topSalesRate`, `topBrandSalesRate`, `topSellerSalesRate`, `totalSkuCount`
 
 ---
 
-## 4. products/competitor-lookup
+## 3. products/competitor-lookup
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| keyword | string | Search keyword |
-| asin | string | Specific ASIN |
-| brand | string | Brand name |
-| pageSize | int | Results per page |
+| Parameter | Type | Note |
+|-----------|------|------|
+| keyword | String | Search keyword |
+| brand | String | Brand filter |
+| seller | String | Seller filter |
+| asin | String | ASIN filter |
+| categoryPath | List\<String\> | Category filter |
+| sortBy | String | `atLeastMonthlySales` / `atLeastMonthlyRevenue` / `bsr` / `price` / `rating` / `reviewCount` / `listingDate` |
+| sortOrder | String | `asc` / `desc` |
+| pageSize | Integer | default 20 |
 
-Returns same product fields as products/search.
+---
+
+## 4. products/search
+
+Same as competitor-lookup, plus:
+
+| Parameter | Type | Note |
+|-----------|------|------|
+| mode | String | 14 preset modes (see SKILL.md) |
+| keywordMatchType | String | `fuzzy` / `phrase` / `exact` |
+| listingAge | **String** | Max age in days ⚠️ must be string |
+
+Filter pairs (all optional, Min/Max): `monthlySales`, `revenue`, `salesGrowthRate`, `bsr`, `subBsr`, `bsrGrowthRate`, `price`, `rating`, `reviewCount`, `fbaShipping`, `variantCount`, `grossMargin`, `sellerCount`
+
+Additional: `includeBrands`, `excludeBrands`, `fulfillment` (`["FBA"]`/`["FBM"]`), `badges` (`["New Release"]`/`["Best Seller"]`)
 
 ---
 
 ## 5. realtime/product
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| asin | string | ASIN to look up |
+| Parameter | Required | Note |
+|-----------|----------|------|
+| asin | **Yes** | Product ASIN |
+| marketplace | No | `US`/`UK`/`DE`/`FR`/`IT`/`ES`/`JP`/`CA`/`AU`/`IN`/`MX`/`BR` (default: US) |
 
-Response fields: `title`, `brand`, `rating`, `ratingCount`, `ratingBreakdown`, `features` (array), `topReviews` (array), `specifications`, `variants` (array), `bestsellersRank` (array of {category, rank}), `buyboxWinner` ({price, seller, fulfillment})
+Response fields: `asin`, `title`, `brand`, `rating`, `ratingCount`, `ratingBreakdown`, `features`, `description`, `specifications`, `categories`, `variants`, `topReviews`, `bestsellersRank` (array), `buyboxWinner` (object with price), `images`, `dimensions`, `weight`
 
-⚠️ No: atLeastMonthlySales, profitMargin, fbaFee
+⚠️ Does NOT have: `atLeastMonthlySales`, `profitMargin`, `fbaFee`, `sellerCount`
 
 ---
 
 ## 6. reviews/analyze
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| asin | string | Single ASIN |
-| asins | array | Multiple ASINs (comparison) |
-| category | string | Category path (category-level analysis) |
-| period | string | Time period (e.g. "90d") |
-| labelType | string | Comma-separated dimensions to analyze |
+| Parameter | Type | Required | Note |
+|-----------|------|----------|------|
+| mode | String | **Yes** | `asin` or `category` |
+| asins | List\<String\> | When mode=asin | ⚠️ plural, array format |
+| categoryPath | String | When mode=category | Category path |
+| labelType | String | No | Filter to dimension |
+| period | String | No | e.g. `90d` |
 
-Response fields: `totalReviews`, `avgRating`, `sentimentDistribution`, `ratingDistribution`, `consumerInsights` (keyed by labelType), `topKeywords`, `verifiedRatio`
+labelType values: `scenarios`, `issues`, `positives`, `improvements`, `buyingFactors`, `painPoints`, `keywords`, `userProfiles`, `usageTimes`, `usageLocations`, `behaviors`
 
-11 labelType options: painPoints, improvements, buyingFactors, issues, positives, scenarios, keywords, userProfiles, usageTimes, usageLocations, behaviors
+Response: `totalReviews`, `avgRating`, `verifiedRatio`, `ratingDistribution`, `sentimentDistribution`, `consumerInsights` (list of InsightItem), `topKeywords`
+
+InsightItem: `element`, `labelType`, `count`, `reviewPercentage`, `avgRating`
 
 ---
 
-## Common Response Structure
+## Shared Product Object (products/search & competitor-lookup)
 
-All endpoints return:
-```json
-{
-  "success": true,
-  "data": [ ... ],
-  "_query": { ... },
-  "_credits": { "consumed": 1, "remaining": 499 }
-}
-```
-
-`.data` is always an **array**. Use `.data[0]` for single results.
+| Field | Type | Note |
+|-------|------|------|
+| asin | String | |
+| title | String | |
+| brand | String | |
+| price | Float | Top-level (unlike realtime) |
+| bsrRank | Integer | BSR rank (NOT `bsr` or `bestsellersRank`) |
+| atLeastMonthlySales | Integer | Lower-bound monthly sales |
+| salesRevenue | Float | Monthly revenue |
+| salesGrowthRate | Float | Growth rate |
+| rating | Float | 0-5 |
+| ratingCount | Integer | NOT `reviewCount` |
+| profitMargin | Float | |
+| fbaFee | Float | |
+| sellerCount | Integer | |
+| variantCount | Integer | |
+| fulfillment | String | FBA/FBM/AMZ |
+| listingDate | String | |
+| buyboxSeller | String | |


### PR DESCRIPTION
## Summary

Fixes 8 accuracy issues in the `apiclaw` general-purpose skill, found during live API testing with all 6 endpoints.

## Changes

### Bug Fixes
1. **categories**: `keyword` → `categoryKeyword`, `parentCategoryName` → `parentCategoryPath`
2. **markets/search**: `topN` must be **string** (`"10"`) not integer (`10`), `category` must be array not comma string
3. **realtime/product**: price is nested in `buyboxWinner.price`, BSR is `bestsellersRank` (array), not top-level fields
4. **reviews/analyze**: `mode` is **required** param, must use `asins` (plural array) not `asin` (singular)
5. **credits**: field path is `meta.creditsConsumed` / `meta.creditsRemaining`, not `_credits.consumed`

### Enhancements
6. Added **endpoint field difference comparison table** (which fields exist in which endpoint)
7. Added **Known Quirks** section (6 common pitfalls)
8. Added minimum 50 reviews requirement note for `reviews/analyze`
9. Updated `references/openapi-reference.md` with correct parameter types and response structures

## Testing

All 6 endpoints verified with live API calls:
- ✅ categories (keyword search + browse children)
- ✅ markets/search (with string topN + array categoryPath)
- ✅ products/search (mode=beginner, 20 results)
- ✅ products/competitor-lookup (keyword, 20 results)
- ✅ realtime/product (full field verification)
- ✅ reviews/analyze (mode=asin, 136 reviews, 527 consumer insights)

**Credits consumed**: 7 | **All parameters and field names match actual API behavior**