### PR TITLE
fix: Review round 2 — SECURITY typo, markdown lint CI, API example note, CONTRIBUTING link

### DIFF
--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -1,0 +1,13 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://api.apiclaw.io"
+    },
+    {
+      "pattern": "^https://apiclaw.io/api-keys"
+    }
+  ],
+  "timeout": "10s",
+  "retryOn429": true,
+  "aliveStatusCodes": [200, 206, 301, 302, 403]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  check:
+  cli-smoke-test:
+    name: CLI Smoke Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,3 +19,14 @@ jobs:
 
       - name: CLI smoke test
         run: python amazon-analysis/scripts/apiclaw.py --help
+
+  markdown-link-check:
+    name: Markdown Link Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          config-file: '.github/mlc_config.json'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ We use conventional commits:
 ## Questions?
 
 - Join our [Discord](https://discord.com/invite/aYcJDbvK)
-- Open a [Discussion](https://github.com/SerendipityOneInc/APIClaw-Skills/issues)
+- [Open an Issue](https://github.com/SerendipityOneInc/APIClaw-Skills/issues)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ curl -X POST 'https://api.apiclaw.io/openapi/v2/products/search' \
   }'
 ```
 
-Response:
+Example response (simplified):
 
 ```json
 {
@@ -97,12 +97,14 @@ Response:
       "ratingCount": 12847,
       "bsrRank": 15,
       "atLeastMonthlySales": 8500,
-      "brand": "ExampleBrand",
+      "brand": "SoundCore",
       "profitMargin": 0.42
     }
   ]
 }
 ```
+
+> **Note:** This is a simplified example. Actual responses include additional fields. See [API reference](apiclaw/references/openapi-reference.md) for full field list.
 
 ## API Endpoints
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,4 +32,3 @@ This security policy covers:
 - **API Key Storage:** Keys can be stored via environment variable (`APICLAW_API_KEY`, preferred) or `config.json` (fallback). The `config.json` file is listed in `.gitignore` to prevent accidental commits.
 - **Network:** The script only communicates with `https://api.apiclaw.io`. No other external endpoints are contacted.
 - **No Telemetry:** This skill does not collect or transmit usage data.
-data.


### PR DESCRIPTION
## Fixes

4 small fixes from quality review:

1. **SECURITY.md** — Removed duplicate trailing `data.` line
2. **CI** — Added markdown link checker (`gaurav-nelson/github-action-markdown-link-check`) + config
3. **README.md** — Marked API response as 'Example response (simplified)', added note linking to full API reference
4. **CONTRIBUTING.md** — Fixed misleading 'Discussion' link → 'Open an Issue'

Linear: HER-35