### PR TITLE
fix: Remove ClawHub references, standardize git clone installation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ What actually happened.
 - Python version:
 - OS:
 - Skill version:
-- How installed: (ClawHub / manual clone)
+- How installed: (git clone / other)
 
 ## Additional Context
 Any other context, screenshots, or error messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Each entry notes which skill or the repo itself was affected.
 
 ### apiclaw v1.0.0
 - Initial release of general skill — lightweight overview of all 6 API endpoints
-- Published to ClawHub
+- Published general skill
 
 ## 2026-03-13
 

--- a/README.md
+++ b/README.md
@@ -38,16 +38,18 @@ This repo contains **two agent skills** that let any AI assistant use APIClaw in
 
 ## Quick Start
 
-### 1. Install the Skill
+### 1. Install the Skills
 
-```bash
-npx clawhub install Amazon-analysis-skill
-```
-
-Or clone manually:
-
+**General skill** (lightweight overview):
 ```bash
 git clone https://github.com/SerendipityOneInc/APIClaw-Skills.git
+# Point your agent to: APIClaw-Skills/apiclaw/SKILL.md
+```
+
+**Amazon deep analysis skill** (full toolkit):
+```bash
+git clone https://github.com/SerendipityOneInc/APIClaw-Skills.git
+# Point your agent to: APIClaw-Skills/amazon-analysis/SKILL.md
 ```
 
 ### 2. Set Your API Key

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -175,7 +175,8 @@ The 4 endpoint types return **different fields**. Do NOT assume they share the s
 For advanced Amazon product research — 14 selection strategies, risk assessment, pricing analysis, listing optimization, and operational monitoring — install the dedicated skill:
 
 ```bash
-clawhub install Amazon-analysis-skill
+git clone https://github.com/SerendipityOneInc/APIClaw-Skills.git
+# Point your agent to: APIClaw-Skills/amazon-analysis/SKILL.md
 ```
 
 ## Links

--- a/config.example.json
+++ b/config.example.json
@@ -1,3 +1,0 @@
-{
-  "api_key": "hms_live_your_key_here"
-}


### PR DESCRIPTION
## Changes

- **README.md**: Replace ClawHub install command with git clone for both skills (general + amazon-analysis), clearly pointing to each SKILL.md path
- **apiclaw/SKILL.md**: Replace ClawHub install with git clone
- **CHANGELOG.md**: Remove ClawHub mention
- **bug_report.md**: Update installation method options
- **Delete config.example.json**: Unnecessary file, API key setup already documented in README

Linear: HER-35