### PR TITLE
fix: Add permissions to CI workflow (CodeQL security alerts)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   cli-smoke-test:
     name: CLI Smoke Test


### PR DESCRIPTION
Fixes CodeQL alerts #2 and #3: `actions/missing-workflow-permissions`

Added `permissions: contents: read` to ci.yml — restricts the workflow token to read-only access (least privilege principle).