### PR TITLE
fix: Improve skill display names + add npx skills install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,17 @@ This repo contains **two agent skills** that let any AI assistant use APIClaw in
 
 ### 1. Install the Skills
 
-**General skill** (lightweight overview):
 ```bash
-git clone https://github.com/SerendipityOneInc/APIClaw-Skills.git
-# Point your agent to: APIClaw-Skills/apiclaw/SKILL.md
+npx skills add SerendipityOneInc/APIClaw-Skills
 ```
 
-**Amazon deep analysis skill** (full toolkit):
+You'll be prompted to select which skills to install:
+- **APIClaw — Commerce Data for AI Agents** (general overview, 6 endpoints)
+- **Amazon Product Research & Seller Analytics** (deep analysis, 14 strategies)
+
+Or clone manually:
 ```bash
 git clone https://github.com/SerendipityOneInc/APIClaw-Skills.git
-# Point your agent to: APIClaw-Skills/amazon-analysis/SKILL.md
 ```
 
 ### 2. Set Your API Key

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -1,7 +1,15 @@
 ---
-name: apiclaw
+name: APIClaw — Commerce Data for AI Agents
 version: 1.0.0
-description: "APIClaw API platform overview — AI-powered commerce data infrastructure. Provides programmatic access to 200M+ Amazon products with real-time data across 6 endpoints: category browsing, market metrics, product search, competitor lookup, realtime ASIN detail, and AI review analysis. Use when user asks: what APIClaw can do, available API endpoints, how to get started, API capabilities overview, credit usage, or general commerce data questions. For deep Amazon product selection strategies and analysis workflows, use the Amazon-analysis-skill instead. Requires APICLAW_API_KEY."
+description: >
+  AI-powered commerce data infrastructure with 200M+ Amazon products.
+  6 API endpoints: category browsing, market metrics, product search,
+  competitor lookup, realtime ASIN detail, and AI review analysis.
+  Use when user asks: what APIClaw can do, available API endpoints,
+  how to get started, API capabilities overview, credit usage, or
+  general commerce data questions. For deep Amazon product selection
+  strategies and analysis workflows, use the Amazon-analysis-skill instead.
+  Requires APICLAW_API_KEY.
 metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": "APICLAW_API_KEY"}}
 ---
 


### PR DESCRIPTION
## Changes

### apiclaw/SKILL.md
- **name**: `apiclaw` → `APIClaw — Commerce Data for AI Agents`
- **description**: Reformatted to multi-line, now shows properly in `npx skills add` selection menu

Before:
```
□ Amazon Product Research & Seller Analytics (Amazon product research and ...)
□ apiclaw
```

After:
```
□ Amazon Product Research & Seller Analytics (Amazon product research and ...)
□ APIClaw — Commerce Data for AI Agents (AI-powered commerce data infrastructure ...)
```

### README.md
- Primary install method changed to `npx skills add SerendipityOneInc/APIClaw-Skills`
- Added skill selection guide showing both options
- Kept `git clone` as manual alternative

Linear: HER-35