### PR TITLE
fix: Shorten skill descriptions for npx skills display

### DIFF
--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -2,6 +2,7 @@
 name: Amazon Product Research & Seller Analytics
 version: 1.1.5
 description: >
+  Deep analysis, 14 selection strategies.
   Amazon product research and seller analytics for FBA and FBM businesses.
   Find winning products with 14 selection strategies, track competitors,
   monitor BSR trends, analyze reviews, estimate monthly sales, optimize

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -2,8 +2,9 @@
 name: APIClaw — Commerce Data for AI Agents
 version: 1.0.0
 description: >
+  General overview, 6 API endpoints.
   AI-powered commerce data infrastructure with 200M+ Amazon products.
-  6 API endpoints: category browsing, market metrics, product search,
+  Endpoints: category browsing, market metrics, product search,
   competitor lookup, realtime ASIN detail, and AI review analysis.
   Use when user asks: what APIClaw can do, available API endpoints,
   how to get started, API capabilities overview, credit usage, or


### PR DESCRIPTION
Shortens the first line of description in both SKILL.md files so `npx skills add` shows clean, readable labels:

**Before:**
```
□ Amazon Product Research & Seller Analytics (Amazon product research and seller analytics for FBA and FBM businesses.)
□ APIClaw — Commerce Data for AI Agents (AI-powered commerce data infrastructure with 200M+ Amazon products.)
```

**After:**
```
□ Amazon Product Research & Seller Analytics (Deep analysis, 14 selection strategies.)
□ APIClaw — Commerce Data for AI Agents (General overview, 6 API endpoints.)
```