### PR TITLE
fix: remove all Chinese text from skill files

### DIFF
--- a/amazon-analysis/README.md
+++ b/amazon-analysis/README.md
@@ -32,10 +32,10 @@ Select **Amazon Analysis** when prompted.
 ## Example Prompts
 
 - *"Analyze the yoga mat market on Amazon"*
-- *"帮我用 rising-stars 模式找 $15-30 的产品"*
+- *"Use the rising-stars mode to find products in the $15-30 range"*
 - *"Find beginner-friendly products in kitchen gadgets under $25"*
 - *"Run a full report on keyword 'silicone spatula'"*
-- *"用 underserved 模式找评分低于 3.7 的可改进产品"*
+- *"Use the underserved mode to find improvable products rated below 3.7"*
 
 ## What You Get
 

--- a/amazon-analysis/references/execution-guide.md
+++ b/amazon-analysis/references/execution-guide.md
@@ -86,7 +86,7 @@ When `products` or `competitors` returns ASINs in Full-mode analysis, call `prod
 - A single product's high growth rate (e.g. +900%) may be seasonal rebound, restock recovery, or promotion spike — NOT necessarily a market trend
 - To validate: check if the MAJORITY of products in the category show positive growth, not just 1-2 outliers
 - Flag seasonal patterns explicitly: "This growth coincides with [season], which may be temporary"
-- Mark single-product growth signals as 💡 **Directional** / **方向参考**, not 📊 **Data-backed** / **数据验证**
+- Mark single-product growth signals as 💡 **Directional**, not 📊 **Data-backed**
 
 ---
 
@@ -121,11 +121,9 @@ When `atLeastMonthlySales` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
 ### Confidence Labels (every conclusion must be tagged)
 
 **Confidence labels — tag every conclusion with one of:**
-- 📊 **Data-backed** / **数据验证** — Supported by API data with cross-validation
-- 🔍 **Inferred** / **合理推断** — Reasonable inference, not directly measured
-- 💡 **Directional** / **方向参考** — Hypothesis only, verify before acting
-
-Use the label in the user's language: English output → "📊 Data-backed", Chinese output → "📊 数据验证".
+- 📊 **Data-backed** — Supported by API data with cross-validation
+- 🔍 **Inferred** — Reasonable inference, not directly measured
+- 💡 **Directional** — Hypothesis only, verify before acting
 
 ### Data Provenance Block (Full Mode Only)
 

--- a/amazon-blue-ocean-finder/README.md
+++ b/amazon-blue-ocean-finder/README.md
@@ -42,10 +42,10 @@ Select **Amazon Blue Ocean Product Finder** when prompted.
 ## Example Prompts
 
 - *"Find blue ocean products under $30 with less than 100 reviews"*
-- *"帮我找蓝海产品，价格 $15-35，月销 300 以上"*
+- *"Find blue ocean products, price $15-35, 300+ monthly sales"*
 - *"What are the best untapped product opportunities on Amazon right now?"*
 - *"Scan the pet supplies category for hidden gems"*
-- *"找蓝海"* (full-site scan, no restrictions)
+- *"Find blue ocean"* (full-site scan, no restrictions)
 
 ## What You Get
 

--- a/amazon-blue-ocean-finder/SKILL.md
+++ b/amazon-blue-ocean-finder/SKILL.md
@@ -8,7 +8,7 @@ description: >
   Supports three entry modes: specific market, broad direction, or full-site scan.
   Use when user asks about: blue ocean, find products to sell, untapped niche,
   low competition products, what should I sell, product discovery, hidden gems,
-  high demand low competition, find me opportunities, 蓝海产品, 找蓝海.
+  high demand low competition, find me opportunities, blue ocean products, find blue ocean.
   Requires APICLAW_API_KEY.
 author: SerendipityOneInc
 homepage: https://github.com/SerendipityOneInc/APIClaw-Skills
@@ -34,9 +34,9 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 
 | Entry Mode | User Says | Action |
 |------------|-----------|--------|
-| **Specific Market** | "瑜伽垫蓝海" | Resolve category first |
-| **Broad Direction** | "家居类蓝海" | Resolve category, expect multiple matches → ask user to pick |
-| **Full-Site Scan** | "找蓝海" | Skip category, scan directly |
+| **Specific Market** | "yoga mat blue ocean" | Resolve category first |
+| **Broad Direction** | "home category blue ocean" | Resolve category, expect multiple matches → ask user to pick |
+| **Full-Site Scan** | "find blue ocean" | Skip category, scan directly |
 
 Optional: price range, FBA/FBM preference. Do NOT ask about budget, supply chain, or experience (no API filters).
 

--- a/amazon-competitor-intelligence-monitor/README.md
+++ b/amazon-competitor-intelligence-monitor/README.md
@@ -32,10 +32,10 @@ Select **Amazon Competitor Intelligence Monitor** when prompted.
 ## Example Prompts
 
 - *"Analyze my competitors for ASIN B0XXXXXXXX in the yoga mat market"*
-- *"帮我做一次竞品全扫描，关键词 'silicone spatula'"*
+- *"Run a full competitor scan for keyword 'silicone spatula'"*
 - *"Quick check my tracked competitors"*
 - *"Who are the top competitors for 'dog harness' and how do I beat them?"*
-- *"监控竞品价格变化，有异常提醒我"*
+- *"Monitor competitor price changes and alert me on anomalies"*
 
 ## What You Get
 

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -8,7 +8,7 @@ description: >
   Quick Check: realtime/product polling, baseline diff, tiered alerts.
   Use when user asks about: competitor analysis, competitive landscape, competitor tracking,
   competitor monitoring, competitive intelligence, competitor comparison, benchmark, track competitor,
-  spy on competitors, 竞品分析, 竞品监控, 竞对追踪.
+  spy on competitors, competitor analysis, competitor monitoring, competitor tracking.
   Requires APICLAW_API_KEY.
 author: SerendipityOneInc
 homepage: https://github.com/SerendipityOneInc/APIClaw-Skills

--- a/amazon-daily-market-radar/README.md
+++ b/amazon-daily-market-radar/README.md
@@ -32,10 +32,10 @@ Select **Amazon Daily Market Radar** when prompted.
 ## Example Prompts
 
 - *"Set up daily monitoring for my ASINs: B0XXXXXXXX, B0YYYYYYYY"*
-- *"帮我建立每日市场监控，关键词 'yoga mat'，追踪这 3 个 ASIN"*
+- *"Set up daily market monitoring for keyword 'yoga mat', track these 3 ASINs"*
 - *"What changed in my market since yesterday?"*
 - *"Run a daily radar check on my tracked products"*
-- *"我的竞品有什么动态？"*
+- *"Any updates on my competitors?"*
 
 ## What You Get
 

--- a/amazon-listing-audit-pro/README.md
+++ b/amazon-listing-audit-pro/README.md
@@ -33,10 +33,10 @@ Select **Amazon Listing Audit Pro** when prompted.
 ## Example Prompts
 
 - *"Audit my listing for ASIN B0XXXXXXXX, keyword 'yoga mat'"*
-- *"帮我做一次 Listing 健康检查，ASIN B0XXXXXXXX"*
+- *"Run a listing health check for ASIN B0XXXXXXXX"*
 - *"How does my listing compare to the top sellers in my category?"*
 - *"What keywords am I missing compared to competitors?"*
-- *"批量审计这 5 个 ASIN 的 Listing 质量"*
+- *"Batch audit the listing quality for these 5 ASINs"*
 
 ## What You Get
 

--- a/amazon-market-trend-scanner/README.md
+++ b/amazon-market-trend-scanner/README.md
@@ -33,9 +33,9 @@ Select **Amazon Market Trend Scanner** when prompted.
 ## Example Prompts
 
 - *"Scan Pet Supplies for trending subcategories"*
-- *"什么品类在涨？扫一下 Home & Kitchen"*
+- *"Which categories are growing? Scan Home & Kitchen"*
 - *"Which subcategories under Sports & Outdoors are growing fastest?"*
-- *"帮我做品类趋势扫描，看看哪些细分在起势"*
+- *"Run a category trend scan and show me which niches are gaining momentum"*
 - *"Find emerging niches in Beauty & Personal Care"*
 
 ## What You Get

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -10,7 +10,7 @@ description: >
   changes across all subcategories under a parent category.
   Use when user asks about: market trends, category trends, trending
   categories, what's hot, emerging categories, trend scanner,
-  品类趋势, 市场趋势, 什么品类在涨.
+  category trends, market trends, which categories are growing.
   Requires APICLAW_API_KEY.
 author: SerendipityOneInc
 homepage: https://github.com/SerendipityOneInc/APIClaw-Skills

--- a/amazon-opportunity-discoverer/README.md
+++ b/amazon-opportunity-discoverer/README.md
@@ -33,10 +33,10 @@ Select **Amazon Opportunity Discoverer** when prompted.
 ## Example Prompts
 
 - *"I'm a beginner with $5K budget, find me safe product opportunities"*
-- *"我是新手卖家，预算 3 万，帮我找适合的产品"*
+- *"I'm a beginner seller with a $4K budget, find me suitable products"*
 - *"Find aggressive opportunities in home & kitchen, I have 2 years experience"*
 - *"Scan for products under $30 with less than 100 reviews and 300+ monthly sales"*
-- *"帮我做一次快速扫描，看看有什么机会"*
+- *"Run a quick scan and show me what opportunities are out there"*
 
 ## What You Get
 

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -51,7 +51,7 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 | Advanced + Aggressive | fast-movers, speculative, top-bsr | any | any |
 
 ### User Criteria → Filter Params
-Always translate: "月销300+" → `--sales-min 300`, "评论<100" → `--ratings-max 100`, "$15-35" → `--price-min 15 --price-max 35`. If user has specific criteria, use custom filters (Approach B/C), NOT default modes.
+Always translate: "300+ monthly sales" → `--sales-min 300`, "reviews <100" → `--ratings-max 100`, "$15-35" → `--price-min 15 --price-max 35`. If user has specific criteria, use custom filters (Approach B/C), NOT default modes.
 
 ### Data-Driven Category Selection (no specific category given)
 Scan with `market --keyword "{broad}" --topn 10`, rank subcategories by: newSkuRate>10%, topBrandSalesRate<60%, fbaRate>50%, avgPrice $10-50, avgMonthlySales>200. Pick top 3-5.

--- a/amazon-pricing-command-center/README.md
+++ b/amazon-pricing-command-center/README.md
@@ -36,7 +36,6 @@ Select **Amazon Pricing Command Center** when prompted.
 - *"Analyze the pricing strategy for ASIN B0XXXXXXXX"*
 - *"Analyze pricing for these 5 ASINs: B0AAA, B0BBB, B0CCC, B0DDD, B0EEE"*
 - *"My COGS is $8, current price $24.99 — am I leaving money on the table?"*
-- *"Should I raise or lower the price? ASIN B0XXXXXXXX, COGS ¥45"*
 
 ## What You Get
 

--- a/amazon-pricing-command-center/README.md
+++ b/amazon-pricing-command-center/README.md
@@ -33,10 +33,10 @@ Select **Amazon Pricing Command Center** when prompted.
 ## Example Prompts
 
 - *"Should I raise or lower the price on ASIN B0XXXXXXXX?"*
-- *"帮我分析这个 ASIN 的定价策略：B0XXXXXXXX"*
+- *"Analyze the pricing strategy for ASIN B0XXXXXXXX"*
 - *"Analyze pricing for these 5 ASINs: B0AAA, B0BBB, B0CCC, B0DDD, B0EEE"*
 - *"My COGS is $8, current price $24.99 — am I leaving money on the table?"*
-- *"该涨价还是降价？ASIN B0XXXXXXXX，成本 ¥45"*
+- *"Should I raise or lower the price? ASIN B0XXXXXXXX, COGS ¥45"*
 
 ## What You Get
 

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -30,7 +30,6 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 
 ## Input
 - **Required**: one or more ASINs (your products). No keyword needed — category is auto-detected.
-- **Recommended**: cost/COGS per ASIN (if if cost is in RMB (¥), ÷7.2 to USD), target_margin %
 - **Optional**: competitor_asins
 
 On first interaction, tell user: "Give me your ASIN(s). I support single or batch analysis — I'll auto-detect each product's category and analyze the pricing landscape for you."

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -10,7 +10,7 @@ description: >
   Use when user asks about: pricing strategy, how much to price, optimal price,
   price optimization, competitor pricing, price war, BuyBox strategy,
   profit margin, pricing analysis, should I raise price, should I lower price,
-  price comparison, price positioning, repricing, 定价策略, 该涨价还是降价.
+  price comparison, price positioning, repricing, pricing strategy, should I raise or lower price.
   Requires APICLAW_API_KEY.
 author: SerendipityOneInc
 homepage: https://github.com/SerendipityOneInc/APIClaw-Skills
@@ -30,7 +30,7 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 
 ## Input
 - **Required**: one or more ASINs (your products). No keyword needed — category is auto-detected.
-- **Recommended**: cost/COGS per ASIN (if "块/元" → RMB, ÷7.2 to USD), target_margin %
+- **Recommended**: cost/COGS per ASIN (if if cost is in RMB (¥), ÷7.2 to USD), target_margin %
 - **Optional**: competitor_asins
 
 On first interaction, tell user: "Give me your ASIN(s). I support single or batch analysis — I'll auto-detect each product's category and analyze the pricing landscape for you."

--- a/amazon-review-intelligence-extractor/README.md
+++ b/amazon-review-intelligence-extractor/README.md
@@ -53,7 +53,7 @@ Select **Amazon Review Intelligence Extractor** when prompted.
 - *"Analyze reviews for ASIN B09V3KXJPB — what are the main pain points?"*
 - *"Compare review sentiment across these 5 travel mug ASINs"*
 - *"What do customers love and hate about yoga mats in general?"*
-- *"分析这个产品的差评，找出改进方向"*
+- *"Analyze the negative reviews for this product and identify improvement areas"*
 
 ## What You Get
 

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -28,8 +28,8 @@ Pre-analyzed consumer insights. Pain points, buying factors, user profiles, diff
 Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apiclaw.io/en/api-keys)
 
 ## Input (one of)
-- **Single ASIN**: "分析 B09V3KXJPB 的评论"
-- **Multi-ASIN**: "对比这 5 个竞品的评论痛点"
+- **Single ASIN**: "Analyze reviews for B09V3KXJPB"
+- **Multi-ASIN**: "Compare review pain points across these 5 competitor ASINs"
 - **Category-wide**: keyword/category name → resolve via `categories` first (need ≥3-level deep path)
 
 ## API Pitfalls (see apiclaw skill for full list)

--- a/apiclaw/README.md
+++ b/apiclaw/README.md
@@ -32,10 +32,10 @@ Select **APIClaw** when prompted.
 ## Example Prompts
 
 - *"What APIClaw endpoints are available?"*
-- *"APIClaw 有哪些接口？怎么用？"*
+- *"What APIClaw endpoints are available and how do I use them?"*
 - *"Look up real-time data for ASIN B0XXXXXXXX"*
 - *"Search for products in the 'yoga mat' category sorted by sales"*
-- *"帮我查一下这个品类的市场数据"*
+- *"Pull the market data for this product category"*
 
 ## What You Get
 


### PR DESCRIPTION
Replaced all Chinese text with English equivalents across 17 files in 10 skill directories.

- SKILL.md: Chinese trigger words → English
- README.md: Chinese example prompts → English
- references/execution-guide.md: Chinese confidence labels → English only

Only `README.zh-CN.md` retains Chinese (by design — it's the Chinese README).