### PR TITLE
fix: add --page arg and allow_abbrev=False to prevent silent argparse prefix matching

### DIFF
--- a/.github/workflows/test-apiclaw.yml
+++ b/.github/workflows/test-apiclaw.yml
@@ -1,0 +1,38 @@
+name: Test apiclaw.py
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apiclaw/scripts/apiclaw.py'
+      - 'amazon-*/scripts/apiclaw.py'
+      - 'tests/test_apiclaw*.py'
+  push:
+    branches: [main]
+    paths:
+      - 'apiclaw/scripts/apiclaw.py'
+      - 'tests/test_apiclaw*.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # No dependencies needed — stdlib only
+
+      - name: Run test suite
+        run: python tests/test_apiclaw.py
+
+      - name: Run page-arg regression tests
+        run: python tests/test_apiclaw_page_arg.py

--- a/amazon-analysis/scripts/apiclaw.py
+++ b/amazon-analysis/scripts/apiclaw.py
@@ -278,6 +278,8 @@ def cmd_market(args):
         params["topN"] = str(args.topn)
     if args.page_size:
         params["pageSize"] = args.page_size
+    if args.page:
+        params["page"] = args.page
     if args.sort:
         params["sortBy"] = args.sort
     if args.order:
@@ -351,6 +353,7 @@ def cmd_products(args):
     params["sortBy"] = args.sort or "atLeastMonthlySales"
     params["sortOrder"] = args.order or "desc"
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
 
     result = api_call("products/search", params)
 
@@ -1978,6 +1981,7 @@ def cmd_price_band_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-overview", params)
     output(result, args.format)
 
@@ -1990,6 +1994,7 @@ def cmd_price_band_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-detail", params)
     output(result, args.format)
 
@@ -2002,6 +2007,7 @@ def cmd_brand_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-overview", params)
     output(result, args.format)
 
@@ -2014,6 +2020,7 @@ def cmd_brand_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-detail", params)
     output(result, args.format)
 
@@ -2036,6 +2043,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="APIClaw CLI — Amazon Product Research",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
@@ -2069,6 +2077,7 @@ Examples:
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
+    p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_mkt.add_argument("--sort", help="Sort field")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
@@ -2093,6 +2102,7 @@ Examples:
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
+    p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
@@ -2200,6 +2210,7 @@ Examples:
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
+    p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
@@ -2207,6 +2218,7 @@ Examples:
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
+    p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
@@ -2214,6 +2226,7 @@ Examples:
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
+    p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
@@ -2221,6 +2234,7 @@ Examples:
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
+    p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──

--- a/amazon-analysis/scripts/apiclaw.py
+++ b/amazon-analysis/scripts/apiclaw.py
@@ -2065,14 +2065,14 @@ Examples:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # ── categories ──
-    p_cat = sub.add_parser("categories", help="Query Amazon category tree")
+    p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
     p_cat.add_argument("--category", help="Exact category path (comma-separated)")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
-    p_mkt = sub.add_parser("market", help="Search market-level data for a category")
+    p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
     p_mkt.add_argument("--category", help="Category path (comma-separated)")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
@@ -2083,7 +2083,7 @@ Examples:
     p_mkt.set_defaults(func=cmd_market)
 
     # ── products ──
-    p_prod = sub.add_parser("products", help="Search products with filters (product selection)")
+    p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
     p_prod.add_argument("--category", help="Category path (comma-separated)")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
@@ -2108,7 +2108,7 @@ Examples:
     p_prod.set_defaults(func=cmd_products)
 
     # ── competitors ──
-    p_comp = sub.add_parser("competitors", help="Look up competitors")
+    p_comp = sub.add_parser("competitors", help="Look up competitors", allow_abbrev=False)
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
@@ -2122,60 +2122,60 @@ Examples:
     p_comp.set_defaults(func=cmd_competitors)
 
     # ── product (single ASIN) ──
-    p_single = sub.add_parser("product", help="Get real-time details for one ASIN")
+    p_single = sub.add_parser("product", help="Get real-time details for one ASIN", allow_abbrev=False)
     p_single.add_argument("--asin", required=True, help="ASIN (required)")
     p_single.add_argument("--marketplace", default="US",
                           help="Marketplace: US/UK/DE/FR/IT/ES/JP/CA/AU/IN/MX/BR (default: US)")
     p_single.set_defaults(func=cmd_product)
 
     # ── report (composite) ──
-    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)")
+    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)", allow_abbrev=False)
     p_report.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_report.add_argument("--topn", type=int, default=10, help="Top N (default: 10)")
     p_report.set_defaults(func=cmd_report)
 
     # ── opportunity (composite) ──
-    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)")
+    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)", allow_abbrev=False)
     p_opp.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_opp.add_argument("--mode", help="Product search mode preset")
     p_opp.set_defaults(func=cmd_opportunity)
 
     # ── market-entry (composite: full analysis) ──
-    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)")
+    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
     p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
-    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis")
+    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
     p_ca.add_argument("--category", help="Category path")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
-    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking")
+    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
     p_pa.add_argument("--category", help="Category path")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
-    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)")
+    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
     p_dr.add_argument("--category", help="Category path")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
-    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders")
+    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
     p_la.add_argument("--category", help="Category path")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
-    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery")
+    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
     p_os.add_argument("--category", help="Category path")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. beginner,emerging,underserved). Omit to use custom filters only.")
@@ -2189,7 +2189,7 @@ Examples:
     p_os.set_defaults(func=cmd_opportunity_scan)
 
     # ── review-deepdive (composite) ──
-    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis")
+    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis", allow_abbrev=False)
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
@@ -2197,7 +2197,7 @@ Examples:
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── analyze (reviews) ──
-    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis")
+    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
     p_analyze.add_argument("--category", help="Category path")
@@ -2206,7 +2206,7 @@ Examples:
     p_analyze.set_defaults(func=cmd_analyze)
 
     # ── price-band-overview ──
-    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)")
+    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
@@ -2214,7 +2214,7 @@ Examples:
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
-    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown")
+    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
@@ -2222,7 +2222,7 @@ Examples:
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
-    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview")
+    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
@@ -2230,7 +2230,7 @@ Examples:
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
-    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats")
+    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
@@ -2238,14 +2238,14 @@ Examples:
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──
-    p_ph = sub.add_parser("product-history", help="Historical data for ASINs")
+    p_ph = sub.add_parser("product-history", help="Historical data for ASINs", allow_abbrev=False)
     p_ph.add_argument("--asins", required=True, help="ASINs (comma-separated)")
     p_ph.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
     p_ph.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
     p_ph.set_defaults(func=cmd_product_history)
 
     # ── check (API self-check) ──
-    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints")
+    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
     args = parser.parse_args()

--- a/amazon-blue-ocean-finder/scripts/apiclaw.py
+++ b/amazon-blue-ocean-finder/scripts/apiclaw.py
@@ -278,6 +278,8 @@ def cmd_market(args):
         params["topN"] = str(args.topn)
     if args.page_size:
         params["pageSize"] = args.page_size
+    if args.page:
+        params["page"] = args.page
     if args.sort:
         params["sortBy"] = args.sort
     if args.order:
@@ -351,6 +353,7 @@ def cmd_products(args):
     params["sortBy"] = args.sort or "atLeastMonthlySales"
     params["sortOrder"] = args.order or "desc"
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
 
     result = api_call("products/search", params)
 
@@ -1978,6 +1981,7 @@ def cmd_price_band_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-overview", params)
     output(result, args.format)
 
@@ -1990,6 +1994,7 @@ def cmd_price_band_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-detail", params)
     output(result, args.format)
 
@@ -2002,6 +2007,7 @@ def cmd_brand_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-overview", params)
     output(result, args.format)
 
@@ -2014,6 +2020,7 @@ def cmd_brand_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-detail", params)
     output(result, args.format)
 
@@ -2036,6 +2043,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="APIClaw CLI — Amazon Product Research",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
@@ -2069,6 +2077,7 @@ Examples:
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
+    p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_mkt.add_argument("--sort", help="Sort field")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
@@ -2093,6 +2102,7 @@ Examples:
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
+    p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
@@ -2200,6 +2210,7 @@ Examples:
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
+    p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
@@ -2207,6 +2218,7 @@ Examples:
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
+    p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
@@ -2214,6 +2226,7 @@ Examples:
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
+    p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
@@ -2221,6 +2234,7 @@ Examples:
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
+    p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──

--- a/amazon-blue-ocean-finder/scripts/apiclaw.py
+++ b/amazon-blue-ocean-finder/scripts/apiclaw.py
@@ -2065,14 +2065,14 @@ Examples:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # ── categories ──
-    p_cat = sub.add_parser("categories", help="Query Amazon category tree")
+    p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
     p_cat.add_argument("--category", help="Exact category path (comma-separated)")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
-    p_mkt = sub.add_parser("market", help="Search market-level data for a category")
+    p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
     p_mkt.add_argument("--category", help="Category path (comma-separated)")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
@@ -2083,7 +2083,7 @@ Examples:
     p_mkt.set_defaults(func=cmd_market)
 
     # ── products ──
-    p_prod = sub.add_parser("products", help="Search products with filters (product selection)")
+    p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
     p_prod.add_argument("--category", help="Category path (comma-separated)")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
@@ -2108,7 +2108,7 @@ Examples:
     p_prod.set_defaults(func=cmd_products)
 
     # ── competitors ──
-    p_comp = sub.add_parser("competitors", help="Look up competitors")
+    p_comp = sub.add_parser("competitors", help="Look up competitors", allow_abbrev=False)
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
@@ -2122,60 +2122,60 @@ Examples:
     p_comp.set_defaults(func=cmd_competitors)
 
     # ── product (single ASIN) ──
-    p_single = sub.add_parser("product", help="Get real-time details for one ASIN")
+    p_single = sub.add_parser("product", help="Get real-time details for one ASIN", allow_abbrev=False)
     p_single.add_argument("--asin", required=True, help="ASIN (required)")
     p_single.add_argument("--marketplace", default="US",
                           help="Marketplace: US/UK/DE/FR/IT/ES/JP/CA/AU/IN/MX/BR (default: US)")
     p_single.set_defaults(func=cmd_product)
 
     # ── report (composite) ──
-    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)")
+    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)", allow_abbrev=False)
     p_report.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_report.add_argument("--topn", type=int, default=10, help="Top N (default: 10)")
     p_report.set_defaults(func=cmd_report)
 
     # ── opportunity (composite) ──
-    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)")
+    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)", allow_abbrev=False)
     p_opp.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_opp.add_argument("--mode", help="Product search mode preset")
     p_opp.set_defaults(func=cmd_opportunity)
 
     # ── market-entry (composite: full analysis) ──
-    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)")
+    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
     p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
-    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis")
+    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
     p_ca.add_argument("--category", help="Category path")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
-    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking")
+    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
     p_pa.add_argument("--category", help="Category path")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
-    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)")
+    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
     p_dr.add_argument("--category", help="Category path")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
-    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders")
+    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
     p_la.add_argument("--category", help="Category path")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
-    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery")
+    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
     p_os.add_argument("--category", help="Category path")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. beginner,emerging,underserved). Omit to use custom filters only.")
@@ -2189,7 +2189,7 @@ Examples:
     p_os.set_defaults(func=cmd_opportunity_scan)
 
     # ── review-deepdive (composite) ──
-    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis")
+    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis", allow_abbrev=False)
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
@@ -2197,7 +2197,7 @@ Examples:
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── analyze (reviews) ──
-    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis")
+    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
     p_analyze.add_argument("--category", help="Category path")
@@ -2206,7 +2206,7 @@ Examples:
     p_analyze.set_defaults(func=cmd_analyze)
 
     # ── price-band-overview ──
-    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)")
+    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
@@ -2214,7 +2214,7 @@ Examples:
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
-    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown")
+    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
@@ -2222,7 +2222,7 @@ Examples:
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
-    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview")
+    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
@@ -2230,7 +2230,7 @@ Examples:
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
-    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats")
+    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
@@ -2238,14 +2238,14 @@ Examples:
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──
-    p_ph = sub.add_parser("product-history", help="Historical data for ASINs")
+    p_ph = sub.add_parser("product-history", help="Historical data for ASINs", allow_abbrev=False)
     p_ph.add_argument("--asins", required=True, help="ASINs (comma-separated)")
     p_ph.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
     p_ph.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
     p_ph.set_defaults(func=cmd_product_history)
 
     # ── check (API self-check) ──
-    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints")
+    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
     args = parser.parse_args()

--- a/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
+++ b/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
@@ -278,6 +278,8 @@ def cmd_market(args):
         params["topN"] = str(args.topn)
     if args.page_size:
         params["pageSize"] = args.page_size
+    if args.page:
+        params["page"] = args.page
     if args.sort:
         params["sortBy"] = args.sort
     if args.order:
@@ -351,6 +353,7 @@ def cmd_products(args):
     params["sortBy"] = args.sort or "atLeastMonthlySales"
     params["sortOrder"] = args.order or "desc"
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
 
     result = api_call("products/search", params)
 
@@ -1978,6 +1981,7 @@ def cmd_price_band_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-overview", params)
     output(result, args.format)
 
@@ -1990,6 +1994,7 @@ def cmd_price_band_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-detail", params)
     output(result, args.format)
 
@@ -2002,6 +2007,7 @@ def cmd_brand_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-overview", params)
     output(result, args.format)
 
@@ -2014,6 +2020,7 @@ def cmd_brand_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-detail", params)
     output(result, args.format)
 
@@ -2036,6 +2043,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="APIClaw CLI — Amazon Product Research",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
@@ -2069,6 +2077,7 @@ Examples:
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
+    p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_mkt.add_argument("--sort", help="Sort field")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
@@ -2093,6 +2102,7 @@ Examples:
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
+    p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
@@ -2200,6 +2210,7 @@ Examples:
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
+    p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
@@ -2207,6 +2218,7 @@ Examples:
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
+    p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
@@ -2214,6 +2226,7 @@ Examples:
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
+    p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
@@ -2221,6 +2234,7 @@ Examples:
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
+    p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──

--- a/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
+++ b/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
@@ -2065,14 +2065,14 @@ Examples:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # ── categories ──
-    p_cat = sub.add_parser("categories", help="Query Amazon category tree")
+    p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
     p_cat.add_argument("--category", help="Exact category path (comma-separated)")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
-    p_mkt = sub.add_parser("market", help="Search market-level data for a category")
+    p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
     p_mkt.add_argument("--category", help="Category path (comma-separated)")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
@@ -2083,7 +2083,7 @@ Examples:
     p_mkt.set_defaults(func=cmd_market)
 
     # ── products ──
-    p_prod = sub.add_parser("products", help="Search products with filters (product selection)")
+    p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
     p_prod.add_argument("--category", help="Category path (comma-separated)")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
@@ -2108,7 +2108,7 @@ Examples:
     p_prod.set_defaults(func=cmd_products)
 
     # ── competitors ──
-    p_comp = sub.add_parser("competitors", help="Look up competitors")
+    p_comp = sub.add_parser("competitors", help="Look up competitors", allow_abbrev=False)
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
@@ -2122,60 +2122,60 @@ Examples:
     p_comp.set_defaults(func=cmd_competitors)
 
     # ── product (single ASIN) ──
-    p_single = sub.add_parser("product", help="Get real-time details for one ASIN")
+    p_single = sub.add_parser("product", help="Get real-time details for one ASIN", allow_abbrev=False)
     p_single.add_argument("--asin", required=True, help="ASIN (required)")
     p_single.add_argument("--marketplace", default="US",
                           help="Marketplace: US/UK/DE/FR/IT/ES/JP/CA/AU/IN/MX/BR (default: US)")
     p_single.set_defaults(func=cmd_product)
 
     # ── report (composite) ──
-    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)")
+    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)", allow_abbrev=False)
     p_report.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_report.add_argument("--topn", type=int, default=10, help="Top N (default: 10)")
     p_report.set_defaults(func=cmd_report)
 
     # ── opportunity (composite) ──
-    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)")
+    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)", allow_abbrev=False)
     p_opp.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_opp.add_argument("--mode", help="Product search mode preset")
     p_opp.set_defaults(func=cmd_opportunity)
 
     # ── market-entry (composite: full analysis) ──
-    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)")
+    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
     p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
-    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis")
+    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
     p_ca.add_argument("--category", help="Category path")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
-    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking")
+    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
     p_pa.add_argument("--category", help="Category path")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
-    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)")
+    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
     p_dr.add_argument("--category", help="Category path")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
-    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders")
+    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
     p_la.add_argument("--category", help="Category path")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
-    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery")
+    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
     p_os.add_argument("--category", help="Category path")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. beginner,emerging,underserved). Omit to use custom filters only.")
@@ -2189,7 +2189,7 @@ Examples:
     p_os.set_defaults(func=cmd_opportunity_scan)
 
     # ── review-deepdive (composite) ──
-    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis")
+    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis", allow_abbrev=False)
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
@@ -2197,7 +2197,7 @@ Examples:
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── analyze (reviews) ──
-    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis")
+    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
     p_analyze.add_argument("--category", help="Category path")
@@ -2206,7 +2206,7 @@ Examples:
     p_analyze.set_defaults(func=cmd_analyze)
 
     # ── price-band-overview ──
-    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)")
+    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
@@ -2214,7 +2214,7 @@ Examples:
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
-    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown")
+    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
@@ -2222,7 +2222,7 @@ Examples:
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
-    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview")
+    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
@@ -2230,7 +2230,7 @@ Examples:
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
-    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats")
+    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
@@ -2238,14 +2238,14 @@ Examples:
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──
-    p_ph = sub.add_parser("product-history", help="Historical data for ASINs")
+    p_ph = sub.add_parser("product-history", help="Historical data for ASINs", allow_abbrev=False)
     p_ph.add_argument("--asins", required=True, help="ASINs (comma-separated)")
     p_ph.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
     p_ph.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
     p_ph.set_defaults(func=cmd_product_history)
 
     # ── check (API self-check) ──
-    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints")
+    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
     args = parser.parse_args()

--- a/amazon-daily-market-radar/scripts/apiclaw.py
+++ b/amazon-daily-market-radar/scripts/apiclaw.py
@@ -278,6 +278,8 @@ def cmd_market(args):
         params["topN"] = str(args.topn)
     if args.page_size:
         params["pageSize"] = args.page_size
+    if args.page:
+        params["page"] = args.page
     if args.sort:
         params["sortBy"] = args.sort
     if args.order:
@@ -351,6 +353,7 @@ def cmd_products(args):
     params["sortBy"] = args.sort or "atLeastMonthlySales"
     params["sortOrder"] = args.order or "desc"
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
 
     result = api_call("products/search", params)
 
@@ -1978,6 +1981,7 @@ def cmd_price_band_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-overview", params)
     output(result, args.format)
 
@@ -1990,6 +1994,7 @@ def cmd_price_band_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-detail", params)
     output(result, args.format)
 
@@ -2002,6 +2007,7 @@ def cmd_brand_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-overview", params)
     output(result, args.format)
 
@@ -2014,6 +2020,7 @@ def cmd_brand_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-detail", params)
     output(result, args.format)
 
@@ -2036,6 +2043,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="APIClaw CLI — Amazon Product Research",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
@@ -2069,6 +2077,7 @@ Examples:
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
+    p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_mkt.add_argument("--sort", help="Sort field")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
@@ -2093,6 +2102,7 @@ Examples:
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
+    p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
@@ -2200,6 +2210,7 @@ Examples:
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
+    p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
@@ -2207,6 +2218,7 @@ Examples:
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
+    p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
@@ -2214,6 +2226,7 @@ Examples:
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
+    p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
@@ -2221,6 +2234,7 @@ Examples:
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
+    p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──

--- a/amazon-daily-market-radar/scripts/apiclaw.py
+++ b/amazon-daily-market-radar/scripts/apiclaw.py
@@ -2065,14 +2065,14 @@ Examples:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # ── categories ──
-    p_cat = sub.add_parser("categories", help="Query Amazon category tree")
+    p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
     p_cat.add_argument("--category", help="Exact category path (comma-separated)")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
-    p_mkt = sub.add_parser("market", help="Search market-level data for a category")
+    p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
     p_mkt.add_argument("--category", help="Category path (comma-separated)")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
@@ -2083,7 +2083,7 @@ Examples:
     p_mkt.set_defaults(func=cmd_market)
 
     # ── products ──
-    p_prod = sub.add_parser("products", help="Search products with filters (product selection)")
+    p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
     p_prod.add_argument("--category", help="Category path (comma-separated)")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
@@ -2108,7 +2108,7 @@ Examples:
     p_prod.set_defaults(func=cmd_products)
 
     # ── competitors ──
-    p_comp = sub.add_parser("competitors", help="Look up competitors")
+    p_comp = sub.add_parser("competitors", help="Look up competitors", allow_abbrev=False)
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
@@ -2122,60 +2122,60 @@ Examples:
     p_comp.set_defaults(func=cmd_competitors)
 
     # ── product (single ASIN) ──
-    p_single = sub.add_parser("product", help="Get real-time details for one ASIN")
+    p_single = sub.add_parser("product", help="Get real-time details for one ASIN", allow_abbrev=False)
     p_single.add_argument("--asin", required=True, help="ASIN (required)")
     p_single.add_argument("--marketplace", default="US",
                           help="Marketplace: US/UK/DE/FR/IT/ES/JP/CA/AU/IN/MX/BR (default: US)")
     p_single.set_defaults(func=cmd_product)
 
     # ── report (composite) ──
-    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)")
+    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)", allow_abbrev=False)
     p_report.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_report.add_argument("--topn", type=int, default=10, help="Top N (default: 10)")
     p_report.set_defaults(func=cmd_report)
 
     # ── opportunity (composite) ──
-    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)")
+    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)", allow_abbrev=False)
     p_opp.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_opp.add_argument("--mode", help="Product search mode preset")
     p_opp.set_defaults(func=cmd_opportunity)
 
     # ── market-entry (composite: full analysis) ──
-    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)")
+    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
     p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
-    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis")
+    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
     p_ca.add_argument("--category", help="Category path")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
-    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking")
+    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
     p_pa.add_argument("--category", help="Category path")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
-    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)")
+    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
     p_dr.add_argument("--category", help="Category path")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
-    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders")
+    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
     p_la.add_argument("--category", help="Category path")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
-    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery")
+    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
     p_os.add_argument("--category", help="Category path")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. beginner,emerging,underserved). Omit to use custom filters only.")
@@ -2189,7 +2189,7 @@ Examples:
     p_os.set_defaults(func=cmd_opportunity_scan)
 
     # ── review-deepdive (composite) ──
-    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis")
+    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis", allow_abbrev=False)
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
@@ -2197,7 +2197,7 @@ Examples:
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── analyze (reviews) ──
-    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis")
+    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
     p_analyze.add_argument("--category", help="Category path")
@@ -2206,7 +2206,7 @@ Examples:
     p_analyze.set_defaults(func=cmd_analyze)
 
     # ── price-band-overview ──
-    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)")
+    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
@@ -2214,7 +2214,7 @@ Examples:
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
-    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown")
+    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
@@ -2222,7 +2222,7 @@ Examples:
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
-    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview")
+    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
@@ -2230,7 +2230,7 @@ Examples:
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
-    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats")
+    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
@@ -2238,14 +2238,14 @@ Examples:
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──
-    p_ph = sub.add_parser("product-history", help="Historical data for ASINs")
+    p_ph = sub.add_parser("product-history", help="Historical data for ASINs", allow_abbrev=False)
     p_ph.add_argument("--asins", required=True, help="ASINs (comma-separated)")
     p_ph.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
     p_ph.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
     p_ph.set_defaults(func=cmd_product_history)
 
     # ── check (API self-check) ──
-    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints")
+    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
     args = parser.parse_args()

--- a/amazon-listing-audit-pro/scripts/apiclaw.py
+++ b/amazon-listing-audit-pro/scripts/apiclaw.py
@@ -278,6 +278,8 @@ def cmd_market(args):
         params["topN"] = str(args.topn)
     if args.page_size:
         params["pageSize"] = args.page_size
+    if args.page:
+        params["page"] = args.page
     if args.sort:
         params["sortBy"] = args.sort
     if args.order:
@@ -351,6 +353,7 @@ def cmd_products(args):
     params["sortBy"] = args.sort or "atLeastMonthlySales"
     params["sortOrder"] = args.order or "desc"
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
 
     result = api_call("products/search", params)
 
@@ -1978,6 +1981,7 @@ def cmd_price_band_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-overview", params)
     output(result, args.format)
 
@@ -1990,6 +1994,7 @@ def cmd_price_band_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-detail", params)
     output(result, args.format)
 
@@ -2002,6 +2007,7 @@ def cmd_brand_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-overview", params)
     output(result, args.format)
 
@@ -2014,6 +2020,7 @@ def cmd_brand_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-detail", params)
     output(result, args.format)
 
@@ -2036,6 +2043,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="APIClaw CLI — Amazon Product Research",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
@@ -2069,6 +2077,7 @@ Examples:
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
+    p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_mkt.add_argument("--sort", help="Sort field")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
@@ -2093,6 +2102,7 @@ Examples:
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
+    p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
@@ -2200,6 +2210,7 @@ Examples:
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
+    p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
@@ -2207,6 +2218,7 @@ Examples:
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
+    p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
@@ -2214,6 +2226,7 @@ Examples:
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
+    p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
@@ -2221,6 +2234,7 @@ Examples:
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
+    p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──

--- a/amazon-listing-audit-pro/scripts/apiclaw.py
+++ b/amazon-listing-audit-pro/scripts/apiclaw.py
@@ -2065,14 +2065,14 @@ Examples:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # ── categories ──
-    p_cat = sub.add_parser("categories", help="Query Amazon category tree")
+    p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
     p_cat.add_argument("--category", help="Exact category path (comma-separated)")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
-    p_mkt = sub.add_parser("market", help="Search market-level data for a category")
+    p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
     p_mkt.add_argument("--category", help="Category path (comma-separated)")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
@@ -2083,7 +2083,7 @@ Examples:
     p_mkt.set_defaults(func=cmd_market)
 
     # ── products ──
-    p_prod = sub.add_parser("products", help="Search products with filters (product selection)")
+    p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
     p_prod.add_argument("--category", help="Category path (comma-separated)")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
@@ -2108,7 +2108,7 @@ Examples:
     p_prod.set_defaults(func=cmd_products)
 
     # ── competitors ──
-    p_comp = sub.add_parser("competitors", help="Look up competitors")
+    p_comp = sub.add_parser("competitors", help="Look up competitors", allow_abbrev=False)
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
@@ -2122,60 +2122,60 @@ Examples:
     p_comp.set_defaults(func=cmd_competitors)
 
     # ── product (single ASIN) ──
-    p_single = sub.add_parser("product", help="Get real-time details for one ASIN")
+    p_single = sub.add_parser("product", help="Get real-time details for one ASIN", allow_abbrev=False)
     p_single.add_argument("--asin", required=True, help="ASIN (required)")
     p_single.add_argument("--marketplace", default="US",
                           help="Marketplace: US/UK/DE/FR/IT/ES/JP/CA/AU/IN/MX/BR (default: US)")
     p_single.set_defaults(func=cmd_product)
 
     # ── report (composite) ──
-    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)")
+    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)", allow_abbrev=False)
     p_report.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_report.add_argument("--topn", type=int, default=10, help="Top N (default: 10)")
     p_report.set_defaults(func=cmd_report)
 
     # ── opportunity (composite) ──
-    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)")
+    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)", allow_abbrev=False)
     p_opp.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_opp.add_argument("--mode", help="Product search mode preset")
     p_opp.set_defaults(func=cmd_opportunity)
 
     # ── market-entry (composite: full analysis) ──
-    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)")
+    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
     p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
-    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis")
+    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
     p_ca.add_argument("--category", help="Category path")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
-    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking")
+    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
     p_pa.add_argument("--category", help="Category path")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
-    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)")
+    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
     p_dr.add_argument("--category", help="Category path")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
-    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders")
+    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
     p_la.add_argument("--category", help="Category path")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
-    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery")
+    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
     p_os.add_argument("--category", help="Category path")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. beginner,emerging,underserved). Omit to use custom filters only.")
@@ -2189,7 +2189,7 @@ Examples:
     p_os.set_defaults(func=cmd_opportunity_scan)
 
     # ── review-deepdive (composite) ──
-    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis")
+    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis", allow_abbrev=False)
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
@@ -2197,7 +2197,7 @@ Examples:
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── analyze (reviews) ──
-    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis")
+    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
     p_analyze.add_argument("--category", help="Category path")
@@ -2206,7 +2206,7 @@ Examples:
     p_analyze.set_defaults(func=cmd_analyze)
 
     # ── price-band-overview ──
-    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)")
+    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
@@ -2214,7 +2214,7 @@ Examples:
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
-    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown")
+    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
@@ -2222,7 +2222,7 @@ Examples:
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
-    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview")
+    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
@@ -2230,7 +2230,7 @@ Examples:
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
-    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats")
+    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
@@ -2238,14 +2238,14 @@ Examples:
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──
-    p_ph = sub.add_parser("product-history", help="Historical data for ASINs")
+    p_ph = sub.add_parser("product-history", help="Historical data for ASINs", allow_abbrev=False)
     p_ph.add_argument("--asins", required=True, help="ASINs (comma-separated)")
     p_ph.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
     p_ph.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
     p_ph.set_defaults(func=cmd_product_history)
 
     # ── check (API self-check) ──
-    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints")
+    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
     args = parser.parse_args()

--- a/amazon-market-entry-analyzer/scripts/apiclaw.py
+++ b/amazon-market-entry-analyzer/scripts/apiclaw.py
@@ -278,6 +278,8 @@ def cmd_market(args):
         params["topN"] = str(args.topn)
     if args.page_size:
         params["pageSize"] = args.page_size
+    if args.page:
+        params["page"] = args.page
     if args.sort:
         params["sortBy"] = args.sort
     if args.order:
@@ -351,6 +353,7 @@ def cmd_products(args):
     params["sortBy"] = args.sort or "atLeastMonthlySales"
     params["sortOrder"] = args.order or "desc"
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
 
     result = api_call("products/search", params)
 
@@ -1978,6 +1981,7 @@ def cmd_price_band_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-overview", params)
     output(result, args.format)
 
@@ -1990,6 +1994,7 @@ def cmd_price_band_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-detail", params)
     output(result, args.format)
 
@@ -2002,6 +2007,7 @@ def cmd_brand_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-overview", params)
     output(result, args.format)
 
@@ -2014,6 +2020,7 @@ def cmd_brand_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-detail", params)
     output(result, args.format)
 
@@ -2036,6 +2043,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="APIClaw CLI — Amazon Product Research",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
@@ -2069,6 +2077,7 @@ Examples:
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
+    p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_mkt.add_argument("--sort", help="Sort field")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
@@ -2093,6 +2102,7 @@ Examples:
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
+    p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
@@ -2200,6 +2210,7 @@ Examples:
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
+    p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
@@ -2207,6 +2218,7 @@ Examples:
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
+    p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
@@ -2214,6 +2226,7 @@ Examples:
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
+    p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
@@ -2221,6 +2234,7 @@ Examples:
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
+    p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──

--- a/amazon-market-entry-analyzer/scripts/apiclaw.py
+++ b/amazon-market-entry-analyzer/scripts/apiclaw.py
@@ -2065,14 +2065,14 @@ Examples:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # ── categories ──
-    p_cat = sub.add_parser("categories", help="Query Amazon category tree")
+    p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
     p_cat.add_argument("--category", help="Exact category path (comma-separated)")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
-    p_mkt = sub.add_parser("market", help="Search market-level data for a category")
+    p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
     p_mkt.add_argument("--category", help="Category path (comma-separated)")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
@@ -2083,7 +2083,7 @@ Examples:
     p_mkt.set_defaults(func=cmd_market)
 
     # ── products ──
-    p_prod = sub.add_parser("products", help="Search products with filters (product selection)")
+    p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
     p_prod.add_argument("--category", help="Category path (comma-separated)")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
@@ -2108,7 +2108,7 @@ Examples:
     p_prod.set_defaults(func=cmd_products)
 
     # ── competitors ──
-    p_comp = sub.add_parser("competitors", help="Look up competitors")
+    p_comp = sub.add_parser("competitors", help="Look up competitors", allow_abbrev=False)
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
@@ -2122,60 +2122,60 @@ Examples:
     p_comp.set_defaults(func=cmd_competitors)
 
     # ── product (single ASIN) ──
-    p_single = sub.add_parser("product", help="Get real-time details for one ASIN")
+    p_single = sub.add_parser("product", help="Get real-time details for one ASIN", allow_abbrev=False)
     p_single.add_argument("--asin", required=True, help="ASIN (required)")
     p_single.add_argument("--marketplace", default="US",
                           help="Marketplace: US/UK/DE/FR/IT/ES/JP/CA/AU/IN/MX/BR (default: US)")
     p_single.set_defaults(func=cmd_product)
 
     # ── report (composite) ──
-    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)")
+    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)", allow_abbrev=False)
     p_report.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_report.add_argument("--topn", type=int, default=10, help="Top N (default: 10)")
     p_report.set_defaults(func=cmd_report)
 
     # ── opportunity (composite) ──
-    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)")
+    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)", allow_abbrev=False)
     p_opp.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_opp.add_argument("--mode", help="Product search mode preset")
     p_opp.set_defaults(func=cmd_opportunity)
 
     # ── market-entry (composite: full analysis) ──
-    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)")
+    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
     p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
-    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis")
+    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
     p_ca.add_argument("--category", help="Category path")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
-    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking")
+    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
     p_pa.add_argument("--category", help="Category path")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
-    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)")
+    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
     p_dr.add_argument("--category", help="Category path")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
-    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders")
+    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
     p_la.add_argument("--category", help="Category path")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
-    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery")
+    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
     p_os.add_argument("--category", help="Category path")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. beginner,emerging,underserved). Omit to use custom filters only.")
@@ -2189,7 +2189,7 @@ Examples:
     p_os.set_defaults(func=cmd_opportunity_scan)
 
     # ── review-deepdive (composite) ──
-    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis")
+    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis", allow_abbrev=False)
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
@@ -2197,7 +2197,7 @@ Examples:
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── analyze (reviews) ──
-    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis")
+    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
     p_analyze.add_argument("--category", help="Category path")
@@ -2206,7 +2206,7 @@ Examples:
     p_analyze.set_defaults(func=cmd_analyze)
 
     # ── price-band-overview ──
-    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)")
+    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
@@ -2214,7 +2214,7 @@ Examples:
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
-    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown")
+    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
@@ -2222,7 +2222,7 @@ Examples:
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
-    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview")
+    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
@@ -2230,7 +2230,7 @@ Examples:
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
-    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats")
+    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
@@ -2238,14 +2238,14 @@ Examples:
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──
-    p_ph = sub.add_parser("product-history", help="Historical data for ASINs")
+    p_ph = sub.add_parser("product-history", help="Historical data for ASINs", allow_abbrev=False)
     p_ph.add_argument("--asins", required=True, help="ASINs (comma-separated)")
     p_ph.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
     p_ph.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
     p_ph.set_defaults(func=cmd_product_history)
 
     # ── check (API self-check) ──
-    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints")
+    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
     args = parser.parse_args()

--- a/amazon-market-trend-scanner/scripts/apiclaw.py
+++ b/amazon-market-trend-scanner/scripts/apiclaw.py
@@ -278,6 +278,8 @@ def cmd_market(args):
         params["topN"] = str(args.topn)
     if args.page_size:
         params["pageSize"] = args.page_size
+    if args.page:
+        params["page"] = args.page
     if args.sort:
         params["sortBy"] = args.sort
     if args.order:
@@ -351,6 +353,7 @@ def cmd_products(args):
     params["sortBy"] = args.sort or "atLeastMonthlySales"
     params["sortOrder"] = args.order or "desc"
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
 
     result = api_call("products/search", params)
 
@@ -1978,6 +1981,7 @@ def cmd_price_band_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-overview", params)
     output(result, args.format)
 
@@ -1990,6 +1994,7 @@ def cmd_price_band_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-detail", params)
     output(result, args.format)
 
@@ -2002,6 +2007,7 @@ def cmd_brand_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-overview", params)
     output(result, args.format)
 
@@ -2014,6 +2020,7 @@ def cmd_brand_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-detail", params)
     output(result, args.format)
 
@@ -2036,6 +2043,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="APIClaw CLI — Amazon Product Research",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
@@ -2069,6 +2077,7 @@ Examples:
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
+    p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_mkt.add_argument("--sort", help="Sort field")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
@@ -2093,6 +2102,7 @@ Examples:
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
+    p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
@@ -2200,6 +2210,7 @@ Examples:
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
+    p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
@@ -2207,6 +2218,7 @@ Examples:
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
+    p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
@@ -2214,6 +2226,7 @@ Examples:
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
+    p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
@@ -2221,6 +2234,7 @@ Examples:
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
+    p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──

--- a/amazon-market-trend-scanner/scripts/apiclaw.py
+++ b/amazon-market-trend-scanner/scripts/apiclaw.py
@@ -2065,14 +2065,14 @@ Examples:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # ── categories ──
-    p_cat = sub.add_parser("categories", help="Query Amazon category tree")
+    p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
     p_cat.add_argument("--category", help="Exact category path (comma-separated)")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
-    p_mkt = sub.add_parser("market", help="Search market-level data for a category")
+    p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
     p_mkt.add_argument("--category", help="Category path (comma-separated)")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
@@ -2083,7 +2083,7 @@ Examples:
     p_mkt.set_defaults(func=cmd_market)
 
     # ── products ──
-    p_prod = sub.add_parser("products", help="Search products with filters (product selection)")
+    p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
     p_prod.add_argument("--category", help="Category path (comma-separated)")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
@@ -2108,7 +2108,7 @@ Examples:
     p_prod.set_defaults(func=cmd_products)
 
     # ── competitors ──
-    p_comp = sub.add_parser("competitors", help="Look up competitors")
+    p_comp = sub.add_parser("competitors", help="Look up competitors", allow_abbrev=False)
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
@@ -2122,60 +2122,60 @@ Examples:
     p_comp.set_defaults(func=cmd_competitors)
 
     # ── product (single ASIN) ──
-    p_single = sub.add_parser("product", help="Get real-time details for one ASIN")
+    p_single = sub.add_parser("product", help="Get real-time details for one ASIN", allow_abbrev=False)
     p_single.add_argument("--asin", required=True, help="ASIN (required)")
     p_single.add_argument("--marketplace", default="US",
                           help="Marketplace: US/UK/DE/FR/IT/ES/JP/CA/AU/IN/MX/BR (default: US)")
     p_single.set_defaults(func=cmd_product)
 
     # ── report (composite) ──
-    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)")
+    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)", allow_abbrev=False)
     p_report.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_report.add_argument("--topn", type=int, default=10, help="Top N (default: 10)")
     p_report.set_defaults(func=cmd_report)
 
     # ── opportunity (composite) ──
-    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)")
+    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)", allow_abbrev=False)
     p_opp.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_opp.add_argument("--mode", help="Product search mode preset")
     p_opp.set_defaults(func=cmd_opportunity)
 
     # ── market-entry (composite: full analysis) ──
-    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)")
+    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
     p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
-    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis")
+    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
     p_ca.add_argument("--category", help="Category path")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
-    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking")
+    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
     p_pa.add_argument("--category", help="Category path")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
-    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)")
+    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
     p_dr.add_argument("--category", help="Category path")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
-    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders")
+    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
     p_la.add_argument("--category", help="Category path")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
-    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery")
+    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
     p_os.add_argument("--category", help="Category path")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. beginner,emerging,underserved). Omit to use custom filters only.")
@@ -2189,7 +2189,7 @@ Examples:
     p_os.set_defaults(func=cmd_opportunity_scan)
 
     # ── review-deepdive (composite) ──
-    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis")
+    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis", allow_abbrev=False)
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
@@ -2197,7 +2197,7 @@ Examples:
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── analyze (reviews) ──
-    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis")
+    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
     p_analyze.add_argument("--category", help="Category path")
@@ -2206,7 +2206,7 @@ Examples:
     p_analyze.set_defaults(func=cmd_analyze)
 
     # ── price-band-overview ──
-    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)")
+    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
@@ -2214,7 +2214,7 @@ Examples:
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
-    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown")
+    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
@@ -2222,7 +2222,7 @@ Examples:
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
-    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview")
+    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
@@ -2230,7 +2230,7 @@ Examples:
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
-    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats")
+    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
@@ -2238,14 +2238,14 @@ Examples:
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──
-    p_ph = sub.add_parser("product-history", help="Historical data for ASINs")
+    p_ph = sub.add_parser("product-history", help="Historical data for ASINs", allow_abbrev=False)
     p_ph.add_argument("--asins", required=True, help="ASINs (comma-separated)")
     p_ph.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
     p_ph.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
     p_ph.set_defaults(func=cmd_product_history)
 
     # ── check (API self-check) ──
-    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints")
+    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
     args = parser.parse_args()

--- a/amazon-opportunity-discoverer/scripts/apiclaw.py
+++ b/amazon-opportunity-discoverer/scripts/apiclaw.py
@@ -278,6 +278,8 @@ def cmd_market(args):
         params["topN"] = str(args.topn)
     if args.page_size:
         params["pageSize"] = args.page_size
+    if args.page:
+        params["page"] = args.page
     if args.sort:
         params["sortBy"] = args.sort
     if args.order:
@@ -351,6 +353,7 @@ def cmd_products(args):
     params["sortBy"] = args.sort or "atLeastMonthlySales"
     params["sortOrder"] = args.order or "desc"
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
 
     result = api_call("products/search", params)
 
@@ -1978,6 +1981,7 @@ def cmd_price_band_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-overview", params)
     output(result, args.format)
 
@@ -1990,6 +1994,7 @@ def cmd_price_band_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-detail", params)
     output(result, args.format)
 
@@ -2002,6 +2007,7 @@ def cmd_brand_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-overview", params)
     output(result, args.format)
 
@@ -2014,6 +2020,7 @@ def cmd_brand_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-detail", params)
     output(result, args.format)
 
@@ -2036,6 +2043,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="APIClaw CLI — Amazon Product Research",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
@@ -2069,6 +2077,7 @@ Examples:
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
+    p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_mkt.add_argument("--sort", help="Sort field")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
@@ -2093,6 +2102,7 @@ Examples:
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
+    p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
@@ -2200,6 +2210,7 @@ Examples:
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
+    p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
@@ -2207,6 +2218,7 @@ Examples:
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
+    p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
@@ -2214,6 +2226,7 @@ Examples:
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
+    p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
@@ -2221,6 +2234,7 @@ Examples:
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
+    p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──

--- a/amazon-opportunity-discoverer/scripts/apiclaw.py
+++ b/amazon-opportunity-discoverer/scripts/apiclaw.py
@@ -2065,14 +2065,14 @@ Examples:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # ── categories ──
-    p_cat = sub.add_parser("categories", help="Query Amazon category tree")
+    p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
     p_cat.add_argument("--category", help="Exact category path (comma-separated)")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
-    p_mkt = sub.add_parser("market", help="Search market-level data for a category")
+    p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
     p_mkt.add_argument("--category", help="Category path (comma-separated)")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
@@ -2083,7 +2083,7 @@ Examples:
     p_mkt.set_defaults(func=cmd_market)
 
     # ── products ──
-    p_prod = sub.add_parser("products", help="Search products with filters (product selection)")
+    p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
     p_prod.add_argument("--category", help="Category path (comma-separated)")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
@@ -2108,7 +2108,7 @@ Examples:
     p_prod.set_defaults(func=cmd_products)
 
     # ── competitors ──
-    p_comp = sub.add_parser("competitors", help="Look up competitors")
+    p_comp = sub.add_parser("competitors", help="Look up competitors", allow_abbrev=False)
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
@@ -2122,60 +2122,60 @@ Examples:
     p_comp.set_defaults(func=cmd_competitors)
 
     # ── product (single ASIN) ──
-    p_single = sub.add_parser("product", help="Get real-time details for one ASIN")
+    p_single = sub.add_parser("product", help="Get real-time details for one ASIN", allow_abbrev=False)
     p_single.add_argument("--asin", required=True, help="ASIN (required)")
     p_single.add_argument("--marketplace", default="US",
                           help="Marketplace: US/UK/DE/FR/IT/ES/JP/CA/AU/IN/MX/BR (default: US)")
     p_single.set_defaults(func=cmd_product)
 
     # ── report (composite) ──
-    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)")
+    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)", allow_abbrev=False)
     p_report.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_report.add_argument("--topn", type=int, default=10, help="Top N (default: 10)")
     p_report.set_defaults(func=cmd_report)
 
     # ── opportunity (composite) ──
-    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)")
+    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)", allow_abbrev=False)
     p_opp.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_opp.add_argument("--mode", help="Product search mode preset")
     p_opp.set_defaults(func=cmd_opportunity)
 
     # ── market-entry (composite: full analysis) ──
-    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)")
+    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
     p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
-    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis")
+    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
     p_ca.add_argument("--category", help="Category path")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
-    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking")
+    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
     p_pa.add_argument("--category", help="Category path")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
-    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)")
+    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
     p_dr.add_argument("--category", help="Category path")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
-    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders")
+    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
     p_la.add_argument("--category", help="Category path")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
-    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery")
+    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
     p_os.add_argument("--category", help="Category path")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. beginner,emerging,underserved). Omit to use custom filters only.")
@@ -2189,7 +2189,7 @@ Examples:
     p_os.set_defaults(func=cmd_opportunity_scan)
 
     # ── review-deepdive (composite) ──
-    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis")
+    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis", allow_abbrev=False)
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
@@ -2197,7 +2197,7 @@ Examples:
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── analyze (reviews) ──
-    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis")
+    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
     p_analyze.add_argument("--category", help="Category path")
@@ -2206,7 +2206,7 @@ Examples:
     p_analyze.set_defaults(func=cmd_analyze)
 
     # ── price-band-overview ──
-    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)")
+    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
@@ -2214,7 +2214,7 @@ Examples:
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
-    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown")
+    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
@@ -2222,7 +2222,7 @@ Examples:
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
-    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview")
+    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
@@ -2230,7 +2230,7 @@ Examples:
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
-    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats")
+    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
@@ -2238,14 +2238,14 @@ Examples:
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──
-    p_ph = sub.add_parser("product-history", help="Historical data for ASINs")
+    p_ph = sub.add_parser("product-history", help="Historical data for ASINs", allow_abbrev=False)
     p_ph.add_argument("--asins", required=True, help="ASINs (comma-separated)")
     p_ph.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
     p_ph.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
     p_ph.set_defaults(func=cmd_product_history)
 
     # ── check (API self-check) ──
-    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints")
+    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
     args = parser.parse_args()

--- a/amazon-pricing-command-center/scripts/apiclaw.py
+++ b/amazon-pricing-command-center/scripts/apiclaw.py
@@ -278,6 +278,8 @@ def cmd_market(args):
         params["topN"] = str(args.topn)
     if args.page_size:
         params["pageSize"] = args.page_size
+    if args.page:
+        params["page"] = args.page
     if args.sort:
         params["sortBy"] = args.sort
     if args.order:
@@ -351,6 +353,7 @@ def cmd_products(args):
     params["sortBy"] = args.sort or "atLeastMonthlySales"
     params["sortOrder"] = args.order or "desc"
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
 
     result = api_call("products/search", params)
 
@@ -1978,6 +1981,7 @@ def cmd_price_band_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-overview", params)
     output(result, args.format)
 
@@ -1990,6 +1994,7 @@ def cmd_price_band_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-detail", params)
     output(result, args.format)
 
@@ -2002,6 +2007,7 @@ def cmd_brand_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-overview", params)
     output(result, args.format)
 
@@ -2014,6 +2020,7 @@ def cmd_brand_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-detail", params)
     output(result, args.format)
 
@@ -2036,6 +2043,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="APIClaw CLI — Amazon Product Research",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
@@ -2069,6 +2077,7 @@ Examples:
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
+    p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_mkt.add_argument("--sort", help="Sort field")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
@@ -2093,6 +2102,7 @@ Examples:
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
+    p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
@@ -2200,6 +2210,7 @@ Examples:
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
+    p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
@@ -2207,6 +2218,7 @@ Examples:
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
+    p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
@@ -2214,6 +2226,7 @@ Examples:
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
+    p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
@@ -2221,6 +2234,7 @@ Examples:
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
+    p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──

--- a/amazon-pricing-command-center/scripts/apiclaw.py
+++ b/amazon-pricing-command-center/scripts/apiclaw.py
@@ -2065,14 +2065,14 @@ Examples:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # ── categories ──
-    p_cat = sub.add_parser("categories", help="Query Amazon category tree")
+    p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
     p_cat.add_argument("--category", help="Exact category path (comma-separated)")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
-    p_mkt = sub.add_parser("market", help="Search market-level data for a category")
+    p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
     p_mkt.add_argument("--category", help="Category path (comma-separated)")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
@@ -2083,7 +2083,7 @@ Examples:
     p_mkt.set_defaults(func=cmd_market)
 
     # ── products ──
-    p_prod = sub.add_parser("products", help="Search products with filters (product selection)")
+    p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
     p_prod.add_argument("--category", help="Category path (comma-separated)")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
@@ -2108,7 +2108,7 @@ Examples:
     p_prod.set_defaults(func=cmd_products)
 
     # ── competitors ──
-    p_comp = sub.add_parser("competitors", help="Look up competitors")
+    p_comp = sub.add_parser("competitors", help="Look up competitors", allow_abbrev=False)
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
@@ -2122,60 +2122,60 @@ Examples:
     p_comp.set_defaults(func=cmd_competitors)
 
     # ── product (single ASIN) ──
-    p_single = sub.add_parser("product", help="Get real-time details for one ASIN")
+    p_single = sub.add_parser("product", help="Get real-time details for one ASIN", allow_abbrev=False)
     p_single.add_argument("--asin", required=True, help="ASIN (required)")
     p_single.add_argument("--marketplace", default="US",
                           help="Marketplace: US/UK/DE/FR/IT/ES/JP/CA/AU/IN/MX/BR (default: US)")
     p_single.set_defaults(func=cmd_product)
 
     # ── report (composite) ──
-    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)")
+    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)", allow_abbrev=False)
     p_report.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_report.add_argument("--topn", type=int, default=10, help="Top N (default: 10)")
     p_report.set_defaults(func=cmd_report)
 
     # ── opportunity (composite) ──
-    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)")
+    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)", allow_abbrev=False)
     p_opp.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_opp.add_argument("--mode", help="Product search mode preset")
     p_opp.set_defaults(func=cmd_opportunity)
 
     # ── market-entry (composite: full analysis) ──
-    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)")
+    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
     p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
-    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis")
+    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
     p_ca.add_argument("--category", help="Category path")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
-    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking")
+    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
     p_pa.add_argument("--category", help="Category path")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
-    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)")
+    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
     p_dr.add_argument("--category", help="Category path")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
-    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders")
+    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
     p_la.add_argument("--category", help="Category path")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
-    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery")
+    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
     p_os.add_argument("--category", help="Category path")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. beginner,emerging,underserved). Omit to use custom filters only.")
@@ -2189,7 +2189,7 @@ Examples:
     p_os.set_defaults(func=cmd_opportunity_scan)
 
     # ── review-deepdive (composite) ──
-    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis")
+    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis", allow_abbrev=False)
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
@@ -2197,7 +2197,7 @@ Examples:
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── analyze (reviews) ──
-    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis")
+    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
     p_analyze.add_argument("--category", help="Category path")
@@ -2206,7 +2206,7 @@ Examples:
     p_analyze.set_defaults(func=cmd_analyze)
 
     # ── price-band-overview ──
-    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)")
+    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
@@ -2214,7 +2214,7 @@ Examples:
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
-    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown")
+    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
@@ -2222,7 +2222,7 @@ Examples:
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
-    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview")
+    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
@@ -2230,7 +2230,7 @@ Examples:
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
-    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats")
+    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
@@ -2238,14 +2238,14 @@ Examples:
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──
-    p_ph = sub.add_parser("product-history", help="Historical data for ASINs")
+    p_ph = sub.add_parser("product-history", help="Historical data for ASINs", allow_abbrev=False)
     p_ph.add_argument("--asins", required=True, help="ASINs (comma-separated)")
     p_ph.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
     p_ph.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
     p_ph.set_defaults(func=cmd_product_history)
 
     # ── check (API self-check) ──
-    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints")
+    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
     args = parser.parse_args()

--- a/amazon-review-intelligence-extractor/scripts/apiclaw.py
+++ b/amazon-review-intelligence-extractor/scripts/apiclaw.py
@@ -278,6 +278,8 @@ def cmd_market(args):
         params["topN"] = str(args.topn)
     if args.page_size:
         params["pageSize"] = args.page_size
+    if args.page:
+        params["page"] = args.page
     if args.sort:
         params["sortBy"] = args.sort
     if args.order:
@@ -351,6 +353,7 @@ def cmd_products(args):
     params["sortBy"] = args.sort or "atLeastMonthlySales"
     params["sortOrder"] = args.order or "desc"
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
 
     result = api_call("products/search", params)
 
@@ -1978,6 +1981,7 @@ def cmd_price_band_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-overview", params)
     output(result, args.format)
 
@@ -1990,6 +1994,7 @@ def cmd_price_band_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-detail", params)
     output(result, args.format)
 
@@ -2002,6 +2007,7 @@ def cmd_brand_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-overview", params)
     output(result, args.format)
 
@@ -2014,6 +2020,7 @@ def cmd_brand_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-detail", params)
     output(result, args.format)
 
@@ -2036,6 +2043,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="APIClaw CLI — Amazon Product Research",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
@@ -2069,6 +2077,7 @@ Examples:
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
+    p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_mkt.add_argument("--sort", help="Sort field")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
@@ -2093,6 +2102,7 @@ Examples:
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
+    p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
@@ -2200,6 +2210,7 @@ Examples:
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
+    p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
@@ -2207,6 +2218,7 @@ Examples:
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
+    p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
@@ -2214,6 +2226,7 @@ Examples:
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
+    p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
@@ -2221,6 +2234,7 @@ Examples:
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
+    p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──

--- a/amazon-review-intelligence-extractor/scripts/apiclaw.py
+++ b/amazon-review-intelligence-extractor/scripts/apiclaw.py
@@ -2065,14 +2065,14 @@ Examples:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # ── categories ──
-    p_cat = sub.add_parser("categories", help="Query Amazon category tree")
+    p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
     p_cat.add_argument("--category", help="Exact category path (comma-separated)")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
-    p_mkt = sub.add_parser("market", help="Search market-level data for a category")
+    p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
     p_mkt.add_argument("--category", help="Category path (comma-separated)")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
@@ -2083,7 +2083,7 @@ Examples:
     p_mkt.set_defaults(func=cmd_market)
 
     # ── products ──
-    p_prod = sub.add_parser("products", help="Search products with filters (product selection)")
+    p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
     p_prod.add_argument("--category", help="Category path (comma-separated)")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
@@ -2108,7 +2108,7 @@ Examples:
     p_prod.set_defaults(func=cmd_products)
 
     # ── competitors ──
-    p_comp = sub.add_parser("competitors", help="Look up competitors")
+    p_comp = sub.add_parser("competitors", help="Look up competitors", allow_abbrev=False)
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
@@ -2122,60 +2122,60 @@ Examples:
     p_comp.set_defaults(func=cmd_competitors)
 
     # ── product (single ASIN) ──
-    p_single = sub.add_parser("product", help="Get real-time details for one ASIN")
+    p_single = sub.add_parser("product", help="Get real-time details for one ASIN", allow_abbrev=False)
     p_single.add_argument("--asin", required=True, help="ASIN (required)")
     p_single.add_argument("--marketplace", default="US",
                           help="Marketplace: US/UK/DE/FR/IT/ES/JP/CA/AU/IN/MX/BR (default: US)")
     p_single.set_defaults(func=cmd_product)
 
     # ── report (composite) ──
-    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)")
+    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)", allow_abbrev=False)
     p_report.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_report.add_argument("--topn", type=int, default=10, help="Top N (default: 10)")
     p_report.set_defaults(func=cmd_report)
 
     # ── opportunity (composite) ──
-    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)")
+    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)", allow_abbrev=False)
     p_opp.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_opp.add_argument("--mode", help="Product search mode preset")
     p_opp.set_defaults(func=cmd_opportunity)
 
     # ── market-entry (composite: full analysis) ──
-    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)")
+    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
     p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
-    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis")
+    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
     p_ca.add_argument("--category", help="Category path")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
-    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking")
+    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
     p_pa.add_argument("--category", help="Category path")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
-    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)")
+    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
     p_dr.add_argument("--category", help="Category path")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
-    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders")
+    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
     p_la.add_argument("--category", help="Category path")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
-    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery")
+    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
     p_os.add_argument("--category", help="Category path")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. beginner,emerging,underserved). Omit to use custom filters only.")
@@ -2189,7 +2189,7 @@ Examples:
     p_os.set_defaults(func=cmd_opportunity_scan)
 
     # ── review-deepdive (composite) ──
-    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis")
+    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis", allow_abbrev=False)
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
@@ -2197,7 +2197,7 @@ Examples:
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── analyze (reviews) ──
-    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis")
+    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
     p_analyze.add_argument("--category", help="Category path")
@@ -2206,7 +2206,7 @@ Examples:
     p_analyze.set_defaults(func=cmd_analyze)
 
     # ── price-band-overview ──
-    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)")
+    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
@@ -2214,7 +2214,7 @@ Examples:
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
-    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown")
+    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
@@ -2222,7 +2222,7 @@ Examples:
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
-    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview")
+    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
@@ -2230,7 +2230,7 @@ Examples:
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
-    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats")
+    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
@@ -2238,14 +2238,14 @@ Examples:
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──
-    p_ph = sub.add_parser("product-history", help="Historical data for ASINs")
+    p_ph = sub.add_parser("product-history", help="Historical data for ASINs", allow_abbrev=False)
     p_ph.add_argument("--asins", required=True, help="ASINs (comma-separated)")
     p_ph.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
     p_ph.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
     p_ph.set_defaults(func=cmd_product_history)
 
     # ── check (API self-check) ──
-    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints")
+    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
     args = parser.parse_args()

--- a/apiclaw/scripts/apiclaw.py
+++ b/apiclaw/scripts/apiclaw.py
@@ -278,6 +278,8 @@ def cmd_market(args):
         params["topN"] = str(args.topn)
     if args.page_size:
         params["pageSize"] = args.page_size
+    if args.page:
+        params["page"] = args.page
     if args.sort:
         params["sortBy"] = args.sort
     if args.order:
@@ -351,6 +353,7 @@ def cmd_products(args):
     params["sortBy"] = args.sort or "atLeastMonthlySales"
     params["sortOrder"] = args.order or "desc"
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
 
     result = api_call("products/search", params)
 
@@ -1978,6 +1981,7 @@ def cmd_price_band_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-overview", params)
     output(result, args.format)
 
@@ -1990,6 +1994,7 @@ def cmd_price_band_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/price-band-detail", params)
     output(result, args.format)
 
@@ -2002,6 +2007,7 @@ def cmd_brand_overview(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-overview", params)
     output(result, args.format)
 
@@ -2014,6 +2020,7 @@ def cmd_brand_detail(args):
     if args.category:
         params["categoryPath"] = parse_category(args.category)
     params["pageSize"] = args.page_size or 20
+    params["page"] = args.page or 1
     result = api_call("products/brand-detail", params)
     output(result, args.format)
 
@@ -2036,6 +2043,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="APIClaw CLI — Amazon Product Research",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
@@ -2069,6 +2077,7 @@ Examples:
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
+    p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_mkt.add_argument("--sort", help="Sort field")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
@@ -2093,6 +2102,7 @@ Examples:
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
+    p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
@@ -2200,6 +2210,7 @@ Examples:
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
+    p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
@@ -2207,6 +2218,7 @@ Examples:
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
+    p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
@@ -2214,6 +2226,7 @@ Examples:
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
+    p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
@@ -2221,6 +2234,7 @@ Examples:
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
+    p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──

--- a/apiclaw/scripts/apiclaw.py
+++ b/apiclaw/scripts/apiclaw.py
@@ -2065,14 +2065,14 @@ Examples:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # ── categories ──
-    p_cat = sub.add_parser("categories", help="Query Amazon category tree")
+    p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
     p_cat.add_argument("--category", help="Exact category path (comma-separated)")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
-    p_mkt = sub.add_parser("market", help="Search market-level data for a category")
+    p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
     p_mkt.add_argument("--category", help="Category path (comma-separated)")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
@@ -2083,7 +2083,7 @@ Examples:
     p_mkt.set_defaults(func=cmd_market)
 
     # ── products ──
-    p_prod = sub.add_parser("products", help="Search products with filters (product selection)")
+    p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
     p_prod.add_argument("--category", help="Category path (comma-separated)")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
@@ -2108,7 +2108,7 @@ Examples:
     p_prod.set_defaults(func=cmd_products)
 
     # ── competitors ──
-    p_comp = sub.add_parser("competitors", help="Look up competitors")
+    p_comp = sub.add_parser("competitors", help="Look up competitors", allow_abbrev=False)
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
@@ -2122,60 +2122,60 @@ Examples:
     p_comp.set_defaults(func=cmd_competitors)
 
     # ── product (single ASIN) ──
-    p_single = sub.add_parser("product", help="Get real-time details for one ASIN")
+    p_single = sub.add_parser("product", help="Get real-time details for one ASIN", allow_abbrev=False)
     p_single.add_argument("--asin", required=True, help="ASIN (required)")
     p_single.add_argument("--marketplace", default="US",
                           help="Marketplace: US/UK/DE/FR/IT/ES/JP/CA/AU/IN/MX/BR (default: US)")
     p_single.set_defaults(func=cmd_product)
 
     # ── report (composite) ──
-    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)")
+    p_report = sub.add_parser("report", help="Full market analysis report (composite workflow)", allow_abbrev=False)
     p_report.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_report.add_argument("--topn", type=int, default=10, help="Top N (default: 10)")
     p_report.set_defaults(func=cmd_report)
 
     # ── opportunity (composite) ──
-    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)")
+    p_opp = sub.add_parser("opportunity", help="Product opportunity discovery (composite workflow)", allow_abbrev=False)
     p_opp.add_argument("--keyword", required=True, help="Category/niche keyword")
     p_opp.add_argument("--mode", help="Product search mode preset")
     p_opp.set_defaults(func=cmd_opportunity)
 
     # ── market-entry (composite: full analysis) ──
-    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)")
+    p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
     p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
-    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis")
+    p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
     p_ca.add_argument("--category", help="Category path")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
-    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking")
+    p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
     p_pa.add_argument("--category", help="Category path")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
-    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)")
+    p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
     p_dr.add_argument("--category", help="Category path")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
-    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders")
+    p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
     p_la.add_argument("--category", help="Category path")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
-    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery")
+    p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
     p_os.add_argument("--category", help="Category path")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. beginner,emerging,underserved). Omit to use custom filters only.")
@@ -2189,7 +2189,7 @@ Examples:
     p_os.set_defaults(func=cmd_opportunity_scan)
 
     # ── review-deepdive (composite) ──
-    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis")
+    p_rd = sub.add_parser("review-deepdive", help="Full 11-dimension review intelligence analysis", allow_abbrev=False)
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
@@ -2197,7 +2197,7 @@ Examples:
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── analyze (reviews) ──
-    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis")
+    p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
     p_analyze.add_argument("--category", help="Category path")
@@ -2206,7 +2206,7 @@ Examples:
     p_analyze.set_defaults(func=cmd_analyze)
 
     # ── price-band-overview ──
-    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)")
+    p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
     p_pbo.add_argument("--category", help="Category path")
     p_pbo.add_argument("--page-size", type=int, default=20)
@@ -2214,7 +2214,7 @@ Examples:
     p_pbo.set_defaults(func=cmd_price_band_overview)
 
     # ── price-band-detail ──
-    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown")
+    p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
     p_pbd.add_argument("--category", help="Category path")
     p_pbd.add_argument("--page-size", type=int, default=20)
@@ -2222,7 +2222,7 @@ Examples:
     p_pbd.set_defaults(func=cmd_price_band_detail)
 
     # ── brand-overview ──
-    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview")
+    p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
     p_bo.add_argument("--category", help="Category path")
     p_bo.add_argument("--page-size", type=int, default=20)
@@ -2230,7 +2230,7 @@ Examples:
     p_bo.set_defaults(func=cmd_brand_overview)
 
     # ── brand-detail ──
-    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats")
+    p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
     p_bd.add_argument("--category", help="Category path")
     p_bd.add_argument("--page-size", type=int, default=20)
@@ -2238,14 +2238,14 @@ Examples:
     p_bd.set_defaults(func=cmd_brand_detail)
 
     # ── product-history ──
-    p_ph = sub.add_parser("product-history", help="Historical data for ASINs")
+    p_ph = sub.add_parser("product-history", help="Historical data for ASINs", allow_abbrev=False)
     p_ph.add_argument("--asins", required=True, help="ASINs (comma-separated)")
     p_ph.add_argument("--start-date", required=True, help="Start date (YYYY-MM-DD)")
     p_ph.add_argument("--end-date", required=True, help="End date (YYYY-MM-DD)")
     p_ph.set_defaults(func=cmd_product_history)
 
     # ── check (API self-check) ──
-    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints")
+    p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
     args = parser.parse_args()

--- a/apiclaw/scripts/test_apiclaw_page_arg.py
+++ b/apiclaw/scripts/test_apiclaw_page_arg.py
@@ -1,0 +1,197 @@
+"""
+Tests for the argparse prefix-matching bug fix.
+
+Verifies that:
+1. --page and --page-size are passed to api_call independently and correctly
+2. --page does NOT overwrite --page-size (the original bug)
+3. allow_abbrev=False causes unknown abbreviations to error out
+4. All 6 affected subcommands: market, products, price-band-overview,
+   price-band-detail, brand-overview, brand-detail
+
+Run:
+    python -m pytest test_apiclaw_page_arg.py -v
+    # or without pytest:
+    python test_apiclaw_page_arg.py
+"""
+
+import importlib
+import json
+import sys
+import types
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Load the module under test without executing main()
+# ---------------------------------------------------------------------------
+SCRIPT_PATH = __file__.replace("test_apiclaw_page_arg.py", "apiclaw.py")
+
+spec = importlib.util.spec_from_file_location("apiclaw", SCRIPT_PATH)
+apiclaw = importlib.util.module_from_spec(spec)
+# Patch get_api_key before exec so the module doesn't fail at import time
+with patch.dict("os.environ", {"APICLAW_API_KEY": "test_key"}):
+    spec.loader.exec_module(apiclaw)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+MOCK_RESPONSE = {"success": True, "data": [], "_query": {"endpoint": "", "params": {}}}
+
+
+def run_cli(*argv):
+    """Run apiclaw.main() with the given argv, mocking api_call.
+
+    Returns the params dict that was passed to api_call.
+    """
+    captured = {}
+
+    def fake_api_call(endpoint, params):
+        captured["endpoint"] = endpoint
+        captured["params"] = dict(params)
+        return {**MOCK_RESPONSE, "_query": {"endpoint": endpoint, "params": params}}
+
+    with patch.object(apiclaw, "api_call", side_effect=fake_api_call), \
+         patch.object(apiclaw, "output"), \
+         patch.object(sys, "argv", ["apiclaw.py", *argv]):
+        apiclaw.main()
+
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+class TestMarketPageArg(unittest.TestCase):
+
+    def test_page_size_not_overwritten_by_page(self):
+        """Original bug: --page 1 used to silently set page_size=1."""
+        result = run_cli("market", "--category", "Sports", "--page-size", "20", "--page", "1")
+        self.assertEqual(result["params"]["pageSize"], 20, "pageSize must remain 20")
+        self.assertEqual(result["params"]["page"], 1, "page must be 1")
+
+    def test_page_default_is_1(self):
+        result = run_cli("market", "--category", "Sports")
+        # page default=1 — but cmd_market only sets page if args.page is truthy
+        # page=1 is truthy (non-zero), so it should be present
+        self.assertEqual(result["params"]["page"], 1)
+
+    def test_custom_page(self):
+        result = run_cli("market", "--category", "Sports", "--page", "3")
+        self.assertEqual(result["params"]["page"], 3)
+        self.assertEqual(result["params"]["pageSize"], 20)  # default
+
+    def test_page_and_page_size_independent(self):
+        result = run_cli("market", "--page-size", "50", "--page", "2", "--keyword", "yoga")
+        self.assertEqual(result["params"]["pageSize"], 50)
+        self.assertEqual(result["params"]["page"], 2)
+
+
+class TestProductsPageArg(unittest.TestCase):
+
+    def test_page_size_not_overwritten_by_page(self):
+        result = run_cli("products", "--keyword", "yoga mat", "--page-size", "20", "--page", "1")
+        self.assertEqual(result["params"]["pageSize"], 20)
+        self.assertEqual(result["params"]["page"], 1)
+
+    def test_custom_page(self):
+        result = run_cli("products", "--keyword", "yoga mat", "--page", "5")
+        self.assertEqual(result["params"]["page"], 5)
+
+    def test_page_size_default(self):
+        result = run_cli("products", "--keyword", "yoga mat")
+        self.assertEqual(result["params"]["pageSize"], 20)
+        self.assertEqual(result["params"]["page"], 1)
+
+
+class TestPriceBandOverviewPageArg(unittest.TestCase):
+
+    def test_page_size_not_overwritten(self):
+        result = run_cli("price-band-overview", "--keyword", "yoga", "--page-size", "30", "--page", "2")
+        self.assertEqual(result["params"]["pageSize"], 30)
+        self.assertEqual(result["params"]["page"], 2)
+
+    def test_defaults(self):
+        result = run_cli("price-band-overview", "--keyword", "yoga")
+        self.assertEqual(result["params"]["pageSize"], 20)
+        self.assertEqual(result["params"]["page"], 1)
+
+
+class TestPriceBandDetailPageArg(unittest.TestCase):
+
+    def test_page_size_not_overwritten(self):
+        result = run_cli("price-band-detail", "--keyword", "yoga", "--page-size", "40", "--page", "3")
+        self.assertEqual(result["params"]["pageSize"], 40)
+        self.assertEqual(result["params"]["page"], 3)
+
+    def test_defaults(self):
+        result = run_cli("price-band-detail", "--keyword", "yoga")
+        self.assertEqual(result["params"]["pageSize"], 20)
+        self.assertEqual(result["params"]["page"], 1)
+
+
+class TestBrandOverviewPageArg(unittest.TestCase):
+
+    def test_page_size_not_overwritten(self):
+        result = run_cli("brand-overview", "--keyword", "yoga", "--page-size", "15", "--page", "2")
+        self.assertEqual(result["params"]["pageSize"], 15)
+        self.assertEqual(result["params"]["page"], 2)
+
+    def test_defaults(self):
+        result = run_cli("brand-overview", "--keyword", "yoga")
+        self.assertEqual(result["params"]["pageSize"], 20)
+        self.assertEqual(result["params"]["page"], 1)
+
+
+class TestBrandDetailPageArg(unittest.TestCase):
+
+    def test_page_size_not_overwritten(self):
+        result = run_cli("brand-detail", "--keyword", "yoga", "--page-size", "25", "--page", "4")
+        self.assertEqual(result["params"]["pageSize"], 25)
+        self.assertEqual(result["params"]["page"], 4)
+
+    def test_defaults(self):
+        result = run_cli("brand-detail", "--keyword", "yoga")
+        self.assertEqual(result["params"]["pageSize"], 20)
+        self.assertEqual(result["params"]["page"], 1)
+
+
+class TestAllowAbbrevDisabled(unittest.TestCase):
+    """allow_abbrev=False: abbreviated args should error, not silently match."""
+
+    def _assert_parse_error(self, *argv):
+        with patch.object(apiclaw, "api_call", return_value=MOCK_RESPONSE), \
+             patch.object(apiclaw, "output"), \
+             patch.object(sys, "argv", ["apiclaw.py", *argv]), \
+             self.assertRaises(SystemExit) as cm:
+            apiclaw.main()
+        self.assertNotEqual(cm.exception.code, 0, "Should exit with error code")
+
+    def test_abbreviated_page_errors_on_market(self):
+        """--pag should NOT be silently matched to --page-size or --page."""
+        self._assert_parse_error("market", "--category", "Sports", "--pag", "1")
+
+    def test_abbreviated_page_size_errors(self):
+        """--page-s should NOT silently match to --page-size."""
+        self._assert_parse_error("market", "--category", "Sports", "--page-s", "20")
+
+
+class TestCompetitorsUnchanged(unittest.TestCase):
+    """competitors already had --page defined — verify it still works."""
+
+    def test_competitors_page_and_page_size(self):
+        result = run_cli("competitors", "--keyword", "earbuds", "--page-size", "30", "--page", "2")
+        self.assertEqual(result["params"]["pageSize"], 30)
+        self.assertEqual(result["params"]["page"], 2)
+
+
+# ---------------------------------------------------------------------------
+# Standalone runner (no pytest required)
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(sys.modules[__name__])
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/tests/test_apiclaw.py
+++ b/tests/test_apiclaw.py
@@ -1,0 +1,332 @@
+"""
+Test suite for apiclaw/scripts/apiclaw.py
+
+Coverage:
+  - parse_category: all supported separators and edge cases
+  - PRODUCT_MODES: all 14 modes accepted without error
+  - argparse: all subcommands have valid --help; allow_abbrev=False regression
+  - param construction: each subcommand passes the right keys to api_call
+  - output format: json and compact both produce valid JSON
+  - page / page-size: not overwritten by prefix matching (regression for #48)
+
+Run from repo root:
+    python tests/test_apiclaw.py
+    python -m pytest tests/test_apiclaw.py -v
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Load module under test
+# ---------------------------------------------------------------------------
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "..", "apiclaw", "scripts", "apiclaw.py")
+
+spec = importlib.util.spec_from_file_location("apiclaw", SCRIPT_PATH)
+apiclaw = importlib.util.module_from_spec(spec)
+with patch.dict("os.environ", {"APICLAW_API_KEY": "test_key"}):
+    spec.loader.exec_module(apiclaw)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+MOCK_OK = {"success": True, "data": [], "_query": {"endpoint": "", "params": {}}}
+
+
+def run_cli(*argv):
+    """Run apiclaw.main() with mocked api_call; return (endpoint, params)."""
+    captured = {}
+
+    def fake_api_call(endpoint, params):
+        captured["endpoint"] = endpoint
+        captured["params"] = dict(params)
+        return {**MOCK_OK, "_query": {"endpoint": endpoint, "params": params}}
+
+    with patch.object(apiclaw, "api_call", side_effect=fake_api_call), \
+         patch.object(apiclaw, "output"), \
+         patch.object(sys, "argv", ["apiclaw.py", *argv]):
+        apiclaw.main()
+
+    return captured
+
+
+def run_cli_stdout(fmt, subcmd, *args):
+    """Run apiclaw.main() with real output(); return stdout as string.
+
+    --format must precede the subcommand (it's a root-level arg).
+    """
+    import io
+
+    def fake_api_call(endpoint, params):
+        return {**MOCK_OK, "_query": {"endpoint": endpoint, "params": params}}
+
+    buf = io.StringIO()
+    argv = ["apiclaw.py", "--format", fmt, subcmd, *args]
+    with patch.object(apiclaw, "api_call", side_effect=fake_api_call), \
+         patch.object(sys, "argv", argv), \
+         patch("sys.stdout", buf):
+        apiclaw.main()
+
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# 1. parse_category
+# ---------------------------------------------------------------------------
+class TestParseCategory(unittest.TestCase):
+
+    def test_comma_separated(self):
+        self.assertEqual(apiclaw.parse_category("Pet Supplies,Dogs,Toys"),
+                         ["Pet Supplies", "Dogs", "Toys"])
+
+    def test_spaced_arrow(self):
+        self.assertEqual(apiclaw.parse_category("Pet Supplies > Dogs > Toys"),
+                         ["Pet Supplies", "Dogs", "Toys"])
+
+    def test_bare_arrow(self):
+        self.assertEqual(apiclaw.parse_category("Pet Supplies>Dogs>Toys"),
+                         ["Pet Supplies", "Dogs", "Toys"])
+
+    def test_bare_arrow_with_spaces_in_name(self):
+        self.assertEqual(apiclaw.parse_category("Home & Kitchen>Storage & Organization"),
+                         ["Home & Kitchen", "Storage & Organization"])
+
+    def test_single_segment(self):
+        self.assertEqual(apiclaw.parse_category("Electronics"), ["Electronics"])
+
+    def test_empty_string(self):
+        self.assertEqual(apiclaw.parse_category(""), [])
+
+    def test_spaced_arrow_takes_priority_over_bare(self):
+        # " > " is checked before ">", so "A > B>C" splits on " > " first
+        result = apiclaw.parse_category("A > B>C")
+        self.assertEqual(result, ["A", "B>C"])
+
+    def test_strips_whitespace(self):
+        self.assertEqual(apiclaw.parse_category("  Pet Supplies , Dogs "),
+                         ["Pet Supplies", "Dogs"])
+
+
+# ---------------------------------------------------------------------------
+# 2. PRODUCT_MODES completeness
+# ---------------------------------------------------------------------------
+class TestProductModes(unittest.TestCase):
+
+    def test_all_14_modes_defined(self):
+        self.assertEqual(len(apiclaw.PRODUCT_MODES), 14)
+
+    def test_all_modes_accepted_by_cli(self):
+        """Every mode name must be accepted by 'products --mode <name>' without sys.exit."""
+        for mode in apiclaw.PRODUCT_MODES:
+            with self.subTest(mode=mode):
+                # Should not raise or call sys.exit
+                result = run_cli("products", "--keyword", "test", "--mode", mode)
+                self.assertIn("endpoint", result)
+
+    def test_unknown_mode_exits(self):
+        with patch.object(apiclaw, "api_call", return_value=MOCK_OK), \
+             patch.object(apiclaw, "output"), \
+             patch.object(sys, "argv", ["apiclaw.py", "products", "--keyword", "test",
+                                        "--mode", "nonexistent-mode"]), \
+             self.assertRaises(SystemExit) as cm:
+            apiclaw.main()
+        self.assertNotEqual(cm.exception.code, 0)
+
+
+# ---------------------------------------------------------------------------
+# 3. --help for every subcommand (argparse definition sanity)
+# ---------------------------------------------------------------------------
+SUBCOMMANDS = [
+    "categories", "market", "products", "competitors", "product",
+    "report", "opportunity", "market-entry", "competitor-analysis",
+    "pricing-analysis", "daily-radar", "listing-audit", "opportunity-scan",
+    "review-deepdive", "analyze", "price-band-overview", "price-band-detail",
+    "brand-overview", "brand-detail", "product-history", "check",
+]
+
+
+class TestSubcommandHelp(unittest.TestCase):
+
+    def _assert_help_exits_0(self, subcmd):
+        with patch.object(sys, "argv", ["apiclaw.py", subcmd, "--help"]), \
+             self.assertRaises(SystemExit) as cm:
+            apiclaw.main()
+        self.assertEqual(cm.exception.code, 0, f"'{subcmd} --help' should exit 0")
+
+    def test_root_help(self):
+        with patch.object(sys, "argv", ["apiclaw.py", "--help"]), \
+             self.assertRaises(SystemExit) as cm:
+            apiclaw.main()
+        self.assertEqual(cm.exception.code, 0)
+
+    def test_all_subcommand_help(self):
+        for subcmd in SUBCOMMANDS:
+            with self.subTest(subcmd=subcmd):
+                self._assert_help_exits_0(subcmd)
+
+
+# ---------------------------------------------------------------------------
+# 4. allow_abbrev=False regression
+# ---------------------------------------------------------------------------
+class TestAllowAbbrevDisabled(unittest.TestCase):
+
+    def _assert_parse_error(self, *argv):
+        with patch.object(apiclaw, "api_call", return_value=MOCK_OK), \
+             patch.object(apiclaw, "output"), \
+             patch.object(sys, "argv", ["apiclaw.py", *argv]), \
+             self.assertRaises(SystemExit) as cm:
+            apiclaw.main()
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_abbreviated_page_errors_on_market(self):
+        self._assert_parse_error("market", "--category", "Sports", "--pag", "1")
+
+    def test_abbreviated_page_size_errors_on_market(self):
+        self._assert_parse_error("market", "--category", "Sports", "--page-s", "20")
+
+    def test_abbreviated_keyword_errors(self):
+        self._assert_parse_error("market", "--key", "yoga")
+
+    def test_abbreviated_category_errors(self):
+        self._assert_parse_error("market", "--cat", "Sports")
+
+
+# ---------------------------------------------------------------------------
+# 5. page / page-size param construction (regression for issue #48)
+# ---------------------------------------------------------------------------
+class TestPageParamConstruction(unittest.TestCase):
+
+    def _check(self, subcmd, extra_args, expected_page, expected_page_size):
+        result = run_cli(subcmd, *extra_args,
+                         "--page-size", str(expected_page_size),
+                         "--page", str(expected_page))
+        self.assertEqual(result["params"].get("pageSize"), expected_page_size,
+                         f"{subcmd}: pageSize should be {expected_page_size}")
+        self.assertEqual(result["params"].get("page"), expected_page,
+                         f"{subcmd}: page should be {expected_page}")
+
+    def test_market(self):
+        self._check("market", ["--keyword", "yoga"], 3, 50)
+
+    def test_products(self):
+        self._check("products", ["--keyword", "yoga"], 2, 30)
+
+    def test_price_band_overview(self):
+        self._check("price-band-overview", ["--keyword", "yoga"], 2, 40)
+
+    def test_price_band_detail(self):
+        self._check("price-band-detail", ["--keyword", "yoga"], 4, 10)
+
+    def test_brand_overview(self):
+        self._check("brand-overview", ["--keyword", "yoga"], 2, 15)
+
+    def test_brand_detail(self):
+        self._check("brand-detail", ["--keyword", "yoga"], 3, 25)
+
+    def test_competitors(self):
+        self._check("competitors", ["--keyword", "earbuds"], 2, 30)
+
+    def test_market_page_default_is_1(self):
+        result = run_cli("market", "--keyword", "yoga")
+        self.assertEqual(result["params"].get("page"), 1)
+        self.assertEqual(result["params"].get("pageSize"), 20)
+
+
+# ---------------------------------------------------------------------------
+# 6. API endpoint routing (each subcommand hits the right endpoint)
+# ---------------------------------------------------------------------------
+class TestEndpointRouting(unittest.TestCase):
+
+    def test_categories(self):
+        r = run_cli("categories", "--keyword", "yoga")
+        self.assertEqual(r["endpoint"], "categories")
+
+    def test_market(self):
+        r = run_cli("market", "--keyword", "yoga")
+        self.assertEqual(r["endpoint"], "markets/search")
+
+    def test_products(self):
+        r = run_cli("products", "--keyword", "yoga")
+        self.assertEqual(r["endpoint"], "products/search")
+
+    def test_competitors(self):
+        r = run_cli("competitors", "--keyword", "yoga")
+        self.assertEqual(r["endpoint"], "products/competitor-lookup")
+
+    def test_product(self):
+        r = run_cli("product", "--asin", "B09V3KXJPB")
+        self.assertEqual(r["endpoint"], "realtime/product")
+
+    def test_price_band_overview(self):
+        r = run_cli("price-band-overview", "--keyword", "yoga")
+        self.assertEqual(r["endpoint"], "products/price-band-overview")
+
+    def test_price_band_detail(self):
+        r = run_cli("price-band-detail", "--keyword", "yoga")
+        self.assertEqual(r["endpoint"], "products/price-band-detail")
+
+    def test_brand_overview(self):
+        r = run_cli("brand-overview", "--keyword", "yoga")
+        self.assertEqual(r["endpoint"], "products/brand-overview")
+
+    def test_brand_detail(self):
+        r = run_cli("brand-detail", "--keyword", "yoga")
+        self.assertEqual(r["endpoint"], "products/brand-detail")
+
+
+# ---------------------------------------------------------------------------
+# 7. Output format produces valid JSON
+# ---------------------------------------------------------------------------
+class TestOutputFormat(unittest.TestCase):
+
+    def test_json_format_is_valid(self):
+        out = run_cli_stdout("json", "market", "--keyword", "yoga")
+        parsed = json.loads(out)
+        self.assertIsInstance(parsed, dict)
+
+    def test_compact_format_is_valid_json(self):
+        out = run_cli_stdout("compact", "market", "--keyword", "yoga")
+        parsed = json.loads(out)
+        self.assertIsInstance(parsed, dict)
+
+    def test_compact_is_single_line(self):
+        out = run_cli_stdout("compact", "market", "--keyword", "yoga")
+        self.assertEqual(out.count("\n"), 1)  # only the trailing newline
+
+    def test_json_is_indented(self):
+        out = run_cli_stdout("json", "market", "--keyword", "yoga")
+        self.assertGreater(out.count("\n"), 1)
+
+
+# ---------------------------------------------------------------------------
+# 8. category param passed correctly to API
+# ---------------------------------------------------------------------------
+class TestCategoryParamPassing(unittest.TestCase):
+
+    def test_comma_format_parsed_to_list(self):
+        r = run_cli("market", "--category", "Pet Supplies,Dogs")
+        self.assertEqual(r["params"]["categoryPath"], ["Pet Supplies", "Dogs"])
+
+    def test_arrow_format_parsed_to_list(self):
+        r = run_cli("market", "--category", "Pet Supplies > Dogs > Toys")
+        self.assertEqual(r["params"]["categoryPath"], ["Pet Supplies", "Dogs", "Toys"])
+
+    def test_keyword_goes_to_correct_key(self):
+        r = run_cli("market", "--keyword", "yoga")
+        self.assertIn("categoryKeyword", r["params"])
+        self.assertEqual(r["params"]["categoryKeyword"], "yoga")
+
+
+# ---------------------------------------------------------------------------
+# Standalone runner
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromModule(sys.modules[__name__])
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/tests/test_apiclaw_page_arg.py
+++ b/tests/test_apiclaw_page_arg.py
@@ -8,14 +8,15 @@ Verifies that:
 4. All 6 affected subcommands: market, products, price-band-overview,
    price-band-detail, brand-overview, brand-detail
 
-Run:
-    python -m pytest test_apiclaw_page_arg.py -v
+Run from repo root:
+    python -m pytest tests/test_apiclaw_page_arg.py -v
     # or without pytest:
-    python test_apiclaw_page_arg.py
+    python tests/test_apiclaw_page_arg.py
 """
 
 import importlib
 import json
+import os
 import sys
 import types
 import unittest
@@ -25,7 +26,7 @@ from unittest.mock import patch
 # ---------------------------------------------------------------------------
 # Load the module under test without executing main()
 # ---------------------------------------------------------------------------
-SCRIPT_PATH = __file__.replace("test_apiclaw_page_arg.py", "apiclaw.py")
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), "..", "apiclaw", "scripts", "apiclaw.py")
 
 spec = importlib.util.spec_from_file_location("apiclaw", SCRIPT_PATH)
 apiclaw = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Summary
- Add `--page` argument to 6 subcommands missing it: `market`, `products`, `price-band-overview`, `price-band-detail`, `brand-overview`, `brand-detail`
- Pass `page` to API params in corresponding `cmd_*` functions
- Set `allow_abbrev=False` on root parser **and all subparsers** (root setting does not propagate to subparsers)
- Add CI workflow `test-apiclaw.yml` + unit test suite `tests/test_apiclaw.py`

## Root Cause

argparse `allow_abbrev=True` (default) silently matched `--page 1` to `--page-size`, overwriting user-specified `pageSize` with no error. The `page` param was also never forwarded to the API.

## Changes

**Bug fix:**
- `apiclaw/scripts/apiclaw.py` — canonical fix applied, then auto-synced to all 10 copies via pre-commit hook
- 11 files total updated (all `*/scripts/apiclaw.py`)

**Tests (`tests/test_apiclaw.py`, 41 tests):**
- `parse_category`: comma / `>` / ` > ` separators, edge cases, whitespace
- `PRODUCT_MODES`: all 14 modes accepted; unknown mode exits non-zero
- Subcommand `--help`: all 21 subcommands produce valid help (argparse sanity)
- `allow_abbrev=False`: abbreviated args error out, not silently matched
- `page` / `page-size` param construction: all 7 affected subcommands
- Endpoint routing: each subcommand hits the correct API endpoint
- Output format: `json` (indented) and `compact` (single-line) both valid JSON
- Category param passing: formats correctly parsed and passed to API

**CI (`.github/workflows/test-apiclaw.yml`):**
- Triggers on `apiclaw.py` or test file changes (PR + push to main)
- Runs both test files; stdlib only, no pip install needed

## Test plan
- [x] `tests/test_apiclaw.py` — 41 tests, all passing
- [x] `tests/test_apiclaw_page_arg.py` — 18 tests, all passing
- [x] `python apiclaw.py market --page-size 20 --page 1` → API receives `pageSize=20, page=1`
- [x] Unknown abbreviated args (e.g. `--pag`, `--page-s`) now raise an error

Fixes #48

🤖 Generated with [Claude Code](https://claude.ai/code)