### PR TITLE
fix: v1.2.1 — API v2 bug fixes, rate limiting, category auto-detection, skill enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,23 +39,23 @@ This repo contains **10 agent skills** organized in two tiers:
 
 **🏗️ Foundation** — data access and full-spectrum analysis:
 
-| Skill | Description | Best For |
-|-------|------------|----------|
-| 📦 [`apiclaw/`](apiclaw/) | Data layer overview, 11 API endpoints, quick integration | Getting started, agent tool-calling |
-| 🎯 [`amazon-analysis/`](amazon-analysis/) | 13 selection strategies, market validation, competitor intelligence | Deep product research, autonomous sourcing |
+| Skill | What It Does | Input | Output | Key Advantage |
+|-------|-------------|-------|--------|---------------|
+| 📦 [`apiclaw/`](apiclaw/) | Direct access to all 11 API endpoints — categories, markets, products, competitors, realtime, reviews, price bands, brands, history | Keyword, category, ASIN, or brand | Raw API data with field mapping and quirk documentation | Complete API reference — every other skill builds on this |
+| 🎯 [`amazon-analysis/`](amazon-analysis/) | 13 built-in selection modes + market research, competitor analysis, ASIN evaluation, pricing, category research | Keyword/category/ASIN + intent | Analysis findings, top products, ASIN deep dives, confidence-tagged insights | Composite commands (`report`, `opportunity`) run multi-endpoint pipelines in one shot |
 
 **⚡ Specialized** — purpose-built for specific workflows:
 
-| Skill | Description | Best For |
-|-------|------------|----------|
-| ⚔️ [`amazon-competitor-intelligence-monitor/`](amazon-competitor-intelligence-monitor/) | Competitor intelligence with continuous monitoring & tiered alerts | Tracking competitors, price wars |
-| 📡 [`amazon-daily-market-radar/`](amazon-daily-market-radar/) | Daily market pulse check and anomaly detection | Morning briefings, trend alerts |
-| ✅ [`amazon-listing-audit-pro/`](amazon-listing-audit-pro/) | Comprehensive listing quality audit and optimization | Listing health checks, conversion improvement |
-| 🚪 [`amazon-market-entry-analyzer/`](amazon-market-entry-analyzer/) | Market viability assessment for new category entry | Go/no-go decisions, market sizing |
-| 📈 [`amazon-market-trend-scanner/`](amazon-market-trend-scanner/) | Category landscape scanning and trend discovery | Category trends, emerging niches |
-| 💎 [`amazon-opportunity-discoverer/`](amazon-opportunity-discoverer/) | Underserved niche and opportunity identification | Finding blue ocean markets |
-| 💰 [`amazon-pricing-command-center/`](amazon-pricing-command-center/) | Dynamic pricing strategy and competitive signals | Price positioning, competitive pricing |
-| 💬 [`amazon-review-intelligence-extractor/`](amazon-review-intelligence-extractor/) | Deep review sentiment analysis and insight extraction | Customer voice analysis, product improvement |
+| Skill | What It Does | Input | Output | Key Advantage |
+|-------|-------------|-------|--------|---------------|
+| ⚔️ [`amazon-competitor-intelligence-monitor/`](amazon-competitor-intelligence-monitor/) | Deep competitor intelligence — Full Scan or Quick Check with tiered alerts | Keyword or ASIN(s), optionally your ASIN + competitor ASINs | Competitor matrix, brand ranking, price map, 30-day trends, scores (1-100), tiered alerts | Dual-mode (Full ~28-35 credits, Quick ~5-10) with three-tier alert system |
+| 📡 [`amazon-daily-market-radar/`](amazon-daily-market-radar/) | Automated daily monitoring — price changes, new competitors, BSR movements, review spikes | Your ASINs (1-10) + keyword | RED/YELLOW/GREEN alerts, KPI dashboard, competitor movement, action items | Set-and-forget with signal validation (7+ day trends vs single-day spikes) |
+| ✅ [`amazon-listing-audit-pro/`](amazon-listing-audit-pro/) | 8-dimension listing health check with optimization recommendations | Your ASIN + keyword | Score (X/100, A-F), 8-dimension scorecard, keyword gaps, priority fix list | Actionable rewrites using high-frequency review language; bulk audit support |
+| 🚪 [`amazon-market-entry-analyzer/`](amazon-market-entry-analyzer/) | One-click market viability — discovers sub-markets, scores (1-100), delivers GO/CAUTION/AVOID | Keyword or category path | Sub-market landscape, verdict, market overview, brand landscape, entry strategy | Auto sub-market discovery with dual-level CR10 check |
+| 📈 [`amazon-market-trend-scanner/`](amazon-market-trend-scanner/) | Category landscape scanning — trending subcategories, emerging niches, market shifts | 1+ category paths or keywords | Trend dashboard, Hot Categories TOP 5, new entrant scan, risk alerts | Category-level trend analysis across ALL subcategories |
+| 💎 [`amazon-opportunity-discoverer/`](amazon-opportunity-discoverer/) | Profile-driven opportunity scanner — auto-selects strategies, validates with real-time data, 7-dimension scoring | Budget + experience level + keyword/category | Top 10 opportunities (S/A/B/C), detailed top 3 analysis, risk alerts | Profile-driven strategy auto-selection + Quick-Scan (~10 credits) |
+| 💰 [`amazon-pricing-command-center/`](amazon-pricing-command-center/) | Data-driven pricing signals — auto-detects leaf category, analyzes pricing landscape | One or more ASINs | RAISE/HOLD/LOWER signal, price band heatmap, competitor price map, BuyBox analysis | ASIN-only input (no keyword needed), Sales/Competition Ratio |
+| 💬 [`amazon-review-intelligence-extractor/`](amazon-review-intelligence-extractor/) | Deep consumer insights from 1B+ pre-analyzed reviews across 11 dimensions | Single ASIN, multiple ASINs, or category keyword | Pain points, buying factors, user profiles, usage patterns, differentiation roadmap | 1B+ pre-analyzed reviews (95% token savings), 11 dimensions |
 
 ## Quick Start
 
@@ -68,18 +68,18 @@ npx skills add SerendipityOneInc/APIClaw-Skills
 You'll be prompted to select which skills to install:
 
 **🏗️ Foundation:**
-- **APIClaw** — Data layer overview, 11 API endpoints, quick integration
-- **Amazon Analysis** — 13 selection strategies, market validation, competitor intelligence
+- **APIClaw — Amazon Commerce Data, 11 Endpoints**
+- **Amazon Analysis — Full-Spectrum Research & Seller Intelligence**
 
 **⚡ Specialized:**
-- **Amazon Competitor War Room** — Competitive monitoring & response
-- **Amazon Daily Market Radar** — Daily market pulse & anomaly detection
-- **Amazon Listing Audit Pro** — Listing quality audit & optimization
-- **Amazon Market Entry Analyzer** — Market viability assessment
-- **Amazon Opportunity Discoverer** — Niche & opportunity identification
-- **Amazon Market Trend Scanner** — Category landscape scanning & trend discovery
-- **Amazon Pricing Command Center** — Pricing strategy & competitive signals
-- **Amazon Review Intelligence Engine** — Review sentiment & insight extraction
+- **Amazon Competitor Intelligence Monitor** — Dual-mode competitive intelligence with tiered alerts
+- **Amazon Daily Market Radar — Automated Monitoring & Alerts**
+- **Amazon Listing Audit Pro — 8-Dimension Health Check**
+- **Amazon Market Entry Analyzer — GO/CAUTION/AVOID Verdicts**
+- **Amazon Market Trend Scanner — Daily Category Radar**
+- **Amazon Opportunity Discoverer — Niche Scanner & Scoring**
+- **Amazon Pricing Command Center — RAISE/HOLD/LOWER Signals**
+- **Amazon Review Intelligence Extractor — Consumer Insights from 1B+ Reviews**
 
 Or clone manually:
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,23 +41,23 @@
 
 **🏗️ 基础层** — 数据接入与全方位分析：
 
-| 技能 | 说明 | 适用场景 |
-|------|------|----------|
-| 📦 [`apiclaw/`](apiclaw/) | 数据层概览，11 个 API 接口，快速集成 | 快速上手，Agent tool-calling |
-| 🎯 [`amazon-analysis/`](amazon-analysis/) | 13 种选品策略，市场验证，竞品情报 | 深度选品调研，自主选品 Agent |
+| 技能 | 说明 | 输入 | 输出 | 核心优势 |
+|------|------|------|------|----------|
+| 📦 [`apiclaw/`](apiclaw/) | 直接调用全部 11 个 API 端点 | 关键词/品类/ASIN/品牌 | 原始 API 数据 + 字段映射文档 | 所有其他 skill 的底层依赖 |
+| 🎯 [`amazon-analysis/`](amazon-analysis/) | 13 种选品模式 + 市场/竞品/ASIN/定价/品类研究 | 关键词/品类/ASIN + 意图 | 分析发现、Top 产品、深度报告、置信度标签 | report/opportunity 复合命令一键跑完 |
 
 **⚡ 专项层** — 面向特定工作流的专用技能：
 
-| 技能 | 说明 | 适用场景 |
-|------|------|----------|
-| ⚔️ [`amazon-competitor-intelligence-monitor/`](amazon-competitor-intelligence-monitor/) | 竞品情报监控与三级告警 | 竞品追踪，价格战 |
-| 📡 [`amazon-daily-market-radar/`](amazon-daily-market-radar/) | 每日市场脉搏与异常检测 | 晨报简报，趋势预警 |
-| ✅ [`amazon-listing-audit-pro/`](amazon-listing-audit-pro/) | Listing 质量全面审计与优化 | Listing 健康检查，转化率提升 |
-| 🚪 [`amazon-market-entry-analyzer/`](amazon-market-entry-analyzer/) | 新品类市场可行性评估 | Go/No-go 决策，市场规模评估 |
-| 📈 [`amazon-market-trend-scanner/`](amazon-market-trend-scanner/) | 品类全景扫描与趋势发现 | 品类趋势，新兴市场 |
-| 💎 [`amazon-opportunity-discoverer/`](amazon-opportunity-discoverer/) | 细分蓝海市场与机会发现 | 蓝海市场挖掘 |
-| 💰 [`amazon-pricing-command-center/`](amazon-pricing-command-center/) | 动态定价策略与竞争信号 | 价格定位，竞争定价 |
-| 💬 [`amazon-review-intelligence-extractor/`](amazon-review-intelligence-extractor/) | 深度评论智能分析与洞察提取 | 消费者声音分析，产品改进 |
+| 技能 | 说明 | 输入 | 输出 | 核心优势 |
+|------|------|------|------|----------|
+| ⚔️ [`amazon-competitor-intelligence-monitor/`](amazon-competitor-intelligence-monitor/) | 深度竞品情报 — Full Scan + Quick Check 双模式 | 关键词或 ASIN，可选竞品 ASIN | 竞品矩阵、品牌排名、价格地图、竞争力评分(1-100)、三级告警 | 双模式 + 自动监控调度 |
+| 📡 [`amazon-daily-market-radar/`](amazon-daily-market-radar/) | 自动化日常监控 — 价格变化、新竞品、BSR 波动、评论飙升 | 你的 ASIN(1-10) + 关键词 | 分级告警(RED/YELLOW/GREEN)、KPI 仪表盘、行动建议 | 区分持续趋势 vs 单日波动 |
+| ✅ [`amazon-listing-audit-pro/`](amazon-listing-audit-pro/) | 8 维度 Listing 健康检查 + 优化建议 | 你的 ASIN + 关键词 | 总分(X/100, A-F)、8 维度评分卡、关键词差距、修改清单 | 基于高频评论语言的改写建议 |
+| 🚪 [`amazon-market-entry-analyzer/`](amazon-market-entry-analyzer/) | 一键市场可行性评估 → GO/CAUTION/AVOID 判定 | 关键词或品类路径 | 子市场全景、判定结果、品牌格局、进入策略 | 自动发现子市场 + 双层 CR10 检查 |
+| 📈 [`amazon-market-trend-scanner/`](amazon-market-trend-scanner/) | 品类全景扫描 — 趋势子品类、新兴 niche | 1+ 品类路径或关键词 | 趋势仪表盘、热门品类 TOP 5、新进入者扫描 | 覆盖所有子品类的品类级趋势分析 |
+| 💎 [`amazon-opportunity-discoverer/`](amazon-opportunity-discoverer/) | 基于卖家画像的自动化选品 — 13 种模式 + 7 维度评分(1-100) | 预算 + 经验等级 + 关键词/品类 | Top 10 机会(S/A/B/C)、Top 3 详细分析、风险告警 | 画像驱动策略选择 + Quick-Scan |
+| 💰 [`amazon-pricing-command-center/`](amazon-pricing-command-center/) | 数据驱动定价信号 — RAISE/HOLD/LOWER | 一个或多个 ASIN | 价格信号、价格带热力图、竞品价格地图、BuyBox 分析 | 只需 ASIN 不需关键词 |
+| 💬 [`amazon-review-intelligence-extractor/`](amazon-review-intelligence-extractor/) | 从 10 亿+评论中提取消费者洞察，11 个分析维度 | 单个/多个 ASIN 或品类关键词 | 痛点、购买因素、用户画像、差异化路线图 | 省 95% token + 11 维度 |
 
 ## 快速开始
 
@@ -70,18 +70,18 @@ npx skills add SerendipityOneInc/APIClaw-Skills
 安装时会提示选择技能：
 
 **🏗️ 基础层：**
-- **APIClaw** — 数据层概览，11 个 API 接口，快速集成
-- **Amazon Analysis** — 13 种选品策略，市场验证，竞品情报
+- **APIClaw — Amazon Commerce Data, 11 Endpoints**
+- **Amazon Analysis — Full-Spectrum Research & Seller Intelligence**
 
 **⚡ 专项层：**
-- **Amazon Competitor War Room** — 竞品监控与应对
-- **Amazon Daily Market Radar** — 每日市场脉搏与异常检测
-- **Amazon Listing Audit Pro** — Listing 质量审计与优化
-- **Amazon Market Entry Analyzer** — 市场可行性评估
-- **Amazon Opportunity Discoverer** — 蓝海市场与机会发现
-- **Amazon Market Trend Scanner** — 品类全景扫描与趋势发现
-- **Amazon Pricing Command Center** — 定价策略与竞争信号
-- **Amazon Review Intelligence Engine** — 评论智能分析与洞察提取
+- **Amazon Competitor Intelligence Monitor** — 双模式竞品情报与三级告警
+- **Amazon Daily Market Radar — Automated Monitoring & Alerts**
+- **Amazon Listing Audit Pro — 8-Dimension Health Check**
+- **Amazon Market Entry Analyzer — GO/CAUTION/AVOID Verdicts**
+- **Amazon Market Trend Scanner — Daily Category Radar**
+- **Amazon Opportunity Discoverer — Niche Scanner & Scoring**
+- **Amazon Pricing Command Center — RAISE/HOLD/LOWER Signals**
+- **Amazon Review Intelligence Extractor — Consumer Insights from 1B+ Reviews**
 
 也可以手动克隆：
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,13 +75,13 @@ npx skills add SerendipityOneInc/APIClaw-Skills
 
 **⚡ 专项层：**
 - **Amazon Competitor Intelligence Monitor** — 双模式竞品情报与三级告警
-- **Amazon Daily Market Radar — Automated Monitoring & Alerts**
-- **Amazon Listing Audit Pro — 8-Dimension Health Check**
-- **Amazon Market Entry Analyzer — GO/CAUTION/AVOID Verdicts**
-- **Amazon Market Trend Scanner — Daily Category Radar**
-- **Amazon Opportunity Discoverer — Niche Scanner & Scoring**
-- **Amazon Pricing Command Center — RAISE/HOLD/LOWER Signals**
-- **Amazon Review Intelligence Extractor — Consumer Insights from 1B+ Reviews**
+- **Amazon Daily Market Radar** — 每日市场脉搏与异常检测
+- **Amazon Listing Audit Pro** — 8 维度 Listing 健康检查与优化
+- **Amazon Market Entry Analyzer** — 一键市场可行性评估，GO/CAUTION/AVOID 判定
+- **Amazon Market Trend Scanner** — 品类全景扫描与趋势发现
+- **Amazon Opportunity Discoverer** — 基于卖家画像的选品扫描与 7 维度评分
+- **Amazon Pricing Command Center** — 数据驱动定价信号，RAISE/HOLD/LOWER
+- **Amazon Review Intelligence Extractor** — 10 亿+评论消费者洞察，11 个分析维度
 
 也可以手动克隆：
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,8 +70,8 @@ npx skills add SerendipityOneInc/APIClaw-Skills
 安装时会提示选择技能：
 
 **🏗️ 基础层：**
-- **APIClaw — Amazon Commerce Data, 11 Endpoints**
-- **Amazon Analysis — Full-Spectrum Research & Seller Intelligence**
+- **APIClaw** — 数据层概览，11 个 API 接口，快速集成
+- **Amazon Analysis** — 13 种选品模式，市场验证，竞品情报
 
 **⚡ 专项层：**
 - **Amazon Competitor Intelligence Monitor** — 双模式竞品情报与三级告警

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -3,7 +3,7 @@ name: Amazon Analysis — Full-Spectrum Research & Seller Intelligence
 version: 1.1.4
 description: >
   Amazon seller data analysis tool. Features: market research, product selection, competitor analysis, ASIN evaluation, pricing reference, category research.
-  Uses scripts/apiclaw.py to call APIClaw API, requires APICLAW_API_KEY.
+  Uses {skill_base_dir}/scripts/apiclaw.py to call APIClaw API, requires APICLAW_API_KEY.
 ---
 
 # APIClaw — Amazon Seller Data Analysis
@@ -14,13 +14,13 @@ description: >
 
 | File | Purpose |
 |------|---------|
-| `scripts/apiclaw.py` | **Execute** for all API calls (run `--help` for params) |
-| `references/reference.md` | Load when you need exact field names or filter details |
+| `{skill_base_dir}/scripts/apiclaw.py` | **Execute** for all API calls (run `--help` for params) |
+| `{skill_base_dir}/references/reference.md` | Load when you need exact field names or filter details |
 
 
 ## Credential
 
-Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apiclaw.io/en/api-keys). Stored in `config.json` in skill root.
+Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apiclaw.io/en/api-keys). Stored in `{skill_base_dir}/config.json` in skill root.
 
 ## Input
 

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -31,10 +31,10 @@ User provides: keyword, category, ASIN, or brand — depending on intent. Use in
 1. **Category first**: keyword search is broad → MUST lock `categoryPath` via `categories` endpoint before other calls
 2. **Brand + category**: Brand queries MUST include `--category` to avoid cross-category contamination
 3. **Use API fields directly**: revenue=`sampleAvgMonthlyRevenue` (NEVER calculate price×sales), sales=`monthlySalesFloor` (lower bound), opportunity=`sampleOpportunityIndex`
-4. **reviews/analysis**: needs 50+ reviews per ASIN; try category mode first (3 calls for painPoints/buyingFactors/improvements), ASIN mode only if all 3 category calls fail
+4. **reviews/analysis**: needs 50+ reviews per ASIN; try category mode first (single call returns all dimensions), ASIN mode only if category call fails. Filter by `labelType` client-side from the `consumerInsights` array.
 5. **Aggregation without categoryPath**: produces severely distorted data
 6. **`.data` is array**: use `.data[0]`, not `.data.field`
-7. **labelType**: only accepts ONE value per call — do NOT comma-separate
+7. **labelType**: NOT an API request parameter — it is a field in the response `consumerInsights` array, used for client-side filtering
 8. **history empty**: try oldest-listed ASINs first, up to 3 rounds of different ASINs before giving up
 9. **Sales null fallback**: Monthly sales ≈ 300,000 / BSR^0.65
 
@@ -64,11 +64,75 @@ Modes can combine with explicit filters (`--price-max`, `--sales-min`, etc). Ove
 - `report --keyword X` → categories + market + products(top50) + realtime(top1)
 - `opportunity --keyword X [--mode Y]` → categories + market + products(filtered) + realtime(top3)
 
+## Analysis Framework
+
+Every analysis should address these dimensions where data is available:
+
+### Market Health Assessment
+| Indicator | Good | Caution | Warning |
+|-----------|------|---------|---------|
+| Monthly demand (sampleAvgMonthlySales) | >1,500 units 📊 | 500-1,500 📊 | <500 📊 |
+| Brand concentration (CR10) | <40% 📊 | 40-60% 📊 | >60% 📊 |
+| New entrant rate (sampleNewSkuRate) | >15% 📊 | 5-15% 📊 | <5% 📊 |
+| Avg review count (sampleAvgRatingCount) | <500 📊 | 500-5,000 📊 | >5,000 📊 |
+| FBA rate (sampleFbaRate) | >60% 📊 | 40-60% 📊 | <40% 📊 |
+
+### Competitive Position Assessment
+- **Price vs category avg**: >20% above = premium positioning, >20% below = value play 🔍
+- **Rating vs category avg**: ≥0.3 above = quality advantage, ≥0.3 below = quality risk 🔍
+- **Review count vs Top 10 avg**: <10% of leaders = high barrier, >50% = competitive 🔍
+- **BSR trend (30d)**: Improving = momentum, stable = holding, declining = losing share 🔍
+
+### Opportunity Viability
+When user asks "should I sell X" or "is this a good niche":
+- ALL of: demand >500, CR10 <60%, avgReviewCount <5,000 → Likely viable 🔍
+- ANY of: demand <200, CR10 >80%, avgReviewCount >10,000 → Likely not viable 🔍
+- Mixed signals → Present data, let user decide with their domain knowledge 💡
+
+### Sales Estimation Notes
+- `monthlySalesFloor` is a **lower-bound** estimate 📊
+- Null sales fallback: Monthly sales ≈ 300,000 / BSR^0.65 🔍
+- Revenue = `sampleAvgMonthlyRevenue` directly — NEVER calculate price × sales 📊
+
 ## Output Spec
 
 Sections: Analysis findings → Data Source & Conditions table (interfaces, category, dateRange, sampleType, topN, filters) → Data Notes (estimated values, T+1 delay, sampling basis).
 
-Confidence labels: 📊 Data-backed | 🔍 Inferred | 💡 Directional. User criteria override AI judgment.
+### Language (required)
+
+Output language MUST match the user's input language. If the user asks in Chinese, the entire report is in Chinese. If in English, output in English. Exception: API field names (e.g. `monthlySalesFloor`, `categoryPath`), endpoint names, technical terms (e.g. ASIN, BSR, CR10, FBA, credits) remain in English.
+
+### Disclaimer (required, at the top of every report)
+
+> Data is based on APIClaw API sampling as of [date]. Monthly sales (`monthlySalesFloor`) are lower-bound estimates. This analysis is for reference only and should not be the sole basis for business decisions. Validate with additional sources before acting.
+
+### Confidence Labels (required, tag EVERY conclusion)
+
+- 📊 **Data-backed** — direct API data (e.g. "CR10 = 54.8% 📊")
+- 🔍 **Inferred** — logical reasoning from data (e.g. "brand concentration is moderate 🔍")
+- 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
+
+Rules: Strategy recommendations are NEVER 📊. Anomalies (>200% growth) are always 💡. User criteria override AI judgment.
+
+### Data Provenance (required)
+
+Include a table at the end of every report:
+
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+| (e.g. Market Overview) | `markets/search` | categoryPath, topN=10 | 📊 Top N sampling, sales are lower-bound |
+| ... | ... | ... | ... |
+
+Extract endpoint and params from `_query` in JSON output. Add notes: sampling method, T+1 delay, realtime vs DB, minimum review threshold, etc.
+
+### API Usage (required)
+
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+| (each endpoint used) | N | N |
+| **Total** | **N** | **N** |
+
+Extract from `meta.creditsConsumed` per response. End with `Credits remaining: N`.
 
 ## Limitations
 

--- a/amazon-analysis/references/reference.md
+++ b/amazon-analysis/references/reference.md
@@ -142,10 +142,11 @@ Request params: `keyword`, `brand`, `asin`, `categoryPath`, `sortBy`, `pageSize`
 - `mode`: `"asin"` or `"category"`
 - `asins`: List<String> (when mode=asin)
 - `categoryPath`: String (when mode=category)
-- `labelType`: filter to specific dimensions. **⚠️ Only ONE value per call — do NOT comma-separate multiple types.** Make separate calls for each labelType needed.
 - `period`: e.g. `"1m"` / `"3m"` / `"6m"` / `"1y"` / `"2y"`
 
-**labelType values (one per call):** `scenarios`, `issues`, `positives`, `improvements`, `buyingFactors`, `painPoints`, `keywords`, `userProfiles`, `usageTimes`, `usageLocations`, `behaviors`
+⚠️ `labelType` is **not** an API request parameter. The API returns all 11 dimensions in a single call. Filter by `labelType` client-side from the `consumerInsights` array.
+
+**labelType values (in response):** `scenarios`, `issues`, `positives`, `improvements`, `buyingFactors`, `painPoints`, `keywords`, `userProfiles`, `usageTimes`, `usageLocations`, `behaviors`
 
 **Response:**
 | Field | Type | Used For |

--- a/amazon-analysis/scripts/apiclaw.py
+++ b/amazon-analysis/scripts/apiclaw.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import sys
+import random
 import time
 import urllib.request
 import urllib.error
@@ -35,9 +36,15 @@ import urllib.error
 
 BASE_URL = "https://api.apiclaw.io/openapi/v2"  # APIClaw API base URL
 API_DOCS = "https://api.apiclaw.io/api-docs"   # API documentation URL
-MAX_RETRIES = 2       # Maximum number of retry attempts for failed requests
-RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on 429 (rate limit)
+MAX_RETRIES = 3       # Maximum number of retry attempts for failed requests
+RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
+RATE_LIMIT_RETRIES = 4  # Extra retries specifically for 429 rate limits
+RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
+MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
+
+# Global request pacer — prevents burst rate limit violations
+_last_request_time = 0.0
 
 # 13 built-in product selection modes
 # Each maps to a set of products/search filter parameters
@@ -110,6 +117,8 @@ def api_call(endpoint: str, params: dict) -> dict:
     Returns the parsed JSON response on success, with _query metadata injected.
     Exits with a clear error message on failure.
     """
+    global _last_request_time
+
     url = f"{BASE_URL}/{endpoint}"
     api_key = get_api_key()
 
@@ -131,8 +140,16 @@ def api_call(endpoint: str, params: dict) -> dict:
         "User-Agent": "APIClaw-CLI/1.0 (Python)",
     }
 
+    # Rate-limit pacing: enforce minimum interval between requests
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < MIN_REQUEST_INTERVAL:
+        time.sleep(MIN_REQUEST_INTERVAL - elapsed)
+
     delay = RETRY_DELAY
-    for attempt in range(1, MAX_RETRIES + 1):
+    max_attempts = MAX_RETRIES
+    for attempt in range(1, max_attempts + 1):
+        _last_request_time = time.monotonic()
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
@@ -163,9 +180,15 @@ def api_call(endpoint: str, params: dict) -> dict:
                     "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
                     endpoint, actual_params)
             elif status == 429:
-                if attempt < MAX_RETRIES:
-                    print(f"Rate limited (429). Waiting {delay}s before retry {attempt}/{MAX_RETRIES}...", file=sys.stderr)
-                    time.sleep(delay)
+                # Switch to longer retry strategy for rate limits
+                if attempt == 1:
+                    max_attempts = RATE_LIMIT_RETRIES
+                    delay = RATE_LIMIT_DELAY
+                if attempt < max_attempts:
+                    jitter = random.uniform(0, delay * 0.25)
+                    wait = delay + jitter
+                    print(f"Rate limited (429). Waiting {wait:.1f}s before retry {attempt}/{max_attempts}...", file=sys.stderr)
+                    time.sleep(wait)
                     delay *= 2
                     continue
                 else:
@@ -177,17 +200,17 @@ def api_call(endpoint: str, params: dict) -> dict:
                     f"Check {API_DOCS} for current endpoints",
                     endpoint, actual_params)
             else:
-                if attempt < MAX_RETRIES:
-                    print(f"HTTP {status}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                if attempt < max_attempts:
+                    print(f"HTTP {status}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                     time.sleep(delay)
                     continue
                 else:
-                    return _error_result(status, f"HTTP {status} after {MAX_RETRIES} attempts",
+                    return _error_result(status, f"HTTP {status} after {max_attempts} attempts",
                         "Check network or try again later",
                         endpoint, actual_params)
         except Exception as e:
-            if attempt < MAX_RETRIES:
-                print(f"Request failed: {e}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+            if attempt < max_attempts:
+                print(f"Request failed: {e}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                 time.sleep(delay)
                 continue
             else:
@@ -196,6 +219,94 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
 
     return _error_result(0, "Unexpected retry loop exit", "This should not happen", endpoint, actual_params)
+
+
+def _filter_review_insights(result, label_type):
+    """Return a shallow copy of a reviews/analysis result filtered to one labelType."""
+    if not result.get("data") or not result["data"].get("consumerInsights"):
+        return result
+    filtered = dict(result)
+    filtered["data"] = dict(result["data"])
+    filtered["data"]["consumerInsights"] = [
+        i for i in result["data"]["consumerInsights"]
+        if i.get("labelType") == label_type
+    ]
+    return filtered
+
+
+def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
+    """
+    Resolve categoryPath with multi-level fallback.
+    Returns (category_path, category_source) tuple.
+
+    Priority:
+      1. keyword → categories API
+      2. asin → realtime/product → categoryPath or bestsellersRank leaf
+      3. keyword → products/search → first result → realtime/product
+    """
+    category_path = None
+    category_source = "user"
+
+    # Priority 1: keyword → categories
+    if keyword:
+        log_fn("Step 0: Resolving category...")
+        cat_result = api_caller("categories", {"categoryKeyword": keyword}, "categories")
+        if results is not None:
+            results["categories"] = cat_result
+        cat_data = cat_result.get("data", [])
+        if cat_data:
+            category_path = cat_data[0].get("categoryPath")
+            category_source = "keyword"
+
+    # Priority 2: asin → realtime/product
+    if not category_path and asin:
+        log_fn("  → Resolving category from ASIN...")
+        rt = api_caller("realtime/product", {"asin": asin, "marketplace": "US"}, f"realtime {asin}")
+        if results is not None:
+            results.setdefault("_asin_realtime", rt)
+        rt_data = rt.get("data", {}) or {}
+        if rt_data.get("categoryPath"):
+            category_path = rt_data["categoryPath"]
+            category_source = "asin_realtime"
+            log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif rt_data.get("bestsellersRank"):
+            leaf = rt_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log_fn(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "asin_bsr"
+                    log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+
+    # Priority 3: keyword → search → first product → realtime
+    if not category_path and keyword:
+        log_fn("  → Resolving category from top search result...")
+        prod_result = api_caller("products/search", {
+            "keyword": keyword, "sortBy": "monthlySalesFloor", "sortOrder": "desc", "pageSize": 5
+        }, "products (category probe)")
+        prod_data = prod_result.get("data", [])
+        if isinstance(prod_data, list) and prod_data:
+            probe_asin = prod_data[0].get("asin")
+            if probe_asin:
+                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+                rt_data = rt.get("data", {}) or {}
+                if rt_data.get("categoryPath"):
+                    category_path = rt_data["categoryPath"]
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+                elif rt_data.get("bestsellersRank"):
+                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
+                    if leaf:
+                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                        cat_data = cat_result.get("data", [])
+                        if cat_data:
+                            category_path = cat_data[0].get("categoryPath")
+                            category_source = "inferred_from_search"
+                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+
+    return category_path, category_source
 
 
 def _error_result(status: int, message: str, action: str, endpoint: str, params: dict) -> dict:
@@ -344,9 +455,9 @@ def cmd_products(args):
     if args.fulfillment:
         params["fulfillments"] = args.fulfillment
     if args.include_brands:
-        params["includeBrands"] = args.include_brands
+        params["includeBrands"] = [b.strip() for b in args.include_brands.split(",")]
     if args.exclude_brands:
-        params["excludeBrands"] = args.exclude_brands
+        params["excludeBrands"] = [b.strip() for b in args.exclude_brands.split(",")]
 
     params["sortBy"] = args.sort or "monthlySalesFloor"
     params["sortOrder"] = args.order or "desc"
@@ -453,7 +564,7 @@ def cmd_report(args):
     print("Step 3/4: Searching top products...", file=sys.stderr)
     products_result = api_call("products/search", {
         "keyword": keyword,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 50,
     })
@@ -508,7 +619,7 @@ def cmd_opportunity(args):
         "keyword": keyword,
         "monthlySalesMin": 300,
         "ratingCountMax": 50,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 20,
     }
@@ -565,17 +676,9 @@ def cmd_market_entry(args):
         return r
 
     # ── Step 0.5: Category Resolution ──
-    if not category_path and keyword:
-        log("Step 0.5: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked category: {' > '.join(category_path)}")
-        else:
-            log("  ⚠️ No category match, will use keyword-only queries")
-
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # ── Step 1: Market Landscape (3 calls) ──
@@ -744,43 +847,36 @@ def cmd_market_entry(args):
     review_results = {}
     label_types = ["painPoints", "buyingFactors", "improvements"]
 
-    # Priority 1: Category mode
-    category_mode_success = True
+    # Priority 1: Category mode (single call, split client-side)
+    category_mode_success = False
     if category_path:
-        for lt in label_types:
-            log(f"  → reviews/analysis category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path,
-                "mode": "category",
-                "labelType": lt,
-                "period": "6m",
-            }, f"reviews {lt}")
-            if r.get("success") is False or not r.get("data", {}).get("consumerInsights"):
-                category_mode_success = False
-                log(f"  ⚠️ Category mode failed for {lt}")
-                break
-            review_results[lt] = r
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path,
+            "mode": "category",
+            "period": "6m",
+        }, "reviews category")
+        if r.get("success") and r.get("data", {}).get("consumerInsights"):
+            category_mode_success = True
+            for lt in label_types:
+                review_results[lt] = _filter_review_insights(r, lt)
 
     # Priority 2: ASIN mode (if category failed)
-    if not category_mode_success or not category_path:
+    if not category_mode_success:
         log("  → Falling back to ASIN mode...")
-        # Pick ASINs with ratingCount >= 50
         review_asins = [p.get("asin") for p in all_products if (p.get("ratingCount") or 0) >= 50][:3]
         if review_asins:
+            log(f"  → reviews/analysis ASIN mode ({review_asins})")
+            r = safe_call("reviews/analysis", {
+                "asins": review_asins,
+                "mode": "asin",
+                "period": "6m",
+            }, "reviews ASIN")
             for lt in label_types:
-                if lt in review_results:
-                    continue
-                log(f"  → reviews/analysis ASIN mode: {lt} ({review_asins})")
-                r = safe_call("reviews/analysis", {
-                    "asins": review_asins,
-                    "mode": "asin",
-                    "labelType": lt,
-                    "period": "6m",
-                }, f"reviews ASIN {lt}")
-                review_results[lt] = r
+                review_results[lt] = _filter_review_insights(r, lt)
 
     results["reviews"] = review_results
-    results["meta"]["review_mode"] = "category" if category_mode_success and category_path else "asin"
+    results["meta"]["review_mode"] = "category" if category_mode_success else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
 
     # ── Summary ──
@@ -819,14 +915,9 @@ def cmd_competitor_analysis(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
-    results["meta"]["resolved_category"] = category_path
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
 
     # Step 1: Competitor Discovery
     log("Step 1/7: Competitor discovery...")
@@ -844,6 +935,7 @@ def cmd_competitor_analysis(args):
     if category_path:
         comp_params["categoryPath"] = category_path
     results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    results["meta"]["resolved_category"] = category_path
     results["meta"]["steps_completed"].append("competitor_discovery")
 
     # Step 2: Market Context
@@ -931,16 +1023,17 @@ def cmd_competitor_analysis(args):
     review_results = {}
     for asin in top_asins[:5]:
         r = safe_call("reviews/analysis", {
-            "asins": [asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [asin], "mode": "asin", "period": "6m"
         }, f"reviews {asin}")
         if r.get("data") and r.get("data", {}).get("consumerInsights"):
             review_results[asin] = r
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -955,7 +1048,7 @@ def cmd_competitor_analysis(args):
                 bp["keyword"] = keyword
             if category_path:
                 bp["categoryPath"] = category_path
-            bp["includeBrands"] = top_brand
+            bp["includeBrands"] = [top_brand]
             results["top_brand_products"] = safe_call("products/search", bp, f"brand {top_brand}")
     results["meta"]["steps_completed"].append("brand_drilldown")
 
@@ -969,6 +1062,7 @@ def cmd_pricing_analysis(args):
     """
     Composite workflow: Pricing Analysis.
     Runs: realtime(my_asin) → price-band → products/competitors → market/brand → history → realtime(top5) → reviews
+    Category is auto-detected from ASIN if not provided.
     """
     my_asin = args.my_asin
     keyword = args.keyword
@@ -976,9 +1070,6 @@ def cmd_pricing_analysis(args):
 
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
-        sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
         sys.exit(1)
 
     category_path = parse_category(category) if category else None
@@ -993,21 +1084,40 @@ def cmd_pricing_analysis(args):
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
         return r
 
-    # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
-    results["meta"]["resolved_category"] = category_path
-
     # Step 1: Current Price Snapshot
     log("Step 1/8: Current price snapshot...")
     results["my_product"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
+    my_data = results["my_product"].get("data", {}) or {}
+    if not my_data.get("title"):
+        log(f"\n❌ ASIN '{my_asin}' not found or has no data. Please check the ASIN and try again.")
+        results["error"] = {"code": "ASIN_NOT_FOUND", "message": f"ASIN '{my_asin}' not found or returned empty data"}
+        output(results, args.format)
+        return
     results["meta"]["steps_completed"].append("price_snapshot")
+
+    # Step 1.5: Auto Category Detection
+    if not category_path:
+        # For pricing, we already have realtime data — extract directly first
+        if my_data.get("categoryPath"):
+            category_path = my_data["categoryPath"]
+            results["meta"]["category_source"] = "asin_realtime"
+            log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif my_data.get("bestsellersRank"):
+            leaf = my_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = safe_call("categories", {"categoryKeyword": leaf}, "categories")
+                results["categories"] = cat_result
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    results["meta"]["category_source"] = "asin_bsr"
+                    log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        # Fallback to keyword
+        if not category_path and keyword:
+            category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+            results["meta"]["category_source"] = category_source
+    results["meta"]["resolved_category"] = category_path
 
     # Step 2: Price Band Intelligence
     log("Step 2/8: Price band intelligence...")
@@ -1110,17 +1220,18 @@ def cmd_pricing_analysis(args):
     my_rc = results["my_product"].get("data", {}).get("ratingCount", 0)
     if my_rc and my_rc >= 50:
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if comp_asins:
         review_results["top_comp"] = safe_call("reviews/analysis", {
-            "asins": [comp_asins[0]], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [comp_asins[0]], "mode": "asin", "period": "6m"
         }, f"reviews {comp_asins[0]}")
     if not review_results and category_path:
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_context")
 
@@ -1157,9 +1268,6 @@ def cmd_daily_radar(args):
     if not asins_str:
         print("ERROR: --asins is required (comma-separated ASINs to track).", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     tracked_asins = [a.strip() for a in asins_str.split(",") if a.strip()]
     category_path = parse_category(category) if category else None
@@ -1175,14 +1283,10 @@ def cmd_daily_radar(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=tracked_asins[0] if tracked_asins else None, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
@@ -1292,10 +1396,9 @@ def cmd_daily_radar(args):
             r = safe_call("reviews/analysis", {
                 "asins": [review_asin],
                 "mode": "asin",
-                "labelType": "painPoints",
                 "period": "6m",
             }, f"reviews {review_asin}")
-            review_results["painPoints"] = r
+            review_results["painPoints"] = _filter_review_insights(r, "painPoints")
             break
     
     if not review_results:
@@ -1324,9 +1427,6 @@ def cmd_listing_audit(args):
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     category_path = parse_category(category) if category else None
     results = {"meta": {"my_asin": my_asin, "keyword": keyword, "category": category, "steps_completed": []}}
@@ -1341,14 +1441,10 @@ def cmd_listing_audit(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Audit Target
@@ -1451,21 +1547,22 @@ def cmd_listing_audit(args):
     if target_rc and target_rc >= 50:
         log(f"  → reviews/analysis ASIN mode: {my_asin}")
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if leader_asins:
         top_leader = leader_asins[0]
         log(f"  → reviews/analysis ASIN mode: {top_leader}")
         review_results["top_leader"] = safe_call("reviews/analysis", {
-            "asins": [top_leader], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [top_leader], "mode": "asin", "period": "6m"
         }, f"reviews {top_leader}")
     # Category fallback
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors", "improvements"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews category {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -1538,14 +1635,9 @@ def cmd_opportunity_scan(args):
         return r
 
     # Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Product Scan (mode-based + custom filters)
@@ -1684,23 +1776,22 @@ def cmd_opportunity_scan(args):
     log("Step 6/6: Consumer insights...")
     review_results = {}
     if category_path:
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
-            log(f"  → category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            if r.get("data") and r.get("data", {}).get("consumerInsights"):
-                review_results[lt] = r
-            else:
-                break
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
+        if r.get("data") and r.get("data", {}).get("consumerInsights"):
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     if not review_results:
         log("  → Falling back to ASIN mode...")
         review_asins = [a for a in top_asins[:3]]
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
+        if review_asins:
             r = safe_call("reviews/analysis", {
-                "asins": review_asins, "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews ASIN {lt}")
-            review_results[lt] = r
+                "asins": review_asins, "mode": "asin", "period": "6m"
+            }, "reviews ASIN")
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["review_mode"] = "category" if category_path and review_results.get("painPoints", {}).get("data", {}).get("consumerInsights") else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
@@ -1743,13 +1834,9 @@ def cmd_review_deepdive(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=target_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Target Identification
@@ -1775,26 +1862,25 @@ def cmd_review_deepdive(args):
     log("Step 2/5: Full review analysis (11 dimensions)...")
     label_types = ["painPoints", "positives", "buyingFactors", "improvements", "userProfiles",
                    "scenarios", "issues", "keywords", "usageTimes", "usageLocations", "behaviors"]
-    
+
     review_results = {}
-    # Target ASIN reviews
+    # Target ASIN reviews (single call, split client-side)
     if target_asin:
+        log(f"  → {target_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [target_asin], "mode": "asin", "period": "6m"
+        }, "reviews target")
         for lt in label_types:
-            log(f"  → {target_asin}: {lt}")
-            r = safe_call("reviews/analysis", {
-                "asins": [target_asin], "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            review_results[f"target_{lt}"] = r
-    
-    # Competitor comparison (top 2)
+            review_results[f"target_{lt}"] = _filter_review_insights(r, lt)
+
+    # Competitor comparison (top 2, single call each)
     for comp_asin in comp_asins[:2]:
-        log(f"  → Competitor {comp_asin}: painPoints + positives")
-        review_results[f"comp_{comp_asin}_painPoints"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+        log(f"  → Competitor {comp_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [comp_asin], "mode": "asin", "period": "6m"
         }, f"reviews comp {comp_asin}")
-        review_results[f"comp_{comp_asin}_positives"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "positives", "period": "6m"
-        }, f"reviews comp+ {comp_asin}")
+        review_results[f"comp_{comp_asin}_painPoints"] = _filter_review_insights(r, "painPoints")
+        review_results[f"comp_{comp_asin}_positives"] = _filter_review_insights(r, "positives")
     
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_analysis")
@@ -1960,12 +2046,19 @@ def cmd_analyze(args):
         print("ERROR: --asin, --asins, or --category is required.", file=sys.stderr)
         sys.exit(1)
 
-    if args.label_type:
-        params["labelType"] = args.label_type
     if args.period:
         params["period"] = args.period
 
     result = api_call("reviews/analysis", params)
+
+    # Client-side filtering by label type (v2 API returns all dimensions in one call)
+    if args.label_type and result.get("data") and result["data"].get("consumerInsights"):
+        requested = [t.strip() for t in args.label_type.split(",")]
+        result["data"]["consumerInsights"] = [
+            i for i in result["data"]["consumerInsights"]
+            if i.get("labelType") in requested
+        ]
+
     output(result, args.format)
 
 
@@ -2246,7 +2339,12 @@ Examples:
     p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+        print(f"ERROR: Unrecognized argument(s): {' '.join(unknown)}", file=sys.stderr)
+        print(f"Run 'apiclaw.py {cmd} --help' to see valid options.", file=sys.stderr)
+        sys.exit(1)
     args.func(args)
 
 

--- a/amazon-analysis/scripts/apiclaw.py
+++ b/amazon-analysis/scripts/apiclaw.py
@@ -234,6 +234,25 @@ def _filter_review_insights(result, label_type):
     return filtered
 
 
+def _fetch_all_history(api_caller, asins, start_date, end_date, log_fn=None):
+    """Fetch products/history for multiple ASINs (one API call per ASIN)."""
+    all_data = []
+    last_response = None
+    for asin in asins:
+        r = api_caller("products/history", {
+            "asin": asin, "startDate": start_date, "endDate": end_date,
+        }, f"history {asin}")
+        last_response = r
+        if r.get("data"):
+            all_data.append(r["data"])
+        elif log_fn:
+            log_fn(f"  ⚠️ No history data for {asin}")
+    if last_response is None:
+        return {"success": False, "data": [], "error": {"message": "No ASINs provided"}}
+    last_response["data"] = all_data
+    return last_response
+
+
 def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
     """
     Resolve categoryPath with multi-level fallback.
@@ -818,11 +837,7 @@ def cmd_market_entry(args):
     round1_asins = top_asins[:3]
     if round1_asins:
         tried_asins.update(round1_asins)
-        r = safe_call("products/history", {
-            "asins": round1_asins,
-            "startDate": thirty_days_ago,
-            "endDate": today,
-        }, "history round 1")
+        r = _fetch_all_history(safe_call, round1_asins, thirty_days_ago, today, log_fn=log)
         history_data = r.get("data", [])
 
     # Round 2: Try oldest products if round 1 was empty
@@ -831,11 +846,7 @@ def cmd_market_entry(args):
         if round2_asins:
             log(f"  → Round 1 empty, trying older ASINs: {round2_asins}")
             tried_asins.update(round2_asins)
-            r = safe_call("products/history", {
-                "asins": round2_asins,
-                "startDate": thirty_days_ago,
-                "endDate": today,
-            }, "history round 2")
+            r = _fetch_all_history(safe_call, round2_asins, thirty_days_ago, today, log_fn=log)
             history_data = r.get("data", [])
 
     results["product_history"] = {"data": history_data, "asins_tried": list(tried_asins)}
@@ -1012,9 +1023,7 @@ def cmd_competitor_analysis(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = ([my_asin] if my_asin else []) + top_asins[:5]
-    r = safe_call("products/history", {
-        "asins": history_asins[:8], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins[:8], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins[:8]}
     results["meta"]["steps_completed"].append("historical_trends")
 
@@ -1198,9 +1207,7 @@ def cmd_pricing_analysis(args):
             break
 
     history_asins = [my_asin] + comp_asins
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("price_trends")
 
@@ -1308,11 +1315,7 @@ def cmd_daily_radar(args):
     tried_asins = set()
     
     # Round 1: All tracked ASINs
-    r = safe_call("products/history", {
-        "asins": tracked_asins,
-        "startDate": seven_days_ago,
-        "endDate": today,
-    }, "history round 1")
+    r = _fetch_all_history(safe_call, tracked_asins, seven_days_ago, today, log_fn=log)
     history_data = r.get("data", [])
     tried_asins.update(tracked_asins)
 
@@ -1571,9 +1574,7 @@ def cmd_listing_audit(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = [my_asin] + leader_asins[:2]
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("trend_context")
 
@@ -1766,9 +1767,7 @@ def cmd_opportunity_scan(args):
     log("Step 5/6: Trend check...")
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
-    r = safe_call("products/history", {
-        "asins": top_asins[:5], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, top_asins[:5], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": top_asins[:5]}
     results["meta"]["steps_completed"].append("trend_check")
 
@@ -1942,9 +1941,7 @@ def cmd_review_deepdive(args):
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     hist_asins = [target_asin] + comp_asins[:2] if target_asin else comp_asins[:3]
     if hist_asins:
-        r = safe_call("products/history", {
-            "asins": hist_asins, "startDate": thirty_ago, "endDate": today
-        }, "history")
+        r = _fetch_all_history(safe_call, hist_asins, thirty_ago, today, log_fn=log)
         results["product_history"] = {"data": r.get("data", []), "asins_tried": hist_asins}
     results["meta"]["steps_completed"].append("price_trend_context")
 
@@ -2119,12 +2116,11 @@ def cmd_brand_detail(args):
 def cmd_product_history(args):
     """Get historical data (price, BSR, sales) for ASINs over a date range."""
     asins = [a.strip() for a in args.asins.split(",")]
-    params = {
-        "asins": asins,
-        "startDate": args.start_date,
-        "endDate": args.end_date,
-    }
-    result = api_call("products/history", params)
+
+    def _api_caller(endpoint, p, label=""):
+        return api_call(endpoint, p)
+
+    result = _fetch_all_history(_api_caller, asins, args.start_date, args.end_date)
     output(result, args.format)
 
 

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -23,9 +23,9 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 
 | File | Purpose |
 |------|---------|
-| `scripts/apiclaw.py` | **Execute** for all API calls (run `--help` for params) |
-| `references/reference.md` | Load for exact field names or response structure |
-| `monitor-data/` | Runtime storage (auto-created): config.json, baseline.json, history/, alerts.json |
+| `{skill_base_dir}/scripts/apiclaw.py` | **Execute** for all API calls (run `--help` for params) |
+| `{skill_base_dir}/references/reference.md` | Load for exact field names or response structure |
+| `{skill_base_dir}/monitor-data/` | Runtime storage (auto-created): config.json, baseline.json, history/, alerts.json |
 
 ## Credential
 
@@ -54,11 +54,11 @@ Brand queries MUST also include confirmed `--category`.
 
 1. `competitor-analysis --keyword X [--category Y] [--my-asin Z]` (composite, auto-detects category)
 2. If `category_source` is `inferred_from_search`, confirm with user before presenting results
-3. Analyze & score → save baseline to `monitor-data/` → offer Auto-Monitor
+3. Analyze & score → save baseline to `{skill_base_dir}/monitor-data/` → offer Auto-Monitor
 
 ## Quick Check Flow
 
-1. Load config.json + baseline.json from `monitor-data/` (missing → fall back to Full Scan)
+1. Load config.json + baseline.json from `{skill_base_dir}/monitor-data/` (missing → fall back to Full Scan)
 2. Poll `product --asin {asin}` for each tracked ASIN
 3. Diff against baseline with tiered alerts → update baseline → offer Auto-Monitor
 

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -39,7 +39,7 @@ Brand queries MUST also include confirmed `--category`.
 
 ## API Pitfalls (CRITICAL)
 
-1. **Category first**: MUST resolve and confirm categoryPath with user before any data collection
+1. **Category auto-detection**: categoryPath is auto-detected from keyword, ASIN, or top search result. If `category_source` in output is `inferred_from_search`, MUST confirm with user before trusting results
 2. **All keyword-based endpoints MUST include `--category`**; ASIN-specific endpoints do NOT need it
 3. **Brand + category**: a brand sells across categories — only analyze within locked subcategory
 4. **Use API fields directly**: revenue=`sampleAvgMonthlyRevenue` (NEVER price×sales), sales=`monthlySalesFloor`, concentration=`sampleTop10BrandSalesRate`
@@ -52,8 +52,8 @@ Brand queries MUST also include confirmed `--category`.
 
 ## Full Scan Flow
 
-1. Parse input → resolve & confirm categoryPath with user
-2. `competitor-analysis --keyword X --category Y [--my-asin Z]` (composite, runs all 11 endpoints)
+1. `competitor-analysis --keyword X [--category Y] [--my-asin Z]` (composite, auto-detects category)
+2. If `category_source` is `inferred_from_search`, confirm with user before presenting results
 3. Analyze & score → save baseline to `monitor-data/` → offer Auto-Monitor
 
 ## Quick Check Flow
@@ -73,13 +73,28 @@ Brand queries MUST also include confirmed `--category`.
 
 ## Competitive Score (per competitor, 1-100)
 
-| Dimension | Weight |
-|-----------|--------|
-| Sales Dominance | 25% — monthly sales, revenue, market share |
-| Brand Strength | 20% — brand sales rate, SKU count, price range |
-| Listing Quality | 20% — images, bullets, A+, title |
-| Customer Satisfaction | 20% — rating, sentiment, pain points |
-| Trend Momentum | 15% — BSR direction, sales growth, price stability |
+| Dimension | Weight | 80-100 (Strong) | 50-79 (Moderate) | 0-49 (Weak) |
+|-----------|--------|-----------------|-------------------|-------------|
+| Sales Dominance | 25% | Top 3 in category, >5K units/mo 📊 | Top 20, 1K-5K units/mo 📊 | Below Top 20, <1K units/mo 📊 |
+| Brand Strength | 20% | Brand in CR10, 5+ SKUs, wide price range 📊 | Known brand, 2-4 SKUs 📊 | Unknown brand, single SKU 📊 |
+| Listing Quality | 20% | 7+ images, 5 bullets, A+, optimized title 📊 | 5-6 images, basic bullets 📊 | <5 images, weak bullets, no A+ 📊 |
+| Customer Satisfaction | 20% | Rating ≥4.5, <3% 1-star, positive sentiment 📊 | 4.0-4.4, 3-8% 1-star 📊 | <4.0 or >8% 1-star 📊 |
+| Trend Momentum | 15% | BSR improving 30d, sales growth >10% 🔍 | BSR stable, flat sales 🔍 | BSR declining, sales drop 🔍 |
+
+### Competitive Threat Level
+| Total Score | Threat | Interpretation |
+|-------------|--------|---------------|
+| 80-100 | 🔴 Dominant | Hard to compete head-on; find differentiation or avoid price band 💡 |
+| 50-79 | 🟡 Competitive | Beatable with better listing, pricing, or reviews 💡 |
+| 0-49 | 🟢 Vulnerable | Weak competitor; opportunity to capture share 💡 |
+
+### Market Structure Analysis
+- **CR10 > 70%**: Concentrated market — new entrants need strong differentiation or niche positioning 🔍
+- **CR10 40-70%**: Moderately competitive — room for well-positioned products 🔍
+- **CR10 < 40%**: Fragmented — opportunity for brand building 🔍
+- **Top brand share > 25%**: Category leader dominance — avoid direct competition in their price band 💡
+- **New SKU rate > 15%**: Active market with frequent new entrants 📊
+- **New SKU rate < 5%**: Mature/stagnant market, high barriers 🔍
 
 ## Auto-Monitor Prompt
 
@@ -89,7 +104,41 @@ After EVERY run, offer: "Set up automatic monitoring? I can generate a scheduled
 
 Full Scan sections: Battlefield Overview → Competitor Matrix → Brand Power Ranking → Price Map → 30-Day Trends → Review Battle → Listing Audit → Competitive Scores → Battle Strategy → Data Provenance → API Usage.
 
-Confidence labels: 📊 Data-backed | 🔍 Inferred | 💡 Directional. Strategy is NEVER 📊. Anomalies (>200% growth) always 💡. User criteria override AI judgment.
+### Language (required)
+
+Output language MUST match the user's input language. If the user asks in Chinese, the entire report is in Chinese. If in English, output in English. Exception: API field names (e.g. `monthlySalesFloor`, `categoryPath`), endpoint names, technical terms (e.g. ASIN, BSR, CR10, FBA, credits) remain in English.
+
+### Disclaimer (required, at the top of every report)
+
+> Data is based on APIClaw API sampling as of [date]. Monthly sales (`monthlySalesFloor`) are lower-bound estimates. This analysis is for reference only and should not be the sole basis for business decisions. Validate with additional sources before acting.
+
+### Confidence Labels (required, tag EVERY conclusion)
+
+- 📊 **Data-backed** — direct API data (e.g. "CR10 = 54.8% 📊")
+- 🔍 **Inferred** — logical reasoning from data (e.g. "brand concentration is moderate 🔍")
+- 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
+
+Rules: Strategy recommendations are NEVER 📊. Anomalies (>200% growth) are always 💡. User criteria override AI judgment.
+
+### Data Provenance (required)
+
+Include a table at the end of every report:
+
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+| (e.g. Market Overview) | `markets/search` | categoryPath, topN=10 | 📊 Top N sampling, sales are lower-bound |
+| ... | ... | ... | ... |
+
+Extract endpoint and params from `_query` in JSON output. Add notes: sampling method, T+1 delay, realtime vs DB, minimum review threshold, etc.
+
+### API Usage (required)
+
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+| (each endpoint used) | N | N |
+| **Total** | **N** | **N** |
+
+Extract from `meta.creditsConsumed` per response. End with `Credits remaining: N`.
 
 ## API Budget
 

--- a/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
+++ b/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import sys
+import random
 import time
 import urllib.request
 import urllib.error
@@ -35,9 +36,15 @@ import urllib.error
 
 BASE_URL = "https://api.apiclaw.io/openapi/v2"  # APIClaw API base URL
 API_DOCS = "https://api.apiclaw.io/api-docs"   # API documentation URL
-MAX_RETRIES = 2       # Maximum number of retry attempts for failed requests
-RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on 429 (rate limit)
+MAX_RETRIES = 3       # Maximum number of retry attempts for failed requests
+RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
+RATE_LIMIT_RETRIES = 4  # Extra retries specifically for 429 rate limits
+RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
+MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
+
+# Global request pacer — prevents burst rate limit violations
+_last_request_time = 0.0
 
 # 13 built-in product selection modes
 # Each maps to a set of products/search filter parameters
@@ -110,6 +117,8 @@ def api_call(endpoint: str, params: dict) -> dict:
     Returns the parsed JSON response on success, with _query metadata injected.
     Exits with a clear error message on failure.
     """
+    global _last_request_time
+
     url = f"{BASE_URL}/{endpoint}"
     api_key = get_api_key()
 
@@ -131,8 +140,16 @@ def api_call(endpoint: str, params: dict) -> dict:
         "User-Agent": "APIClaw-CLI/1.0 (Python)",
     }
 
+    # Rate-limit pacing: enforce minimum interval between requests
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < MIN_REQUEST_INTERVAL:
+        time.sleep(MIN_REQUEST_INTERVAL - elapsed)
+
     delay = RETRY_DELAY
-    for attempt in range(1, MAX_RETRIES + 1):
+    max_attempts = MAX_RETRIES
+    for attempt in range(1, max_attempts + 1):
+        _last_request_time = time.monotonic()
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
@@ -163,9 +180,15 @@ def api_call(endpoint: str, params: dict) -> dict:
                     "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
                     endpoint, actual_params)
             elif status == 429:
-                if attempt < MAX_RETRIES:
-                    print(f"Rate limited (429). Waiting {delay}s before retry {attempt}/{MAX_RETRIES}...", file=sys.stderr)
-                    time.sleep(delay)
+                # Switch to longer retry strategy for rate limits
+                if attempt == 1:
+                    max_attempts = RATE_LIMIT_RETRIES
+                    delay = RATE_LIMIT_DELAY
+                if attempt < max_attempts:
+                    jitter = random.uniform(0, delay * 0.25)
+                    wait = delay + jitter
+                    print(f"Rate limited (429). Waiting {wait:.1f}s before retry {attempt}/{max_attempts}...", file=sys.stderr)
+                    time.sleep(wait)
                     delay *= 2
                     continue
                 else:
@@ -177,17 +200,17 @@ def api_call(endpoint: str, params: dict) -> dict:
                     f"Check {API_DOCS} for current endpoints",
                     endpoint, actual_params)
             else:
-                if attempt < MAX_RETRIES:
-                    print(f"HTTP {status}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                if attempt < max_attempts:
+                    print(f"HTTP {status}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                     time.sleep(delay)
                     continue
                 else:
-                    return _error_result(status, f"HTTP {status} after {MAX_RETRIES} attempts",
+                    return _error_result(status, f"HTTP {status} after {max_attempts} attempts",
                         "Check network or try again later",
                         endpoint, actual_params)
         except Exception as e:
-            if attempt < MAX_RETRIES:
-                print(f"Request failed: {e}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+            if attempt < max_attempts:
+                print(f"Request failed: {e}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                 time.sleep(delay)
                 continue
             else:
@@ -196,6 +219,94 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
 
     return _error_result(0, "Unexpected retry loop exit", "This should not happen", endpoint, actual_params)
+
+
+def _filter_review_insights(result, label_type):
+    """Return a shallow copy of a reviews/analysis result filtered to one labelType."""
+    if not result.get("data") or not result["data"].get("consumerInsights"):
+        return result
+    filtered = dict(result)
+    filtered["data"] = dict(result["data"])
+    filtered["data"]["consumerInsights"] = [
+        i for i in result["data"]["consumerInsights"]
+        if i.get("labelType") == label_type
+    ]
+    return filtered
+
+
+def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
+    """
+    Resolve categoryPath with multi-level fallback.
+    Returns (category_path, category_source) tuple.
+
+    Priority:
+      1. keyword → categories API
+      2. asin → realtime/product → categoryPath or bestsellersRank leaf
+      3. keyword → products/search → first result → realtime/product
+    """
+    category_path = None
+    category_source = "user"
+
+    # Priority 1: keyword → categories
+    if keyword:
+        log_fn("Step 0: Resolving category...")
+        cat_result = api_caller("categories", {"categoryKeyword": keyword}, "categories")
+        if results is not None:
+            results["categories"] = cat_result
+        cat_data = cat_result.get("data", [])
+        if cat_data:
+            category_path = cat_data[0].get("categoryPath")
+            category_source = "keyword"
+
+    # Priority 2: asin → realtime/product
+    if not category_path and asin:
+        log_fn("  → Resolving category from ASIN...")
+        rt = api_caller("realtime/product", {"asin": asin, "marketplace": "US"}, f"realtime {asin}")
+        if results is not None:
+            results.setdefault("_asin_realtime", rt)
+        rt_data = rt.get("data", {}) or {}
+        if rt_data.get("categoryPath"):
+            category_path = rt_data["categoryPath"]
+            category_source = "asin_realtime"
+            log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif rt_data.get("bestsellersRank"):
+            leaf = rt_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log_fn(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "asin_bsr"
+                    log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+
+    # Priority 3: keyword → search → first product → realtime
+    if not category_path and keyword:
+        log_fn("  → Resolving category from top search result...")
+        prod_result = api_caller("products/search", {
+            "keyword": keyword, "sortBy": "monthlySalesFloor", "sortOrder": "desc", "pageSize": 5
+        }, "products (category probe)")
+        prod_data = prod_result.get("data", [])
+        if isinstance(prod_data, list) and prod_data:
+            probe_asin = prod_data[0].get("asin")
+            if probe_asin:
+                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+                rt_data = rt.get("data", {}) or {}
+                if rt_data.get("categoryPath"):
+                    category_path = rt_data["categoryPath"]
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+                elif rt_data.get("bestsellersRank"):
+                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
+                    if leaf:
+                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                        cat_data = cat_result.get("data", [])
+                        if cat_data:
+                            category_path = cat_data[0].get("categoryPath")
+                            category_source = "inferred_from_search"
+                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+
+    return category_path, category_source
 
 
 def _error_result(status: int, message: str, action: str, endpoint: str, params: dict) -> dict:
@@ -344,9 +455,9 @@ def cmd_products(args):
     if args.fulfillment:
         params["fulfillments"] = args.fulfillment
     if args.include_brands:
-        params["includeBrands"] = args.include_brands
+        params["includeBrands"] = [b.strip() for b in args.include_brands.split(",")]
     if args.exclude_brands:
-        params["excludeBrands"] = args.exclude_brands
+        params["excludeBrands"] = [b.strip() for b in args.exclude_brands.split(",")]
 
     params["sortBy"] = args.sort or "monthlySalesFloor"
     params["sortOrder"] = args.order or "desc"
@@ -453,7 +564,7 @@ def cmd_report(args):
     print("Step 3/4: Searching top products...", file=sys.stderr)
     products_result = api_call("products/search", {
         "keyword": keyword,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 50,
     })
@@ -508,7 +619,7 @@ def cmd_opportunity(args):
         "keyword": keyword,
         "monthlySalesMin": 300,
         "ratingCountMax": 50,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 20,
     }
@@ -565,17 +676,9 @@ def cmd_market_entry(args):
         return r
 
     # ── Step 0.5: Category Resolution ──
-    if not category_path and keyword:
-        log("Step 0.5: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked category: {' > '.join(category_path)}")
-        else:
-            log("  ⚠️ No category match, will use keyword-only queries")
-
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # ── Step 1: Market Landscape (3 calls) ──
@@ -744,43 +847,36 @@ def cmd_market_entry(args):
     review_results = {}
     label_types = ["painPoints", "buyingFactors", "improvements"]
 
-    # Priority 1: Category mode
-    category_mode_success = True
+    # Priority 1: Category mode (single call, split client-side)
+    category_mode_success = False
     if category_path:
-        for lt in label_types:
-            log(f"  → reviews/analysis category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path,
-                "mode": "category",
-                "labelType": lt,
-                "period": "6m",
-            }, f"reviews {lt}")
-            if r.get("success") is False or not r.get("data", {}).get("consumerInsights"):
-                category_mode_success = False
-                log(f"  ⚠️ Category mode failed for {lt}")
-                break
-            review_results[lt] = r
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path,
+            "mode": "category",
+            "period": "6m",
+        }, "reviews category")
+        if r.get("success") and r.get("data", {}).get("consumerInsights"):
+            category_mode_success = True
+            for lt in label_types:
+                review_results[lt] = _filter_review_insights(r, lt)
 
     # Priority 2: ASIN mode (if category failed)
-    if not category_mode_success or not category_path:
+    if not category_mode_success:
         log("  → Falling back to ASIN mode...")
-        # Pick ASINs with ratingCount >= 50
         review_asins = [p.get("asin") for p in all_products if (p.get("ratingCount") or 0) >= 50][:3]
         if review_asins:
+            log(f"  → reviews/analysis ASIN mode ({review_asins})")
+            r = safe_call("reviews/analysis", {
+                "asins": review_asins,
+                "mode": "asin",
+                "period": "6m",
+            }, "reviews ASIN")
             for lt in label_types:
-                if lt in review_results:
-                    continue
-                log(f"  → reviews/analysis ASIN mode: {lt} ({review_asins})")
-                r = safe_call("reviews/analysis", {
-                    "asins": review_asins,
-                    "mode": "asin",
-                    "labelType": lt,
-                    "period": "6m",
-                }, f"reviews ASIN {lt}")
-                review_results[lt] = r
+                review_results[lt] = _filter_review_insights(r, lt)
 
     results["reviews"] = review_results
-    results["meta"]["review_mode"] = "category" if category_mode_success and category_path else "asin"
+    results["meta"]["review_mode"] = "category" if category_mode_success else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
 
     # ── Summary ──
@@ -819,14 +915,9 @@ def cmd_competitor_analysis(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
-    results["meta"]["resolved_category"] = category_path
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
 
     # Step 1: Competitor Discovery
     log("Step 1/7: Competitor discovery...")
@@ -844,6 +935,7 @@ def cmd_competitor_analysis(args):
     if category_path:
         comp_params["categoryPath"] = category_path
     results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    results["meta"]["resolved_category"] = category_path
     results["meta"]["steps_completed"].append("competitor_discovery")
 
     # Step 2: Market Context
@@ -931,16 +1023,17 @@ def cmd_competitor_analysis(args):
     review_results = {}
     for asin in top_asins[:5]:
         r = safe_call("reviews/analysis", {
-            "asins": [asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [asin], "mode": "asin", "period": "6m"
         }, f"reviews {asin}")
         if r.get("data") and r.get("data", {}).get("consumerInsights"):
             review_results[asin] = r
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -955,7 +1048,7 @@ def cmd_competitor_analysis(args):
                 bp["keyword"] = keyword
             if category_path:
                 bp["categoryPath"] = category_path
-            bp["includeBrands"] = top_brand
+            bp["includeBrands"] = [top_brand]
             results["top_brand_products"] = safe_call("products/search", bp, f"brand {top_brand}")
     results["meta"]["steps_completed"].append("brand_drilldown")
 
@@ -969,6 +1062,7 @@ def cmd_pricing_analysis(args):
     """
     Composite workflow: Pricing Analysis.
     Runs: realtime(my_asin) → price-band → products/competitors → market/brand → history → realtime(top5) → reviews
+    Category is auto-detected from ASIN if not provided.
     """
     my_asin = args.my_asin
     keyword = args.keyword
@@ -976,9 +1070,6 @@ def cmd_pricing_analysis(args):
 
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
-        sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
         sys.exit(1)
 
     category_path = parse_category(category) if category else None
@@ -993,21 +1084,40 @@ def cmd_pricing_analysis(args):
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
         return r
 
-    # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
-    results["meta"]["resolved_category"] = category_path
-
     # Step 1: Current Price Snapshot
     log("Step 1/8: Current price snapshot...")
     results["my_product"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
+    my_data = results["my_product"].get("data", {}) or {}
+    if not my_data.get("title"):
+        log(f"\n❌ ASIN '{my_asin}' not found or has no data. Please check the ASIN and try again.")
+        results["error"] = {"code": "ASIN_NOT_FOUND", "message": f"ASIN '{my_asin}' not found or returned empty data"}
+        output(results, args.format)
+        return
     results["meta"]["steps_completed"].append("price_snapshot")
+
+    # Step 1.5: Auto Category Detection
+    if not category_path:
+        # For pricing, we already have realtime data — extract directly first
+        if my_data.get("categoryPath"):
+            category_path = my_data["categoryPath"]
+            results["meta"]["category_source"] = "asin_realtime"
+            log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif my_data.get("bestsellersRank"):
+            leaf = my_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = safe_call("categories", {"categoryKeyword": leaf}, "categories")
+                results["categories"] = cat_result
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    results["meta"]["category_source"] = "asin_bsr"
+                    log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        # Fallback to keyword
+        if not category_path and keyword:
+            category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+            results["meta"]["category_source"] = category_source
+    results["meta"]["resolved_category"] = category_path
 
     # Step 2: Price Band Intelligence
     log("Step 2/8: Price band intelligence...")
@@ -1110,17 +1220,18 @@ def cmd_pricing_analysis(args):
     my_rc = results["my_product"].get("data", {}).get("ratingCount", 0)
     if my_rc and my_rc >= 50:
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if comp_asins:
         review_results["top_comp"] = safe_call("reviews/analysis", {
-            "asins": [comp_asins[0]], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [comp_asins[0]], "mode": "asin", "period": "6m"
         }, f"reviews {comp_asins[0]}")
     if not review_results and category_path:
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_context")
 
@@ -1157,9 +1268,6 @@ def cmd_daily_radar(args):
     if not asins_str:
         print("ERROR: --asins is required (comma-separated ASINs to track).", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     tracked_asins = [a.strip() for a in asins_str.split(",") if a.strip()]
     category_path = parse_category(category) if category else None
@@ -1175,14 +1283,10 @@ def cmd_daily_radar(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=tracked_asins[0] if tracked_asins else None, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
@@ -1292,10 +1396,9 @@ def cmd_daily_radar(args):
             r = safe_call("reviews/analysis", {
                 "asins": [review_asin],
                 "mode": "asin",
-                "labelType": "painPoints",
                 "period": "6m",
             }, f"reviews {review_asin}")
-            review_results["painPoints"] = r
+            review_results["painPoints"] = _filter_review_insights(r, "painPoints")
             break
     
     if not review_results:
@@ -1324,9 +1427,6 @@ def cmd_listing_audit(args):
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     category_path = parse_category(category) if category else None
     results = {"meta": {"my_asin": my_asin, "keyword": keyword, "category": category, "steps_completed": []}}
@@ -1341,14 +1441,10 @@ def cmd_listing_audit(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Audit Target
@@ -1451,21 +1547,22 @@ def cmd_listing_audit(args):
     if target_rc and target_rc >= 50:
         log(f"  → reviews/analysis ASIN mode: {my_asin}")
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if leader_asins:
         top_leader = leader_asins[0]
         log(f"  → reviews/analysis ASIN mode: {top_leader}")
         review_results["top_leader"] = safe_call("reviews/analysis", {
-            "asins": [top_leader], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [top_leader], "mode": "asin", "period": "6m"
         }, f"reviews {top_leader}")
     # Category fallback
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors", "improvements"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews category {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -1538,14 +1635,9 @@ def cmd_opportunity_scan(args):
         return r
 
     # Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Product Scan (mode-based + custom filters)
@@ -1684,23 +1776,22 @@ def cmd_opportunity_scan(args):
     log("Step 6/6: Consumer insights...")
     review_results = {}
     if category_path:
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
-            log(f"  → category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            if r.get("data") and r.get("data", {}).get("consumerInsights"):
-                review_results[lt] = r
-            else:
-                break
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
+        if r.get("data") and r.get("data", {}).get("consumerInsights"):
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     if not review_results:
         log("  → Falling back to ASIN mode...")
         review_asins = [a for a in top_asins[:3]]
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
+        if review_asins:
             r = safe_call("reviews/analysis", {
-                "asins": review_asins, "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews ASIN {lt}")
-            review_results[lt] = r
+                "asins": review_asins, "mode": "asin", "period": "6m"
+            }, "reviews ASIN")
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["review_mode"] = "category" if category_path and review_results.get("painPoints", {}).get("data", {}).get("consumerInsights") else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
@@ -1743,13 +1834,9 @@ def cmd_review_deepdive(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=target_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Target Identification
@@ -1775,26 +1862,25 @@ def cmd_review_deepdive(args):
     log("Step 2/5: Full review analysis (11 dimensions)...")
     label_types = ["painPoints", "positives", "buyingFactors", "improvements", "userProfiles",
                    "scenarios", "issues", "keywords", "usageTimes", "usageLocations", "behaviors"]
-    
+
     review_results = {}
-    # Target ASIN reviews
+    # Target ASIN reviews (single call, split client-side)
     if target_asin:
+        log(f"  → {target_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [target_asin], "mode": "asin", "period": "6m"
+        }, "reviews target")
         for lt in label_types:
-            log(f"  → {target_asin}: {lt}")
-            r = safe_call("reviews/analysis", {
-                "asins": [target_asin], "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            review_results[f"target_{lt}"] = r
-    
-    # Competitor comparison (top 2)
+            review_results[f"target_{lt}"] = _filter_review_insights(r, lt)
+
+    # Competitor comparison (top 2, single call each)
     for comp_asin in comp_asins[:2]:
-        log(f"  → Competitor {comp_asin}: painPoints + positives")
-        review_results[f"comp_{comp_asin}_painPoints"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+        log(f"  → Competitor {comp_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [comp_asin], "mode": "asin", "period": "6m"
         }, f"reviews comp {comp_asin}")
-        review_results[f"comp_{comp_asin}_positives"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "positives", "period": "6m"
-        }, f"reviews comp+ {comp_asin}")
+        review_results[f"comp_{comp_asin}_painPoints"] = _filter_review_insights(r, "painPoints")
+        review_results[f"comp_{comp_asin}_positives"] = _filter_review_insights(r, "positives")
     
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_analysis")
@@ -1960,12 +2046,19 @@ def cmd_analyze(args):
         print("ERROR: --asin, --asins, or --category is required.", file=sys.stderr)
         sys.exit(1)
 
-    if args.label_type:
-        params["labelType"] = args.label_type
     if args.period:
         params["period"] = args.period
 
     result = api_call("reviews/analysis", params)
+
+    # Client-side filtering by label type (v2 API returns all dimensions in one call)
+    if args.label_type and result.get("data") and result["data"].get("consumerInsights"):
+        requested = [t.strip() for t in args.label_type.split(",")]
+        result["data"]["consumerInsights"] = [
+            i for i in result["data"]["consumerInsights"]
+            if i.get("labelType") in requested
+        ]
+
     output(result, args.format)
 
 
@@ -2246,7 +2339,12 @@ Examples:
     p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+        print(f"ERROR: Unrecognized argument(s): {' '.join(unknown)}", file=sys.stderr)
+        print(f"Run 'apiclaw.py {cmd} --help' to see valid options.", file=sys.stderr)
+        sys.exit(1)
     args.func(args)
 
 

--- a/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
+++ b/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
@@ -234,6 +234,25 @@ def _filter_review_insights(result, label_type):
     return filtered
 
 
+def _fetch_all_history(api_caller, asins, start_date, end_date, log_fn=None):
+    """Fetch products/history for multiple ASINs (one API call per ASIN)."""
+    all_data = []
+    last_response = None
+    for asin in asins:
+        r = api_caller("products/history", {
+            "asin": asin, "startDate": start_date, "endDate": end_date,
+        }, f"history {asin}")
+        last_response = r
+        if r.get("data"):
+            all_data.append(r["data"])
+        elif log_fn:
+            log_fn(f"  ⚠️ No history data for {asin}")
+    if last_response is None:
+        return {"success": False, "data": [], "error": {"message": "No ASINs provided"}}
+    last_response["data"] = all_data
+    return last_response
+
+
 def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
     """
     Resolve categoryPath with multi-level fallback.
@@ -818,11 +837,7 @@ def cmd_market_entry(args):
     round1_asins = top_asins[:3]
     if round1_asins:
         tried_asins.update(round1_asins)
-        r = safe_call("products/history", {
-            "asins": round1_asins,
-            "startDate": thirty_days_ago,
-            "endDate": today,
-        }, "history round 1")
+        r = _fetch_all_history(safe_call, round1_asins, thirty_days_ago, today, log_fn=log)
         history_data = r.get("data", [])
 
     # Round 2: Try oldest products if round 1 was empty
@@ -831,11 +846,7 @@ def cmd_market_entry(args):
         if round2_asins:
             log(f"  → Round 1 empty, trying older ASINs: {round2_asins}")
             tried_asins.update(round2_asins)
-            r = safe_call("products/history", {
-                "asins": round2_asins,
-                "startDate": thirty_days_ago,
-                "endDate": today,
-            }, "history round 2")
+            r = _fetch_all_history(safe_call, round2_asins, thirty_days_ago, today, log_fn=log)
             history_data = r.get("data", [])
 
     results["product_history"] = {"data": history_data, "asins_tried": list(tried_asins)}
@@ -1012,9 +1023,7 @@ def cmd_competitor_analysis(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = ([my_asin] if my_asin else []) + top_asins[:5]
-    r = safe_call("products/history", {
-        "asins": history_asins[:8], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins[:8], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins[:8]}
     results["meta"]["steps_completed"].append("historical_trends")
 
@@ -1198,9 +1207,7 @@ def cmd_pricing_analysis(args):
             break
 
     history_asins = [my_asin] + comp_asins
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("price_trends")
 
@@ -1308,11 +1315,7 @@ def cmd_daily_radar(args):
     tried_asins = set()
     
     # Round 1: All tracked ASINs
-    r = safe_call("products/history", {
-        "asins": tracked_asins,
-        "startDate": seven_days_ago,
-        "endDate": today,
-    }, "history round 1")
+    r = _fetch_all_history(safe_call, tracked_asins, seven_days_ago, today, log_fn=log)
     history_data = r.get("data", [])
     tried_asins.update(tracked_asins)
 
@@ -1571,9 +1574,7 @@ def cmd_listing_audit(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = [my_asin] + leader_asins[:2]
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("trend_context")
 
@@ -1766,9 +1767,7 @@ def cmd_opportunity_scan(args):
     log("Step 5/6: Trend check...")
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
-    r = safe_call("products/history", {
-        "asins": top_asins[:5], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, top_asins[:5], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": top_asins[:5]}
     results["meta"]["steps_completed"].append("trend_check")
 
@@ -1942,9 +1941,7 @@ def cmd_review_deepdive(args):
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     hist_asins = [target_asin] + comp_asins[:2] if target_asin else comp_asins[:3]
     if hist_asins:
-        r = safe_call("products/history", {
-            "asins": hist_asins, "startDate": thirty_ago, "endDate": today
-        }, "history")
+        r = _fetch_all_history(safe_call, hist_asins, thirty_ago, today, log_fn=log)
         results["product_history"] = {"data": r.get("data", []), "asins_tried": hist_asins}
     results["meta"]["steps_completed"].append("price_trend_context")
 
@@ -2119,12 +2116,11 @@ def cmd_brand_detail(args):
 def cmd_product_history(args):
     """Get historical data (price, BSR, sales) for ASINs over a date range."""
     asins = [a.strip() for a in args.asins.split(",")]
-    params = {
-        "asins": asins,
-        "startDate": args.start_date,
-        "endDate": args.end_date,
-    }
-    result = api_call("products/history", params)
+
+    def _api_caller(endpoint, p, label=""):
+        return api_call(endpoint, p)
+
+    result = _fetch_all_history(_api_caller, asins, args.start_date, args.end_date)
     output(result, args.format)
 
 

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -24,9 +24,9 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 
 | File | Purpose |
 |------|---------|
-| `scripts/apiclaw.py` | **Execute** for all API calls (run `--help` for params) |
-| `references/reference.md` | Load for exact field names or response structure |
-| `data/` | Runtime: watchlist.json, last-run.json (auto-created) |
+| `{skill_base_dir}/scripts/apiclaw.py` | **Execute** for all API calls (run `--help` for params) |
+| `{skill_base_dir}/references/reference.md` | Load for exact field names or response structure |
+| `{skill_base_dir}/data/` | Runtime: watchlist.json, last-run.json (auto-created) |
 
 ## Credential
 
@@ -47,8 +47,8 @@ Collect in ONE message: ✅ my_asins (1-10) | 💡 competitor_asins (up to 20) |
 ## Execution
 
 1. `daily-radar --asins "asin1,asin2,..." [--keyword X] [--category Y]` (composite, auto-detects category from ASINs)
-3. Compare against `data/last-run.json` for change detection (first run = baseline only, no alerts)
-4. Generate alert-prioritized briefing → save snapshot to `data/last-run.json`
+3. Compare against `{skill_base_dir}/data/last-run.json` for change detection (first run = baseline only, no alerts)
+4. Generate alert-prioritized briefing → save snapshot to `{skill_base_dir}/data/last-run.json`
 
 ## Alert Rules
 

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -34,11 +34,11 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 
 ## Input (First Run)
 
-Collect in ONE message: ✅ my_asins (1-10) + keyword | 💡 competitor_asins (up to 20) | 📌 alert_preferences.
+Collect in ONE message: ✅ my_asins (1-10) | 💡 competitor_asins (up to 20) | 📌 alert_preferences. Optional: keyword, category. Category is auto-detected from first tracked ASIN if not provided.
 
 ## API Pitfalls (CRITICAL)
 
-1. **Category first**: MUST resolve categoryPath via `categories --keyword` before any data collection
+1. **Category auto-detection**: categoryPath is auto-detected from tracked ASINs. If `category_source` in output is `inferred_from_search`, confirm with user
 2. **All keyword-based endpoints MUST include `--category`**; ASIN-specific endpoints do NOT
 3. **Use API fields directly**: revenue=`sampleAvgMonthlyRevenue` (NEVER price×sales), sales=`monthlySalesFloor`, concentration=`sampleTop10BrandSalesRate`
 4. **reviews/analysis**: needs 50+ reviews
@@ -46,8 +46,7 @@ Collect in ONE message: ✅ my_asins (1-10) + keyword | 💡 competitor_asins (u
 
 ## Execution
 
-1. Resolve & lock categoryPath
-2. `daily-radar --asins "asin1,asin2,..." --keyword X --category Y` (composite, runs all endpoints)
+1. `daily-radar --asins "asin1,asin2,..." [--keyword X] [--category Y]` (composite, auto-detects category from ASINs)
 3. Compare against `data/last-run.json` for change detection (first run = baseline only, no alerts)
 4. Generate alert-prioritized briefing → save snapshot to `data/last-run.json`
 
@@ -70,15 +69,63 @@ Growth signal validation:
 - 🔍 Possible signal: 2-3 days of change
 - 💡 Single-day spike: could be promotion/restock
 
+### Change Interpretation Guide
+| Metric | Normal Range | Action Trigger | Likely Cause |
+|--------|-------------|----------------|-------------|
+| Price change | ±3% | >5% sustained 3+ days | Repricing strategy or promotion 🔍 |
+| BSR shift | ±15% daily | >30% sustained or >50% single day | Stockout, promotion, or algorithm change 🔍 |
+| Rating drop | ±0.1 | >0.2 in 7 days | Product quality issue or review attack 🔍 |
+| Review velocity | ±20% | >50% spike | Vine program, review manipulation, or viral moment 🔍 |
+| New entrant in Top 20 | 0-1/week | 3+ in one week | Market shift or seasonal demand 🔍 |
+
+### Action Recommendations by Alert Level
+- **🔴 RED**: Require immediate response — check inventory, match price if needed, investigate quality issues 💡
+- **🟡 YELLOW**: Monitor for 3-5 days before acting — may be temporary fluctuation 💡
+- **🟢 GREEN**: Opportunity window — act within 1-2 weeks before competitors notice 💡
+
 ## Output Spec
 
 First run: "Baseline Established" — KPI Dashboard (current snapshot) only, no alerts.
 
 Subsequent runs: Alert Summary → RED Alerts → YELLOW Alerts → GREEN Opportunities → KPI Dashboard (today vs yesterday) → Competitor Movement → Market Shifts → Action Items → Data Provenance → API Usage.
 
-Confidence labels: 📊 Data-backed | 🔍 Inferred | 💡 Directional. Strategy is NEVER 📊. Anomalies (>200% growth) always 💡. User criteria override AI judgment.
+### Language (required)
+
+Output language MUST match the user's input language. If the user asks in Chinese, the entire report is in Chinese. If in English, output in English. Exception: API field names (e.g. `monthlySalesFloor`, `categoryPath`), endpoint names, technical terms (e.g. ASIN, BSR, CR10, FBA, credits) remain in English.
+
+### Disclaimer (required, at the top of every report)
+
+> Data is based on APIClaw API sampling as of [date]. Monthly sales (`monthlySalesFloor`) are lower-bound estimates. This analysis is for reference only and should not be the sole basis for business decisions. Validate with additional sources before acting.
+
+### Confidence Labels (required, tag EVERY conclusion)
+
+- 📊 **Data-backed** — direct API data (e.g. "CR10 = 54.8% 📊")
+- 🔍 **Inferred** — logical reasoning from data (e.g. "brand concentration is moderate 🔍")
+- 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
+
+Rules: Strategy recommendations are NEVER 📊. Anomalies (>200% growth) are always 💡. User criteria override AI judgment.
 
 Sample bias: "Based on Top [N] by sales volume; niche/new products may be underrepresented."
+
+### Data Provenance (required)
+
+Include a table at the end of every report:
+
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+| (e.g. Market Overview) | `markets/search` | categoryPath, topN=10 | 📊 Top N sampling, sales are lower-bound |
+| ... | ... | ... | ... |
+
+Extract endpoint and params from `_query` in JSON output. Add notes: sampling method, T+1 delay, realtime vs DB, minimum review threshold, etc.
+
+### API Usage (required)
+
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+| (each endpoint used) | N | N |
+| **Total** | **N** | **N** |
+
+Extract from `meta.creditsConsumed` per response. End with `Credits remaining: N`.
 
 ## API Budget: ~15-30 credits
 

--- a/amazon-daily-market-radar/scripts/apiclaw.py
+++ b/amazon-daily-market-radar/scripts/apiclaw.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import sys
+import random
 import time
 import urllib.request
 import urllib.error
@@ -35,9 +36,15 @@ import urllib.error
 
 BASE_URL = "https://api.apiclaw.io/openapi/v2"  # APIClaw API base URL
 API_DOCS = "https://api.apiclaw.io/api-docs"   # API documentation URL
-MAX_RETRIES = 2       # Maximum number of retry attempts for failed requests
-RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on 429 (rate limit)
+MAX_RETRIES = 3       # Maximum number of retry attempts for failed requests
+RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
+RATE_LIMIT_RETRIES = 4  # Extra retries specifically for 429 rate limits
+RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
+MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
+
+# Global request pacer — prevents burst rate limit violations
+_last_request_time = 0.0
 
 # 13 built-in product selection modes
 # Each maps to a set of products/search filter parameters
@@ -110,6 +117,8 @@ def api_call(endpoint: str, params: dict) -> dict:
     Returns the parsed JSON response on success, with _query metadata injected.
     Exits with a clear error message on failure.
     """
+    global _last_request_time
+
     url = f"{BASE_URL}/{endpoint}"
     api_key = get_api_key()
 
@@ -131,8 +140,16 @@ def api_call(endpoint: str, params: dict) -> dict:
         "User-Agent": "APIClaw-CLI/1.0 (Python)",
     }
 
+    # Rate-limit pacing: enforce minimum interval between requests
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < MIN_REQUEST_INTERVAL:
+        time.sleep(MIN_REQUEST_INTERVAL - elapsed)
+
     delay = RETRY_DELAY
-    for attempt in range(1, MAX_RETRIES + 1):
+    max_attempts = MAX_RETRIES
+    for attempt in range(1, max_attempts + 1):
+        _last_request_time = time.monotonic()
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
@@ -163,9 +180,15 @@ def api_call(endpoint: str, params: dict) -> dict:
                     "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
                     endpoint, actual_params)
             elif status == 429:
-                if attempt < MAX_RETRIES:
-                    print(f"Rate limited (429). Waiting {delay}s before retry {attempt}/{MAX_RETRIES}...", file=sys.stderr)
-                    time.sleep(delay)
+                # Switch to longer retry strategy for rate limits
+                if attempt == 1:
+                    max_attempts = RATE_LIMIT_RETRIES
+                    delay = RATE_LIMIT_DELAY
+                if attempt < max_attempts:
+                    jitter = random.uniform(0, delay * 0.25)
+                    wait = delay + jitter
+                    print(f"Rate limited (429). Waiting {wait:.1f}s before retry {attempt}/{max_attempts}...", file=sys.stderr)
+                    time.sleep(wait)
                     delay *= 2
                     continue
                 else:
@@ -177,17 +200,17 @@ def api_call(endpoint: str, params: dict) -> dict:
                     f"Check {API_DOCS} for current endpoints",
                     endpoint, actual_params)
             else:
-                if attempt < MAX_RETRIES:
-                    print(f"HTTP {status}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                if attempt < max_attempts:
+                    print(f"HTTP {status}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                     time.sleep(delay)
                     continue
                 else:
-                    return _error_result(status, f"HTTP {status} after {MAX_RETRIES} attempts",
+                    return _error_result(status, f"HTTP {status} after {max_attempts} attempts",
                         "Check network or try again later",
                         endpoint, actual_params)
         except Exception as e:
-            if attempt < MAX_RETRIES:
-                print(f"Request failed: {e}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+            if attempt < max_attempts:
+                print(f"Request failed: {e}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                 time.sleep(delay)
                 continue
             else:
@@ -196,6 +219,94 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
 
     return _error_result(0, "Unexpected retry loop exit", "This should not happen", endpoint, actual_params)
+
+
+def _filter_review_insights(result, label_type):
+    """Return a shallow copy of a reviews/analysis result filtered to one labelType."""
+    if not result.get("data") or not result["data"].get("consumerInsights"):
+        return result
+    filtered = dict(result)
+    filtered["data"] = dict(result["data"])
+    filtered["data"]["consumerInsights"] = [
+        i for i in result["data"]["consumerInsights"]
+        if i.get("labelType") == label_type
+    ]
+    return filtered
+
+
+def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
+    """
+    Resolve categoryPath with multi-level fallback.
+    Returns (category_path, category_source) tuple.
+
+    Priority:
+      1. keyword → categories API
+      2. asin → realtime/product → categoryPath or bestsellersRank leaf
+      3. keyword → products/search → first result → realtime/product
+    """
+    category_path = None
+    category_source = "user"
+
+    # Priority 1: keyword → categories
+    if keyword:
+        log_fn("Step 0: Resolving category...")
+        cat_result = api_caller("categories", {"categoryKeyword": keyword}, "categories")
+        if results is not None:
+            results["categories"] = cat_result
+        cat_data = cat_result.get("data", [])
+        if cat_data:
+            category_path = cat_data[0].get("categoryPath")
+            category_source = "keyword"
+
+    # Priority 2: asin → realtime/product
+    if not category_path and asin:
+        log_fn("  → Resolving category from ASIN...")
+        rt = api_caller("realtime/product", {"asin": asin, "marketplace": "US"}, f"realtime {asin}")
+        if results is not None:
+            results.setdefault("_asin_realtime", rt)
+        rt_data = rt.get("data", {}) or {}
+        if rt_data.get("categoryPath"):
+            category_path = rt_data["categoryPath"]
+            category_source = "asin_realtime"
+            log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif rt_data.get("bestsellersRank"):
+            leaf = rt_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log_fn(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "asin_bsr"
+                    log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+
+    # Priority 3: keyword → search → first product → realtime
+    if not category_path and keyword:
+        log_fn("  → Resolving category from top search result...")
+        prod_result = api_caller("products/search", {
+            "keyword": keyword, "sortBy": "monthlySalesFloor", "sortOrder": "desc", "pageSize": 5
+        }, "products (category probe)")
+        prod_data = prod_result.get("data", [])
+        if isinstance(prod_data, list) and prod_data:
+            probe_asin = prod_data[0].get("asin")
+            if probe_asin:
+                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+                rt_data = rt.get("data", {}) or {}
+                if rt_data.get("categoryPath"):
+                    category_path = rt_data["categoryPath"]
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+                elif rt_data.get("bestsellersRank"):
+                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
+                    if leaf:
+                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                        cat_data = cat_result.get("data", [])
+                        if cat_data:
+                            category_path = cat_data[0].get("categoryPath")
+                            category_source = "inferred_from_search"
+                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+
+    return category_path, category_source
 
 
 def _error_result(status: int, message: str, action: str, endpoint: str, params: dict) -> dict:
@@ -344,9 +455,9 @@ def cmd_products(args):
     if args.fulfillment:
         params["fulfillments"] = args.fulfillment
     if args.include_brands:
-        params["includeBrands"] = args.include_brands
+        params["includeBrands"] = [b.strip() for b in args.include_brands.split(",")]
     if args.exclude_brands:
-        params["excludeBrands"] = args.exclude_brands
+        params["excludeBrands"] = [b.strip() for b in args.exclude_brands.split(",")]
 
     params["sortBy"] = args.sort or "monthlySalesFloor"
     params["sortOrder"] = args.order or "desc"
@@ -453,7 +564,7 @@ def cmd_report(args):
     print("Step 3/4: Searching top products...", file=sys.stderr)
     products_result = api_call("products/search", {
         "keyword": keyword,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 50,
     })
@@ -508,7 +619,7 @@ def cmd_opportunity(args):
         "keyword": keyword,
         "monthlySalesMin": 300,
         "ratingCountMax": 50,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 20,
     }
@@ -565,17 +676,9 @@ def cmd_market_entry(args):
         return r
 
     # ── Step 0.5: Category Resolution ──
-    if not category_path and keyword:
-        log("Step 0.5: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked category: {' > '.join(category_path)}")
-        else:
-            log("  ⚠️ No category match, will use keyword-only queries")
-
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # ── Step 1: Market Landscape (3 calls) ──
@@ -744,43 +847,36 @@ def cmd_market_entry(args):
     review_results = {}
     label_types = ["painPoints", "buyingFactors", "improvements"]
 
-    # Priority 1: Category mode
-    category_mode_success = True
+    # Priority 1: Category mode (single call, split client-side)
+    category_mode_success = False
     if category_path:
-        for lt in label_types:
-            log(f"  → reviews/analysis category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path,
-                "mode": "category",
-                "labelType": lt,
-                "period": "6m",
-            }, f"reviews {lt}")
-            if r.get("success") is False or not r.get("data", {}).get("consumerInsights"):
-                category_mode_success = False
-                log(f"  ⚠️ Category mode failed for {lt}")
-                break
-            review_results[lt] = r
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path,
+            "mode": "category",
+            "period": "6m",
+        }, "reviews category")
+        if r.get("success") and r.get("data", {}).get("consumerInsights"):
+            category_mode_success = True
+            for lt in label_types:
+                review_results[lt] = _filter_review_insights(r, lt)
 
     # Priority 2: ASIN mode (if category failed)
-    if not category_mode_success or not category_path:
+    if not category_mode_success:
         log("  → Falling back to ASIN mode...")
-        # Pick ASINs with ratingCount >= 50
         review_asins = [p.get("asin") for p in all_products if (p.get("ratingCount") or 0) >= 50][:3]
         if review_asins:
+            log(f"  → reviews/analysis ASIN mode ({review_asins})")
+            r = safe_call("reviews/analysis", {
+                "asins": review_asins,
+                "mode": "asin",
+                "period": "6m",
+            }, "reviews ASIN")
             for lt in label_types:
-                if lt in review_results:
-                    continue
-                log(f"  → reviews/analysis ASIN mode: {lt} ({review_asins})")
-                r = safe_call("reviews/analysis", {
-                    "asins": review_asins,
-                    "mode": "asin",
-                    "labelType": lt,
-                    "period": "6m",
-                }, f"reviews ASIN {lt}")
-                review_results[lt] = r
+                review_results[lt] = _filter_review_insights(r, lt)
 
     results["reviews"] = review_results
-    results["meta"]["review_mode"] = "category" if category_mode_success and category_path else "asin"
+    results["meta"]["review_mode"] = "category" if category_mode_success else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
 
     # ── Summary ──
@@ -819,14 +915,9 @@ def cmd_competitor_analysis(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
-    results["meta"]["resolved_category"] = category_path
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
 
     # Step 1: Competitor Discovery
     log("Step 1/7: Competitor discovery...")
@@ -844,6 +935,7 @@ def cmd_competitor_analysis(args):
     if category_path:
         comp_params["categoryPath"] = category_path
     results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    results["meta"]["resolved_category"] = category_path
     results["meta"]["steps_completed"].append("competitor_discovery")
 
     # Step 2: Market Context
@@ -931,16 +1023,17 @@ def cmd_competitor_analysis(args):
     review_results = {}
     for asin in top_asins[:5]:
         r = safe_call("reviews/analysis", {
-            "asins": [asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [asin], "mode": "asin", "period": "6m"
         }, f"reviews {asin}")
         if r.get("data") and r.get("data", {}).get("consumerInsights"):
             review_results[asin] = r
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -955,7 +1048,7 @@ def cmd_competitor_analysis(args):
                 bp["keyword"] = keyword
             if category_path:
                 bp["categoryPath"] = category_path
-            bp["includeBrands"] = top_brand
+            bp["includeBrands"] = [top_brand]
             results["top_brand_products"] = safe_call("products/search", bp, f"brand {top_brand}")
     results["meta"]["steps_completed"].append("brand_drilldown")
 
@@ -969,6 +1062,7 @@ def cmd_pricing_analysis(args):
     """
     Composite workflow: Pricing Analysis.
     Runs: realtime(my_asin) → price-band → products/competitors → market/brand → history → realtime(top5) → reviews
+    Category is auto-detected from ASIN if not provided.
     """
     my_asin = args.my_asin
     keyword = args.keyword
@@ -976,9 +1070,6 @@ def cmd_pricing_analysis(args):
 
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
-        sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
         sys.exit(1)
 
     category_path = parse_category(category) if category else None
@@ -993,21 +1084,40 @@ def cmd_pricing_analysis(args):
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
         return r
 
-    # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
-    results["meta"]["resolved_category"] = category_path
-
     # Step 1: Current Price Snapshot
     log("Step 1/8: Current price snapshot...")
     results["my_product"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
+    my_data = results["my_product"].get("data", {}) or {}
+    if not my_data.get("title"):
+        log(f"\n❌ ASIN '{my_asin}' not found or has no data. Please check the ASIN and try again.")
+        results["error"] = {"code": "ASIN_NOT_FOUND", "message": f"ASIN '{my_asin}' not found or returned empty data"}
+        output(results, args.format)
+        return
     results["meta"]["steps_completed"].append("price_snapshot")
+
+    # Step 1.5: Auto Category Detection
+    if not category_path:
+        # For pricing, we already have realtime data — extract directly first
+        if my_data.get("categoryPath"):
+            category_path = my_data["categoryPath"]
+            results["meta"]["category_source"] = "asin_realtime"
+            log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif my_data.get("bestsellersRank"):
+            leaf = my_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = safe_call("categories", {"categoryKeyword": leaf}, "categories")
+                results["categories"] = cat_result
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    results["meta"]["category_source"] = "asin_bsr"
+                    log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        # Fallback to keyword
+        if not category_path and keyword:
+            category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+            results["meta"]["category_source"] = category_source
+    results["meta"]["resolved_category"] = category_path
 
     # Step 2: Price Band Intelligence
     log("Step 2/8: Price band intelligence...")
@@ -1110,17 +1220,18 @@ def cmd_pricing_analysis(args):
     my_rc = results["my_product"].get("data", {}).get("ratingCount", 0)
     if my_rc and my_rc >= 50:
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if comp_asins:
         review_results["top_comp"] = safe_call("reviews/analysis", {
-            "asins": [comp_asins[0]], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [comp_asins[0]], "mode": "asin", "period": "6m"
         }, f"reviews {comp_asins[0]}")
     if not review_results and category_path:
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_context")
 
@@ -1157,9 +1268,6 @@ def cmd_daily_radar(args):
     if not asins_str:
         print("ERROR: --asins is required (comma-separated ASINs to track).", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     tracked_asins = [a.strip() for a in asins_str.split(",") if a.strip()]
     category_path = parse_category(category) if category else None
@@ -1175,14 +1283,10 @@ def cmd_daily_radar(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=tracked_asins[0] if tracked_asins else None, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
@@ -1292,10 +1396,9 @@ def cmd_daily_radar(args):
             r = safe_call("reviews/analysis", {
                 "asins": [review_asin],
                 "mode": "asin",
-                "labelType": "painPoints",
                 "period": "6m",
             }, f"reviews {review_asin}")
-            review_results["painPoints"] = r
+            review_results["painPoints"] = _filter_review_insights(r, "painPoints")
             break
     
     if not review_results:
@@ -1324,9 +1427,6 @@ def cmd_listing_audit(args):
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     category_path = parse_category(category) if category else None
     results = {"meta": {"my_asin": my_asin, "keyword": keyword, "category": category, "steps_completed": []}}
@@ -1341,14 +1441,10 @@ def cmd_listing_audit(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Audit Target
@@ -1451,21 +1547,22 @@ def cmd_listing_audit(args):
     if target_rc and target_rc >= 50:
         log(f"  → reviews/analysis ASIN mode: {my_asin}")
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if leader_asins:
         top_leader = leader_asins[0]
         log(f"  → reviews/analysis ASIN mode: {top_leader}")
         review_results["top_leader"] = safe_call("reviews/analysis", {
-            "asins": [top_leader], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [top_leader], "mode": "asin", "period": "6m"
         }, f"reviews {top_leader}")
     # Category fallback
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors", "improvements"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews category {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -1538,14 +1635,9 @@ def cmd_opportunity_scan(args):
         return r
 
     # Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Product Scan (mode-based + custom filters)
@@ -1684,23 +1776,22 @@ def cmd_opportunity_scan(args):
     log("Step 6/6: Consumer insights...")
     review_results = {}
     if category_path:
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
-            log(f"  → category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            if r.get("data") and r.get("data", {}).get("consumerInsights"):
-                review_results[lt] = r
-            else:
-                break
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
+        if r.get("data") and r.get("data", {}).get("consumerInsights"):
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     if not review_results:
         log("  → Falling back to ASIN mode...")
         review_asins = [a for a in top_asins[:3]]
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
+        if review_asins:
             r = safe_call("reviews/analysis", {
-                "asins": review_asins, "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews ASIN {lt}")
-            review_results[lt] = r
+                "asins": review_asins, "mode": "asin", "period": "6m"
+            }, "reviews ASIN")
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["review_mode"] = "category" if category_path and review_results.get("painPoints", {}).get("data", {}).get("consumerInsights") else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
@@ -1743,13 +1834,9 @@ def cmd_review_deepdive(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=target_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Target Identification
@@ -1775,26 +1862,25 @@ def cmd_review_deepdive(args):
     log("Step 2/5: Full review analysis (11 dimensions)...")
     label_types = ["painPoints", "positives", "buyingFactors", "improvements", "userProfiles",
                    "scenarios", "issues", "keywords", "usageTimes", "usageLocations", "behaviors"]
-    
+
     review_results = {}
-    # Target ASIN reviews
+    # Target ASIN reviews (single call, split client-side)
     if target_asin:
+        log(f"  → {target_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [target_asin], "mode": "asin", "period": "6m"
+        }, "reviews target")
         for lt in label_types:
-            log(f"  → {target_asin}: {lt}")
-            r = safe_call("reviews/analysis", {
-                "asins": [target_asin], "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            review_results[f"target_{lt}"] = r
-    
-    # Competitor comparison (top 2)
+            review_results[f"target_{lt}"] = _filter_review_insights(r, lt)
+
+    # Competitor comparison (top 2, single call each)
     for comp_asin in comp_asins[:2]:
-        log(f"  → Competitor {comp_asin}: painPoints + positives")
-        review_results[f"comp_{comp_asin}_painPoints"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+        log(f"  → Competitor {comp_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [comp_asin], "mode": "asin", "period": "6m"
         }, f"reviews comp {comp_asin}")
-        review_results[f"comp_{comp_asin}_positives"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "positives", "period": "6m"
-        }, f"reviews comp+ {comp_asin}")
+        review_results[f"comp_{comp_asin}_painPoints"] = _filter_review_insights(r, "painPoints")
+        review_results[f"comp_{comp_asin}_positives"] = _filter_review_insights(r, "positives")
     
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_analysis")
@@ -1960,12 +2046,19 @@ def cmd_analyze(args):
         print("ERROR: --asin, --asins, or --category is required.", file=sys.stderr)
         sys.exit(1)
 
-    if args.label_type:
-        params["labelType"] = args.label_type
     if args.period:
         params["period"] = args.period
 
     result = api_call("reviews/analysis", params)
+
+    # Client-side filtering by label type (v2 API returns all dimensions in one call)
+    if args.label_type and result.get("data") and result["data"].get("consumerInsights"):
+        requested = [t.strip() for t in args.label_type.split(",")]
+        result["data"]["consumerInsights"] = [
+            i for i in result["data"]["consumerInsights"]
+            if i.get("labelType") in requested
+        ]
+
     output(result, args.format)
 
 
@@ -2246,7 +2339,12 @@ Examples:
     p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+        print(f"ERROR: Unrecognized argument(s): {' '.join(unknown)}", file=sys.stderr)
+        print(f"Run 'apiclaw.py {cmd} --help' to see valid options.", file=sys.stderr)
+        sys.exit(1)
     args.func(args)
 
 

--- a/amazon-daily-market-radar/scripts/apiclaw.py
+++ b/amazon-daily-market-radar/scripts/apiclaw.py
@@ -234,6 +234,25 @@ def _filter_review_insights(result, label_type):
     return filtered
 
 
+def _fetch_all_history(api_caller, asins, start_date, end_date, log_fn=None):
+    """Fetch products/history for multiple ASINs (one API call per ASIN)."""
+    all_data = []
+    last_response = None
+    for asin in asins:
+        r = api_caller("products/history", {
+            "asin": asin, "startDate": start_date, "endDate": end_date,
+        }, f"history {asin}")
+        last_response = r
+        if r.get("data"):
+            all_data.append(r["data"])
+        elif log_fn:
+            log_fn(f"  ⚠️ No history data for {asin}")
+    if last_response is None:
+        return {"success": False, "data": [], "error": {"message": "No ASINs provided"}}
+    last_response["data"] = all_data
+    return last_response
+
+
 def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
     """
     Resolve categoryPath with multi-level fallback.
@@ -818,11 +837,7 @@ def cmd_market_entry(args):
     round1_asins = top_asins[:3]
     if round1_asins:
         tried_asins.update(round1_asins)
-        r = safe_call("products/history", {
-            "asins": round1_asins,
-            "startDate": thirty_days_ago,
-            "endDate": today,
-        }, "history round 1")
+        r = _fetch_all_history(safe_call, round1_asins, thirty_days_ago, today, log_fn=log)
         history_data = r.get("data", [])
 
     # Round 2: Try oldest products if round 1 was empty
@@ -831,11 +846,7 @@ def cmd_market_entry(args):
         if round2_asins:
             log(f"  → Round 1 empty, trying older ASINs: {round2_asins}")
             tried_asins.update(round2_asins)
-            r = safe_call("products/history", {
-                "asins": round2_asins,
-                "startDate": thirty_days_ago,
-                "endDate": today,
-            }, "history round 2")
+            r = _fetch_all_history(safe_call, round2_asins, thirty_days_ago, today, log_fn=log)
             history_data = r.get("data", [])
 
     results["product_history"] = {"data": history_data, "asins_tried": list(tried_asins)}
@@ -1012,9 +1023,7 @@ def cmd_competitor_analysis(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = ([my_asin] if my_asin else []) + top_asins[:5]
-    r = safe_call("products/history", {
-        "asins": history_asins[:8], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins[:8], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins[:8]}
     results["meta"]["steps_completed"].append("historical_trends")
 
@@ -1198,9 +1207,7 @@ def cmd_pricing_analysis(args):
             break
 
     history_asins = [my_asin] + comp_asins
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("price_trends")
 
@@ -1308,11 +1315,7 @@ def cmd_daily_radar(args):
     tried_asins = set()
     
     # Round 1: All tracked ASINs
-    r = safe_call("products/history", {
-        "asins": tracked_asins,
-        "startDate": seven_days_ago,
-        "endDate": today,
-    }, "history round 1")
+    r = _fetch_all_history(safe_call, tracked_asins, seven_days_ago, today, log_fn=log)
     history_data = r.get("data", [])
     tried_asins.update(tracked_asins)
 
@@ -1571,9 +1574,7 @@ def cmd_listing_audit(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = [my_asin] + leader_asins[:2]
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("trend_context")
 
@@ -1766,9 +1767,7 @@ def cmd_opportunity_scan(args):
     log("Step 5/6: Trend check...")
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
-    r = safe_call("products/history", {
-        "asins": top_asins[:5], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, top_asins[:5], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": top_asins[:5]}
     results["meta"]["steps_completed"].append("trend_check")
 
@@ -1942,9 +1941,7 @@ def cmd_review_deepdive(args):
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     hist_asins = [target_asin] + comp_asins[:2] if target_asin else comp_asins[:3]
     if hist_asins:
-        r = safe_call("products/history", {
-            "asins": hist_asins, "startDate": thirty_ago, "endDate": today
-        }, "history")
+        r = _fetch_all_history(safe_call, hist_asins, thirty_ago, today, log_fn=log)
         results["product_history"] = {"data": r.get("data", []), "asins_tried": hist_asins}
     results["meta"]["steps_completed"].append("price_trend_context")
 
@@ -2119,12 +2116,11 @@ def cmd_brand_detail(args):
 def cmd_product_history(args):
     """Get historical data (price, BSR, sales) for ASINs over a date range."""
     asins = [a.strip() for a in args.asins.split(",")]
-    params = {
-        "asins": asins,
-        "startDate": args.start_date,
-        "endDate": args.end_date,
-    }
-    result = api_call("products/history", params)
+
+    def _api_caller(endpoint, p, label=""):
+        return api_call(endpoint, p)
+
+    result = _fetch_all_history(_api_caller, asins, args.start_date, args.end_date)
     output(result, args.format)
 
 

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -25,8 +25,8 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 
 | File | Purpose |
 |------|---------|
-| `scripts/apiclaw.py` | **Execute** for all API calls (run `--help` for params) |
-| `references/reference.md` | Load for exact field names or response structure |
+| `{skill_base_dir}/scripts/apiclaw.py` | **Execute** for all API calls (run `--help` for params) |
+| `{skill_base_dir}/references/reference.md` | Load for exact field names or response structure |
 
 ## Credential
 

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -34,11 +34,11 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 
 ## Input
 
-Required: my_asin + keyword. Collect missing inputs in ONE message.
+Required: my_asin. Optional: keyword, category. Category is auto-detected from ASIN via `realtime/product` if not provided. If `category_source` is `inferred_from_search`, confirm with user before proceeding.
 
 ## API Pitfalls (CRITICAL)
 
-1. **Category first**: MUST resolve categoryPath via `categories --keyword` before data collection
+1. **Category auto-detection**: categoryPath is auto-detected from ASIN. If `category_source` in output is `inferred_from_search`, confirm with user
 2. **All keyword-based endpoints MUST include `--category`**; ASIN-specific endpoints do NOT
 3. **Use API fields directly**: revenue=`sampleAvgMonthlyRevenue` (NEVER price×sales), sales=`monthlySalesFloor`, opportunity=`sampleOpportunityIndex`
 4. **reviews/analysis**: needs 50+ reviews; ASIN mode first, category fallback
@@ -46,8 +46,7 @@ Required: my_asin + keyword. Collect missing inputs in ONE message.
 
 ## Execution
 
-1. Resolve & lock categoryPath
-2. `listing-audit --my-asin X --keyword Y --category Z` (composite, runs all endpoints automatically)
+1. `listing-audit --my-asin X [--keyword Y] [--category Z]` (composite, auto-detects category from ASIN)
 3. Score 8 dimensions → generate report with improvements
 
 ## 8 Scoring Dimensions
@@ -71,9 +70,43 @@ Sections: Overall Score (X/100, A-F grade) → 8-Dimension Scorecard → Title A
 
 Suggested rewrites should incorporate high-frequency positive review language.
 
-Confidence labels: 📊 Data-backed | 🔍 Inferred | 💡 Directional. Strategy is NEVER 📊. User criteria override AI judgment.
+### Language (required)
+
+Output language MUST match the user's input language. If the user asks in Chinese, the entire report is in Chinese. If in English, output in English. Exception: API field names (e.g. `monthlySalesFloor`, `categoryPath`), endpoint names, technical terms (e.g. ASIN, BSR, CR10, FBA, credits) remain in English.
+
+### Disclaimer (required, at the top of every report)
+
+> Data is based on APIClaw API sampling as of [date]. Monthly sales (`monthlySalesFloor`) are lower-bound estimates. This analysis is for reference only and should not be the sole basis for business decisions. Validate with additional sources before acting.
+
+### Confidence Labels (required, tag EVERY conclusion)
+
+- 📊 **Data-backed** — direct API data (e.g. "CR10 = 54.8% 📊")
+- 🔍 **Inferred** — logical reasoning from data (e.g. "brand concentration is moderate 🔍")
+- 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
+
+Rules: Strategy recommendations are NEVER 📊. User criteria override AI judgment.
 
 Bulk audit: share market data across ASINs, run audit per ASIN.
+
+### Data Provenance (required)
+
+Include a table at the end of every report:
+
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+| (e.g. Market Overview) | `markets/search` | categoryPath, topN=10 | 📊 Top N sampling, sales are lower-bound |
+| ... | ... | ... | ... |
+
+Extract endpoint and params from `_query` in JSON output. Add notes: sampling method, T+1 delay, realtime vs DB, minimum review threshold, etc.
+
+### API Usage (required)
+
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+| (each endpoint used) | N | N |
+| **Total** | **N** | **N** |
+
+Extract from `meta.creditsConsumed` per response. End with `Credits remaining: N`.
 
 ## API Budget: ~20-25 credits
 

--- a/amazon-listing-audit-pro/scripts/apiclaw.py
+++ b/amazon-listing-audit-pro/scripts/apiclaw.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import sys
+import random
 import time
 import urllib.request
 import urllib.error
@@ -35,9 +36,15 @@ import urllib.error
 
 BASE_URL = "https://api.apiclaw.io/openapi/v2"  # APIClaw API base URL
 API_DOCS = "https://api.apiclaw.io/api-docs"   # API documentation URL
-MAX_RETRIES = 2       # Maximum number of retry attempts for failed requests
-RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on 429 (rate limit)
+MAX_RETRIES = 3       # Maximum number of retry attempts for failed requests
+RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
+RATE_LIMIT_RETRIES = 4  # Extra retries specifically for 429 rate limits
+RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
+MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
+
+# Global request pacer — prevents burst rate limit violations
+_last_request_time = 0.0
 
 # 13 built-in product selection modes
 # Each maps to a set of products/search filter parameters
@@ -110,6 +117,8 @@ def api_call(endpoint: str, params: dict) -> dict:
     Returns the parsed JSON response on success, with _query metadata injected.
     Exits with a clear error message on failure.
     """
+    global _last_request_time
+
     url = f"{BASE_URL}/{endpoint}"
     api_key = get_api_key()
 
@@ -131,8 +140,16 @@ def api_call(endpoint: str, params: dict) -> dict:
         "User-Agent": "APIClaw-CLI/1.0 (Python)",
     }
 
+    # Rate-limit pacing: enforce minimum interval between requests
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < MIN_REQUEST_INTERVAL:
+        time.sleep(MIN_REQUEST_INTERVAL - elapsed)
+
     delay = RETRY_DELAY
-    for attempt in range(1, MAX_RETRIES + 1):
+    max_attempts = MAX_RETRIES
+    for attempt in range(1, max_attempts + 1):
+        _last_request_time = time.monotonic()
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
@@ -163,9 +180,15 @@ def api_call(endpoint: str, params: dict) -> dict:
                     "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
                     endpoint, actual_params)
             elif status == 429:
-                if attempt < MAX_RETRIES:
-                    print(f"Rate limited (429). Waiting {delay}s before retry {attempt}/{MAX_RETRIES}...", file=sys.stderr)
-                    time.sleep(delay)
+                # Switch to longer retry strategy for rate limits
+                if attempt == 1:
+                    max_attempts = RATE_LIMIT_RETRIES
+                    delay = RATE_LIMIT_DELAY
+                if attempt < max_attempts:
+                    jitter = random.uniform(0, delay * 0.25)
+                    wait = delay + jitter
+                    print(f"Rate limited (429). Waiting {wait:.1f}s before retry {attempt}/{max_attempts}...", file=sys.stderr)
+                    time.sleep(wait)
                     delay *= 2
                     continue
                 else:
@@ -177,17 +200,17 @@ def api_call(endpoint: str, params: dict) -> dict:
                     f"Check {API_DOCS} for current endpoints",
                     endpoint, actual_params)
             else:
-                if attempt < MAX_RETRIES:
-                    print(f"HTTP {status}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                if attempt < max_attempts:
+                    print(f"HTTP {status}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                     time.sleep(delay)
                     continue
                 else:
-                    return _error_result(status, f"HTTP {status} after {MAX_RETRIES} attempts",
+                    return _error_result(status, f"HTTP {status} after {max_attempts} attempts",
                         "Check network or try again later",
                         endpoint, actual_params)
         except Exception as e:
-            if attempt < MAX_RETRIES:
-                print(f"Request failed: {e}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+            if attempt < max_attempts:
+                print(f"Request failed: {e}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                 time.sleep(delay)
                 continue
             else:
@@ -196,6 +219,94 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
 
     return _error_result(0, "Unexpected retry loop exit", "This should not happen", endpoint, actual_params)
+
+
+def _filter_review_insights(result, label_type):
+    """Return a shallow copy of a reviews/analysis result filtered to one labelType."""
+    if not result.get("data") or not result["data"].get("consumerInsights"):
+        return result
+    filtered = dict(result)
+    filtered["data"] = dict(result["data"])
+    filtered["data"]["consumerInsights"] = [
+        i for i in result["data"]["consumerInsights"]
+        if i.get("labelType") == label_type
+    ]
+    return filtered
+
+
+def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
+    """
+    Resolve categoryPath with multi-level fallback.
+    Returns (category_path, category_source) tuple.
+
+    Priority:
+      1. keyword → categories API
+      2. asin → realtime/product → categoryPath or bestsellersRank leaf
+      3. keyword → products/search → first result → realtime/product
+    """
+    category_path = None
+    category_source = "user"
+
+    # Priority 1: keyword → categories
+    if keyword:
+        log_fn("Step 0: Resolving category...")
+        cat_result = api_caller("categories", {"categoryKeyword": keyword}, "categories")
+        if results is not None:
+            results["categories"] = cat_result
+        cat_data = cat_result.get("data", [])
+        if cat_data:
+            category_path = cat_data[0].get("categoryPath")
+            category_source = "keyword"
+
+    # Priority 2: asin → realtime/product
+    if not category_path and asin:
+        log_fn("  → Resolving category from ASIN...")
+        rt = api_caller("realtime/product", {"asin": asin, "marketplace": "US"}, f"realtime {asin}")
+        if results is not None:
+            results.setdefault("_asin_realtime", rt)
+        rt_data = rt.get("data", {}) or {}
+        if rt_data.get("categoryPath"):
+            category_path = rt_data["categoryPath"]
+            category_source = "asin_realtime"
+            log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif rt_data.get("bestsellersRank"):
+            leaf = rt_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log_fn(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "asin_bsr"
+                    log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+
+    # Priority 3: keyword → search → first product → realtime
+    if not category_path and keyword:
+        log_fn("  → Resolving category from top search result...")
+        prod_result = api_caller("products/search", {
+            "keyword": keyword, "sortBy": "monthlySalesFloor", "sortOrder": "desc", "pageSize": 5
+        }, "products (category probe)")
+        prod_data = prod_result.get("data", [])
+        if isinstance(prod_data, list) and prod_data:
+            probe_asin = prod_data[0].get("asin")
+            if probe_asin:
+                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+                rt_data = rt.get("data", {}) or {}
+                if rt_data.get("categoryPath"):
+                    category_path = rt_data["categoryPath"]
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+                elif rt_data.get("bestsellersRank"):
+                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
+                    if leaf:
+                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                        cat_data = cat_result.get("data", [])
+                        if cat_data:
+                            category_path = cat_data[0].get("categoryPath")
+                            category_source = "inferred_from_search"
+                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+
+    return category_path, category_source
 
 
 def _error_result(status: int, message: str, action: str, endpoint: str, params: dict) -> dict:
@@ -344,9 +455,9 @@ def cmd_products(args):
     if args.fulfillment:
         params["fulfillments"] = args.fulfillment
     if args.include_brands:
-        params["includeBrands"] = args.include_brands
+        params["includeBrands"] = [b.strip() for b in args.include_brands.split(",")]
     if args.exclude_brands:
-        params["excludeBrands"] = args.exclude_brands
+        params["excludeBrands"] = [b.strip() for b in args.exclude_brands.split(",")]
 
     params["sortBy"] = args.sort or "monthlySalesFloor"
     params["sortOrder"] = args.order or "desc"
@@ -453,7 +564,7 @@ def cmd_report(args):
     print("Step 3/4: Searching top products...", file=sys.stderr)
     products_result = api_call("products/search", {
         "keyword": keyword,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 50,
     })
@@ -508,7 +619,7 @@ def cmd_opportunity(args):
         "keyword": keyword,
         "monthlySalesMin": 300,
         "ratingCountMax": 50,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 20,
     }
@@ -565,17 +676,9 @@ def cmd_market_entry(args):
         return r
 
     # ── Step 0.5: Category Resolution ──
-    if not category_path and keyword:
-        log("Step 0.5: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked category: {' > '.join(category_path)}")
-        else:
-            log("  ⚠️ No category match, will use keyword-only queries")
-
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # ── Step 1: Market Landscape (3 calls) ──
@@ -744,43 +847,36 @@ def cmd_market_entry(args):
     review_results = {}
     label_types = ["painPoints", "buyingFactors", "improvements"]
 
-    # Priority 1: Category mode
-    category_mode_success = True
+    # Priority 1: Category mode (single call, split client-side)
+    category_mode_success = False
     if category_path:
-        for lt in label_types:
-            log(f"  → reviews/analysis category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path,
-                "mode": "category",
-                "labelType": lt,
-                "period": "6m",
-            }, f"reviews {lt}")
-            if r.get("success") is False or not r.get("data", {}).get("consumerInsights"):
-                category_mode_success = False
-                log(f"  ⚠️ Category mode failed for {lt}")
-                break
-            review_results[lt] = r
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path,
+            "mode": "category",
+            "period": "6m",
+        }, "reviews category")
+        if r.get("success") and r.get("data", {}).get("consumerInsights"):
+            category_mode_success = True
+            for lt in label_types:
+                review_results[lt] = _filter_review_insights(r, lt)
 
     # Priority 2: ASIN mode (if category failed)
-    if not category_mode_success or not category_path:
+    if not category_mode_success:
         log("  → Falling back to ASIN mode...")
-        # Pick ASINs with ratingCount >= 50
         review_asins = [p.get("asin") for p in all_products if (p.get("ratingCount") or 0) >= 50][:3]
         if review_asins:
+            log(f"  → reviews/analysis ASIN mode ({review_asins})")
+            r = safe_call("reviews/analysis", {
+                "asins": review_asins,
+                "mode": "asin",
+                "period": "6m",
+            }, "reviews ASIN")
             for lt in label_types:
-                if lt in review_results:
-                    continue
-                log(f"  → reviews/analysis ASIN mode: {lt} ({review_asins})")
-                r = safe_call("reviews/analysis", {
-                    "asins": review_asins,
-                    "mode": "asin",
-                    "labelType": lt,
-                    "period": "6m",
-                }, f"reviews ASIN {lt}")
-                review_results[lt] = r
+                review_results[lt] = _filter_review_insights(r, lt)
 
     results["reviews"] = review_results
-    results["meta"]["review_mode"] = "category" if category_mode_success and category_path else "asin"
+    results["meta"]["review_mode"] = "category" if category_mode_success else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
 
     # ── Summary ──
@@ -819,14 +915,9 @@ def cmd_competitor_analysis(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
-    results["meta"]["resolved_category"] = category_path
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
 
     # Step 1: Competitor Discovery
     log("Step 1/7: Competitor discovery...")
@@ -844,6 +935,7 @@ def cmd_competitor_analysis(args):
     if category_path:
         comp_params["categoryPath"] = category_path
     results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    results["meta"]["resolved_category"] = category_path
     results["meta"]["steps_completed"].append("competitor_discovery")
 
     # Step 2: Market Context
@@ -931,16 +1023,17 @@ def cmd_competitor_analysis(args):
     review_results = {}
     for asin in top_asins[:5]:
         r = safe_call("reviews/analysis", {
-            "asins": [asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [asin], "mode": "asin", "period": "6m"
         }, f"reviews {asin}")
         if r.get("data") and r.get("data", {}).get("consumerInsights"):
             review_results[asin] = r
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -955,7 +1048,7 @@ def cmd_competitor_analysis(args):
                 bp["keyword"] = keyword
             if category_path:
                 bp["categoryPath"] = category_path
-            bp["includeBrands"] = top_brand
+            bp["includeBrands"] = [top_brand]
             results["top_brand_products"] = safe_call("products/search", bp, f"brand {top_brand}")
     results["meta"]["steps_completed"].append("brand_drilldown")
 
@@ -969,6 +1062,7 @@ def cmd_pricing_analysis(args):
     """
     Composite workflow: Pricing Analysis.
     Runs: realtime(my_asin) → price-band → products/competitors → market/brand → history → realtime(top5) → reviews
+    Category is auto-detected from ASIN if not provided.
     """
     my_asin = args.my_asin
     keyword = args.keyword
@@ -976,9 +1070,6 @@ def cmd_pricing_analysis(args):
 
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
-        sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
         sys.exit(1)
 
     category_path = parse_category(category) if category else None
@@ -993,21 +1084,40 @@ def cmd_pricing_analysis(args):
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
         return r
 
-    # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
-    results["meta"]["resolved_category"] = category_path
-
     # Step 1: Current Price Snapshot
     log("Step 1/8: Current price snapshot...")
     results["my_product"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
+    my_data = results["my_product"].get("data", {}) or {}
+    if not my_data.get("title"):
+        log(f"\n❌ ASIN '{my_asin}' not found or has no data. Please check the ASIN and try again.")
+        results["error"] = {"code": "ASIN_NOT_FOUND", "message": f"ASIN '{my_asin}' not found or returned empty data"}
+        output(results, args.format)
+        return
     results["meta"]["steps_completed"].append("price_snapshot")
+
+    # Step 1.5: Auto Category Detection
+    if not category_path:
+        # For pricing, we already have realtime data — extract directly first
+        if my_data.get("categoryPath"):
+            category_path = my_data["categoryPath"]
+            results["meta"]["category_source"] = "asin_realtime"
+            log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif my_data.get("bestsellersRank"):
+            leaf = my_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = safe_call("categories", {"categoryKeyword": leaf}, "categories")
+                results["categories"] = cat_result
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    results["meta"]["category_source"] = "asin_bsr"
+                    log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        # Fallback to keyword
+        if not category_path and keyword:
+            category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+            results["meta"]["category_source"] = category_source
+    results["meta"]["resolved_category"] = category_path
 
     # Step 2: Price Band Intelligence
     log("Step 2/8: Price band intelligence...")
@@ -1110,17 +1220,18 @@ def cmd_pricing_analysis(args):
     my_rc = results["my_product"].get("data", {}).get("ratingCount", 0)
     if my_rc and my_rc >= 50:
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if comp_asins:
         review_results["top_comp"] = safe_call("reviews/analysis", {
-            "asins": [comp_asins[0]], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [comp_asins[0]], "mode": "asin", "period": "6m"
         }, f"reviews {comp_asins[0]}")
     if not review_results and category_path:
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_context")
 
@@ -1157,9 +1268,6 @@ def cmd_daily_radar(args):
     if not asins_str:
         print("ERROR: --asins is required (comma-separated ASINs to track).", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     tracked_asins = [a.strip() for a in asins_str.split(",") if a.strip()]
     category_path = parse_category(category) if category else None
@@ -1175,14 +1283,10 @@ def cmd_daily_radar(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=tracked_asins[0] if tracked_asins else None, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
@@ -1292,10 +1396,9 @@ def cmd_daily_radar(args):
             r = safe_call("reviews/analysis", {
                 "asins": [review_asin],
                 "mode": "asin",
-                "labelType": "painPoints",
                 "period": "6m",
             }, f"reviews {review_asin}")
-            review_results["painPoints"] = r
+            review_results["painPoints"] = _filter_review_insights(r, "painPoints")
             break
     
     if not review_results:
@@ -1324,9 +1427,6 @@ def cmd_listing_audit(args):
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     category_path = parse_category(category) if category else None
     results = {"meta": {"my_asin": my_asin, "keyword": keyword, "category": category, "steps_completed": []}}
@@ -1341,14 +1441,10 @@ def cmd_listing_audit(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Audit Target
@@ -1451,21 +1547,22 @@ def cmd_listing_audit(args):
     if target_rc and target_rc >= 50:
         log(f"  → reviews/analysis ASIN mode: {my_asin}")
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if leader_asins:
         top_leader = leader_asins[0]
         log(f"  → reviews/analysis ASIN mode: {top_leader}")
         review_results["top_leader"] = safe_call("reviews/analysis", {
-            "asins": [top_leader], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [top_leader], "mode": "asin", "period": "6m"
         }, f"reviews {top_leader}")
     # Category fallback
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors", "improvements"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews category {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -1538,14 +1635,9 @@ def cmd_opportunity_scan(args):
         return r
 
     # Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Product Scan (mode-based + custom filters)
@@ -1684,23 +1776,22 @@ def cmd_opportunity_scan(args):
     log("Step 6/6: Consumer insights...")
     review_results = {}
     if category_path:
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
-            log(f"  → category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            if r.get("data") and r.get("data", {}).get("consumerInsights"):
-                review_results[lt] = r
-            else:
-                break
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
+        if r.get("data") and r.get("data", {}).get("consumerInsights"):
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     if not review_results:
         log("  → Falling back to ASIN mode...")
         review_asins = [a for a in top_asins[:3]]
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
+        if review_asins:
             r = safe_call("reviews/analysis", {
-                "asins": review_asins, "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews ASIN {lt}")
-            review_results[lt] = r
+                "asins": review_asins, "mode": "asin", "period": "6m"
+            }, "reviews ASIN")
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["review_mode"] = "category" if category_path and review_results.get("painPoints", {}).get("data", {}).get("consumerInsights") else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
@@ -1743,13 +1834,9 @@ def cmd_review_deepdive(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=target_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Target Identification
@@ -1775,26 +1862,25 @@ def cmd_review_deepdive(args):
     log("Step 2/5: Full review analysis (11 dimensions)...")
     label_types = ["painPoints", "positives", "buyingFactors", "improvements", "userProfiles",
                    "scenarios", "issues", "keywords", "usageTimes", "usageLocations", "behaviors"]
-    
+
     review_results = {}
-    # Target ASIN reviews
+    # Target ASIN reviews (single call, split client-side)
     if target_asin:
+        log(f"  → {target_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [target_asin], "mode": "asin", "period": "6m"
+        }, "reviews target")
         for lt in label_types:
-            log(f"  → {target_asin}: {lt}")
-            r = safe_call("reviews/analysis", {
-                "asins": [target_asin], "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            review_results[f"target_{lt}"] = r
-    
-    # Competitor comparison (top 2)
+            review_results[f"target_{lt}"] = _filter_review_insights(r, lt)
+
+    # Competitor comparison (top 2, single call each)
     for comp_asin in comp_asins[:2]:
-        log(f"  → Competitor {comp_asin}: painPoints + positives")
-        review_results[f"comp_{comp_asin}_painPoints"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+        log(f"  → Competitor {comp_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [comp_asin], "mode": "asin", "period": "6m"
         }, f"reviews comp {comp_asin}")
-        review_results[f"comp_{comp_asin}_positives"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "positives", "period": "6m"
-        }, f"reviews comp+ {comp_asin}")
+        review_results[f"comp_{comp_asin}_painPoints"] = _filter_review_insights(r, "painPoints")
+        review_results[f"comp_{comp_asin}_positives"] = _filter_review_insights(r, "positives")
     
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_analysis")
@@ -1960,12 +2046,19 @@ def cmd_analyze(args):
         print("ERROR: --asin, --asins, or --category is required.", file=sys.stderr)
         sys.exit(1)
 
-    if args.label_type:
-        params["labelType"] = args.label_type
     if args.period:
         params["period"] = args.period
 
     result = api_call("reviews/analysis", params)
+
+    # Client-side filtering by label type (v2 API returns all dimensions in one call)
+    if args.label_type and result.get("data") and result["data"].get("consumerInsights"):
+        requested = [t.strip() for t in args.label_type.split(",")]
+        result["data"]["consumerInsights"] = [
+            i for i in result["data"]["consumerInsights"]
+            if i.get("labelType") in requested
+        ]
+
     output(result, args.format)
 
 
@@ -2246,7 +2339,12 @@ Examples:
     p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+        print(f"ERROR: Unrecognized argument(s): {' '.join(unknown)}", file=sys.stderr)
+        print(f"Run 'apiclaw.py {cmd} --help' to see valid options.", file=sys.stderr)
+        sys.exit(1)
     args.func(args)
 
 

--- a/amazon-listing-audit-pro/scripts/apiclaw.py
+++ b/amazon-listing-audit-pro/scripts/apiclaw.py
@@ -234,6 +234,25 @@ def _filter_review_insights(result, label_type):
     return filtered
 
 
+def _fetch_all_history(api_caller, asins, start_date, end_date, log_fn=None):
+    """Fetch products/history for multiple ASINs (one API call per ASIN)."""
+    all_data = []
+    last_response = None
+    for asin in asins:
+        r = api_caller("products/history", {
+            "asin": asin, "startDate": start_date, "endDate": end_date,
+        }, f"history {asin}")
+        last_response = r
+        if r.get("data"):
+            all_data.append(r["data"])
+        elif log_fn:
+            log_fn(f"  ⚠️ No history data for {asin}")
+    if last_response is None:
+        return {"success": False, "data": [], "error": {"message": "No ASINs provided"}}
+    last_response["data"] = all_data
+    return last_response
+
+
 def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
     """
     Resolve categoryPath with multi-level fallback.
@@ -818,11 +837,7 @@ def cmd_market_entry(args):
     round1_asins = top_asins[:3]
     if round1_asins:
         tried_asins.update(round1_asins)
-        r = safe_call("products/history", {
-            "asins": round1_asins,
-            "startDate": thirty_days_ago,
-            "endDate": today,
-        }, "history round 1")
+        r = _fetch_all_history(safe_call, round1_asins, thirty_days_ago, today, log_fn=log)
         history_data = r.get("data", [])
 
     # Round 2: Try oldest products if round 1 was empty
@@ -831,11 +846,7 @@ def cmd_market_entry(args):
         if round2_asins:
             log(f"  → Round 1 empty, trying older ASINs: {round2_asins}")
             tried_asins.update(round2_asins)
-            r = safe_call("products/history", {
-                "asins": round2_asins,
-                "startDate": thirty_days_ago,
-                "endDate": today,
-            }, "history round 2")
+            r = _fetch_all_history(safe_call, round2_asins, thirty_days_ago, today, log_fn=log)
             history_data = r.get("data", [])
 
     results["product_history"] = {"data": history_data, "asins_tried": list(tried_asins)}
@@ -1012,9 +1023,7 @@ def cmd_competitor_analysis(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = ([my_asin] if my_asin else []) + top_asins[:5]
-    r = safe_call("products/history", {
-        "asins": history_asins[:8], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins[:8], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins[:8]}
     results["meta"]["steps_completed"].append("historical_trends")
 
@@ -1198,9 +1207,7 @@ def cmd_pricing_analysis(args):
             break
 
     history_asins = [my_asin] + comp_asins
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("price_trends")
 
@@ -1308,11 +1315,7 @@ def cmd_daily_radar(args):
     tried_asins = set()
     
     # Round 1: All tracked ASINs
-    r = safe_call("products/history", {
-        "asins": tracked_asins,
-        "startDate": seven_days_ago,
-        "endDate": today,
-    }, "history round 1")
+    r = _fetch_all_history(safe_call, tracked_asins, seven_days_ago, today, log_fn=log)
     history_data = r.get("data", [])
     tried_asins.update(tracked_asins)
 
@@ -1571,9 +1574,7 @@ def cmd_listing_audit(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = [my_asin] + leader_asins[:2]
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("trend_context")
 
@@ -1766,9 +1767,7 @@ def cmd_opportunity_scan(args):
     log("Step 5/6: Trend check...")
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
-    r = safe_call("products/history", {
-        "asins": top_asins[:5], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, top_asins[:5], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": top_asins[:5]}
     results["meta"]["steps_completed"].append("trend_check")
 
@@ -1942,9 +1941,7 @@ def cmd_review_deepdive(args):
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     hist_asins = [target_asin] + comp_asins[:2] if target_asin else comp_asins[:3]
     if hist_asins:
-        r = safe_call("products/history", {
-            "asins": hist_asins, "startDate": thirty_ago, "endDate": today
-        }, "history")
+        r = _fetch_all_history(safe_call, hist_asins, thirty_ago, today, log_fn=log)
         results["product_history"] = {"data": r.get("data", []), "asins_tried": hist_asins}
     results["meta"]["steps_completed"].append("price_trend_context")
 
@@ -2119,12 +2116,11 @@ def cmd_brand_detail(args):
 def cmd_product_history(args):
     """Get historical data (price, BSR, sales) for ASINs over a date range."""
     asins = [a.strip() for a in args.asins.split(",")]
-    params = {
-        "asins": asins,
-        "startDate": args.start_date,
-        "endDate": args.end_date,
-    }
-    result = api_call("products/history", params)
+
+    def _api_caller(endpoint, p, label=""):
+        return api_call(endpoint, p)
+
+    result = _fetch_all_history(_api_caller, asins, args.start_date, args.end_date)
     output(result, args.format)
 
 

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -20,8 +20,8 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 One input (keyword/category). Full market viability assessment with sub-market discovery.
 
 ## Files
-- **Script**: `scripts/apiclaw.py` (execute, don't read) — run `--help` for params
-- **Reference**: `references/reference.md` (field names & response structure)
+- **Script**: `{skill_base_dir}/scripts/apiclaw.py` (execute, don't read) — run `--help` for params
+- **Reference**: `{skill_base_dir}/references/reference.md` (field names & response structure)
 
 ## Credential
 Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apiclaw.io/en/api-keys)
@@ -80,7 +80,7 @@ Present TOP 10 sub-markets. Ask user which to deep-dive (default: top 3). If ≤
 
 ## Composite Command
 ```bash
-python3 scripts/apiclaw.py market-entry --keyword "{kw}" --category "{path}"
+python3 {skill_base_dir}/scripts/apiclaw.py market-entry --keyword "{kw}" --category "{path}"
 ```
 Runs all 11 endpoints (~20 calls). Output JSON is large — use targeted extraction, not full read.
 

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -31,7 +31,7 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 - **Optional**: marketplace (default US)
 
 ## API Pitfalls (shared with apiclaw skill — critical!)
-- Keyword search is broad → **MUST lock categoryPath first** via `categories` endpoint
+- Keyword search is broad → categoryPath is auto-resolved via `categories` endpoint, with fallback to top search result. If `category_source` is `inferred_from_search`, confirm with user
 - Brand/price-band queries **MUST include --category** to avoid cross-category contamination
 - Revenue = `sampleAvgMonthlyRevenue` (NEVER calculate avgPrice × totalSales — overestimates 30-70%)
 - Sales = `monthlySalesFloor` (lower bound). Fallback: 300,000 / BSR^0.65, tag 🔍
@@ -85,11 +85,46 @@ python3 scripts/apiclaw.py market-entry --keyword "{kw}" --category "{path}"
 Runs all 11 endpoints (~20 calls). Output JSON is large — use targeted extraction, not full read.
 
 ## Output
-Respond in user's language. Tag every conclusion: 📊 Data-backed / 🔍 Inferred / 💡 Directional.
+Respond in user's language.
 
 Sections: Sub-Market Landscape → Executive Summary → Market Overview → Trend → Brand Landscape → Price Structure → Top 5 Competitors → Consumer Insights → Scoring Breakdown (with "Basis" column) → Entry Strategy → Data Provenance → API Usage → Cross-Market Comparison
 
-Begin with disclaimer: data is as-of date, sales are lower-bound, validate before decisions.
 If user provides COGS, calculate break-even and profit. If not, prompt for it.
+
+### Language (required)
+
+Output language MUST match the user's input language. If the user asks in Chinese, the entire report is in Chinese. If in English, output in English. Exception: API field names (e.g. `monthlySalesFloor`, `categoryPath`), endpoint names, technical terms (e.g. ASIN, BSR, CR10, FBA, credits) remain in English.
+
+### Disclaimer (required, at the top of every report)
+
+> Data is based on APIClaw API sampling as of [date]. Monthly sales (`monthlySalesFloor`) are lower-bound estimates. This analysis is for reference only and should not be the sole basis for business decisions. Validate with additional sources before acting.
+
+### Confidence Labels (required, tag EVERY conclusion)
+
+- 📊 **Data-backed** — direct API data (e.g. "CR10 = 54.8% 📊")
+- 🔍 **Inferred** — logical reasoning from data (e.g. "brand concentration is moderate 🔍")
+- 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
+
+Rules: Strategy recommendations are NEVER 📊. Anomalies (>200% growth) are always 💡. User criteria override AI judgment.
+
+### Data Provenance (required)
+
+Include a table at the end of every report:
+
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+| (e.g. Market Overview) | `markets/search` | categoryPath, topN=10 | 📊 Top N sampling, sales are lower-bound |
+| ... | ... | ... | ... |
+
+Extract endpoint and params from `_query` in JSON output. Add notes: sampling method, T+1 delay, realtime vs DB, minimum review threshold, etc.
+
+### API Usage (required)
+
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+| (each endpoint used) | N | N |
+| **Total** | **N** | **N** |
+
+Extract from `meta.creditsConsumed` per response. End with `Credits remaining: N`.
 
 ## API Budget: ~20 calls

--- a/amazon-market-entry-analyzer/scripts/apiclaw.py
+++ b/amazon-market-entry-analyzer/scripts/apiclaw.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import sys
+import random
 import time
 import urllib.request
 import urllib.error
@@ -35,9 +36,15 @@ import urllib.error
 
 BASE_URL = "https://api.apiclaw.io/openapi/v2"  # APIClaw API base URL
 API_DOCS = "https://api.apiclaw.io/api-docs"   # API documentation URL
-MAX_RETRIES = 2       # Maximum number of retry attempts for failed requests
-RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on 429 (rate limit)
+MAX_RETRIES = 3       # Maximum number of retry attempts for failed requests
+RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
+RATE_LIMIT_RETRIES = 4  # Extra retries specifically for 429 rate limits
+RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
+MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
+
+# Global request pacer — prevents burst rate limit violations
+_last_request_time = 0.0
 
 # 13 built-in product selection modes
 # Each maps to a set of products/search filter parameters
@@ -110,6 +117,8 @@ def api_call(endpoint: str, params: dict) -> dict:
     Returns the parsed JSON response on success, with _query metadata injected.
     Exits with a clear error message on failure.
     """
+    global _last_request_time
+
     url = f"{BASE_URL}/{endpoint}"
     api_key = get_api_key()
 
@@ -131,8 +140,16 @@ def api_call(endpoint: str, params: dict) -> dict:
         "User-Agent": "APIClaw-CLI/1.0 (Python)",
     }
 
+    # Rate-limit pacing: enforce minimum interval between requests
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < MIN_REQUEST_INTERVAL:
+        time.sleep(MIN_REQUEST_INTERVAL - elapsed)
+
     delay = RETRY_DELAY
-    for attempt in range(1, MAX_RETRIES + 1):
+    max_attempts = MAX_RETRIES
+    for attempt in range(1, max_attempts + 1):
+        _last_request_time = time.monotonic()
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
@@ -163,9 +180,15 @@ def api_call(endpoint: str, params: dict) -> dict:
                     "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
                     endpoint, actual_params)
             elif status == 429:
-                if attempt < MAX_RETRIES:
-                    print(f"Rate limited (429). Waiting {delay}s before retry {attempt}/{MAX_RETRIES}...", file=sys.stderr)
-                    time.sleep(delay)
+                # Switch to longer retry strategy for rate limits
+                if attempt == 1:
+                    max_attempts = RATE_LIMIT_RETRIES
+                    delay = RATE_LIMIT_DELAY
+                if attempt < max_attempts:
+                    jitter = random.uniform(0, delay * 0.25)
+                    wait = delay + jitter
+                    print(f"Rate limited (429). Waiting {wait:.1f}s before retry {attempt}/{max_attempts}...", file=sys.stderr)
+                    time.sleep(wait)
                     delay *= 2
                     continue
                 else:
@@ -177,17 +200,17 @@ def api_call(endpoint: str, params: dict) -> dict:
                     f"Check {API_DOCS} for current endpoints",
                     endpoint, actual_params)
             else:
-                if attempt < MAX_RETRIES:
-                    print(f"HTTP {status}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                if attempt < max_attempts:
+                    print(f"HTTP {status}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                     time.sleep(delay)
                     continue
                 else:
-                    return _error_result(status, f"HTTP {status} after {MAX_RETRIES} attempts",
+                    return _error_result(status, f"HTTP {status} after {max_attempts} attempts",
                         "Check network or try again later",
                         endpoint, actual_params)
         except Exception as e:
-            if attempt < MAX_RETRIES:
-                print(f"Request failed: {e}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+            if attempt < max_attempts:
+                print(f"Request failed: {e}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                 time.sleep(delay)
                 continue
             else:
@@ -196,6 +219,94 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
 
     return _error_result(0, "Unexpected retry loop exit", "This should not happen", endpoint, actual_params)
+
+
+def _filter_review_insights(result, label_type):
+    """Return a shallow copy of a reviews/analysis result filtered to one labelType."""
+    if not result.get("data") or not result["data"].get("consumerInsights"):
+        return result
+    filtered = dict(result)
+    filtered["data"] = dict(result["data"])
+    filtered["data"]["consumerInsights"] = [
+        i for i in result["data"]["consumerInsights"]
+        if i.get("labelType") == label_type
+    ]
+    return filtered
+
+
+def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
+    """
+    Resolve categoryPath with multi-level fallback.
+    Returns (category_path, category_source) tuple.
+
+    Priority:
+      1. keyword → categories API
+      2. asin → realtime/product → categoryPath or bestsellersRank leaf
+      3. keyword → products/search → first result → realtime/product
+    """
+    category_path = None
+    category_source = "user"
+
+    # Priority 1: keyword → categories
+    if keyword:
+        log_fn("Step 0: Resolving category...")
+        cat_result = api_caller("categories", {"categoryKeyword": keyword}, "categories")
+        if results is not None:
+            results["categories"] = cat_result
+        cat_data = cat_result.get("data", [])
+        if cat_data:
+            category_path = cat_data[0].get("categoryPath")
+            category_source = "keyword"
+
+    # Priority 2: asin → realtime/product
+    if not category_path and asin:
+        log_fn("  → Resolving category from ASIN...")
+        rt = api_caller("realtime/product", {"asin": asin, "marketplace": "US"}, f"realtime {asin}")
+        if results is not None:
+            results.setdefault("_asin_realtime", rt)
+        rt_data = rt.get("data", {}) or {}
+        if rt_data.get("categoryPath"):
+            category_path = rt_data["categoryPath"]
+            category_source = "asin_realtime"
+            log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif rt_data.get("bestsellersRank"):
+            leaf = rt_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log_fn(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "asin_bsr"
+                    log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+
+    # Priority 3: keyword → search → first product → realtime
+    if not category_path and keyword:
+        log_fn("  → Resolving category from top search result...")
+        prod_result = api_caller("products/search", {
+            "keyword": keyword, "sortBy": "monthlySalesFloor", "sortOrder": "desc", "pageSize": 5
+        }, "products (category probe)")
+        prod_data = prod_result.get("data", [])
+        if isinstance(prod_data, list) and prod_data:
+            probe_asin = prod_data[0].get("asin")
+            if probe_asin:
+                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+                rt_data = rt.get("data", {}) or {}
+                if rt_data.get("categoryPath"):
+                    category_path = rt_data["categoryPath"]
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+                elif rt_data.get("bestsellersRank"):
+                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
+                    if leaf:
+                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                        cat_data = cat_result.get("data", [])
+                        if cat_data:
+                            category_path = cat_data[0].get("categoryPath")
+                            category_source = "inferred_from_search"
+                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+
+    return category_path, category_source
 
 
 def _error_result(status: int, message: str, action: str, endpoint: str, params: dict) -> dict:
@@ -344,9 +455,9 @@ def cmd_products(args):
     if args.fulfillment:
         params["fulfillments"] = args.fulfillment
     if args.include_brands:
-        params["includeBrands"] = args.include_brands
+        params["includeBrands"] = [b.strip() for b in args.include_brands.split(",")]
     if args.exclude_brands:
-        params["excludeBrands"] = args.exclude_brands
+        params["excludeBrands"] = [b.strip() for b in args.exclude_brands.split(",")]
 
     params["sortBy"] = args.sort or "monthlySalesFloor"
     params["sortOrder"] = args.order or "desc"
@@ -453,7 +564,7 @@ def cmd_report(args):
     print("Step 3/4: Searching top products...", file=sys.stderr)
     products_result = api_call("products/search", {
         "keyword": keyword,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 50,
     })
@@ -508,7 +619,7 @@ def cmd_opportunity(args):
         "keyword": keyword,
         "monthlySalesMin": 300,
         "ratingCountMax": 50,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 20,
     }
@@ -565,17 +676,9 @@ def cmd_market_entry(args):
         return r
 
     # ── Step 0.5: Category Resolution ──
-    if not category_path and keyword:
-        log("Step 0.5: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked category: {' > '.join(category_path)}")
-        else:
-            log("  ⚠️ No category match, will use keyword-only queries")
-
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # ── Step 1: Market Landscape (3 calls) ──
@@ -744,43 +847,36 @@ def cmd_market_entry(args):
     review_results = {}
     label_types = ["painPoints", "buyingFactors", "improvements"]
 
-    # Priority 1: Category mode
-    category_mode_success = True
+    # Priority 1: Category mode (single call, split client-side)
+    category_mode_success = False
     if category_path:
-        for lt in label_types:
-            log(f"  → reviews/analysis category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path,
-                "mode": "category",
-                "labelType": lt,
-                "period": "6m",
-            }, f"reviews {lt}")
-            if r.get("success") is False or not r.get("data", {}).get("consumerInsights"):
-                category_mode_success = False
-                log(f"  ⚠️ Category mode failed for {lt}")
-                break
-            review_results[lt] = r
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path,
+            "mode": "category",
+            "period": "6m",
+        }, "reviews category")
+        if r.get("success") and r.get("data", {}).get("consumerInsights"):
+            category_mode_success = True
+            for lt in label_types:
+                review_results[lt] = _filter_review_insights(r, lt)
 
     # Priority 2: ASIN mode (if category failed)
-    if not category_mode_success or not category_path:
+    if not category_mode_success:
         log("  → Falling back to ASIN mode...")
-        # Pick ASINs with ratingCount >= 50
         review_asins = [p.get("asin") for p in all_products if (p.get("ratingCount") or 0) >= 50][:3]
         if review_asins:
+            log(f"  → reviews/analysis ASIN mode ({review_asins})")
+            r = safe_call("reviews/analysis", {
+                "asins": review_asins,
+                "mode": "asin",
+                "period": "6m",
+            }, "reviews ASIN")
             for lt in label_types:
-                if lt in review_results:
-                    continue
-                log(f"  → reviews/analysis ASIN mode: {lt} ({review_asins})")
-                r = safe_call("reviews/analysis", {
-                    "asins": review_asins,
-                    "mode": "asin",
-                    "labelType": lt,
-                    "period": "6m",
-                }, f"reviews ASIN {lt}")
-                review_results[lt] = r
+                review_results[lt] = _filter_review_insights(r, lt)
 
     results["reviews"] = review_results
-    results["meta"]["review_mode"] = "category" if category_mode_success and category_path else "asin"
+    results["meta"]["review_mode"] = "category" if category_mode_success else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
 
     # ── Summary ──
@@ -819,14 +915,9 @@ def cmd_competitor_analysis(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
-    results["meta"]["resolved_category"] = category_path
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
 
     # Step 1: Competitor Discovery
     log("Step 1/7: Competitor discovery...")
@@ -844,6 +935,7 @@ def cmd_competitor_analysis(args):
     if category_path:
         comp_params["categoryPath"] = category_path
     results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    results["meta"]["resolved_category"] = category_path
     results["meta"]["steps_completed"].append("competitor_discovery")
 
     # Step 2: Market Context
@@ -931,16 +1023,17 @@ def cmd_competitor_analysis(args):
     review_results = {}
     for asin in top_asins[:5]:
         r = safe_call("reviews/analysis", {
-            "asins": [asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [asin], "mode": "asin", "period": "6m"
         }, f"reviews {asin}")
         if r.get("data") and r.get("data", {}).get("consumerInsights"):
             review_results[asin] = r
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -955,7 +1048,7 @@ def cmd_competitor_analysis(args):
                 bp["keyword"] = keyword
             if category_path:
                 bp["categoryPath"] = category_path
-            bp["includeBrands"] = top_brand
+            bp["includeBrands"] = [top_brand]
             results["top_brand_products"] = safe_call("products/search", bp, f"brand {top_brand}")
     results["meta"]["steps_completed"].append("brand_drilldown")
 
@@ -969,6 +1062,7 @@ def cmd_pricing_analysis(args):
     """
     Composite workflow: Pricing Analysis.
     Runs: realtime(my_asin) → price-band → products/competitors → market/brand → history → realtime(top5) → reviews
+    Category is auto-detected from ASIN if not provided.
     """
     my_asin = args.my_asin
     keyword = args.keyword
@@ -976,9 +1070,6 @@ def cmd_pricing_analysis(args):
 
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
-        sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
         sys.exit(1)
 
     category_path = parse_category(category) if category else None
@@ -993,21 +1084,40 @@ def cmd_pricing_analysis(args):
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
         return r
 
-    # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
-    results["meta"]["resolved_category"] = category_path
-
     # Step 1: Current Price Snapshot
     log("Step 1/8: Current price snapshot...")
     results["my_product"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
+    my_data = results["my_product"].get("data", {}) or {}
+    if not my_data.get("title"):
+        log(f"\n❌ ASIN '{my_asin}' not found or has no data. Please check the ASIN and try again.")
+        results["error"] = {"code": "ASIN_NOT_FOUND", "message": f"ASIN '{my_asin}' not found or returned empty data"}
+        output(results, args.format)
+        return
     results["meta"]["steps_completed"].append("price_snapshot")
+
+    # Step 1.5: Auto Category Detection
+    if not category_path:
+        # For pricing, we already have realtime data — extract directly first
+        if my_data.get("categoryPath"):
+            category_path = my_data["categoryPath"]
+            results["meta"]["category_source"] = "asin_realtime"
+            log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif my_data.get("bestsellersRank"):
+            leaf = my_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = safe_call("categories", {"categoryKeyword": leaf}, "categories")
+                results["categories"] = cat_result
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    results["meta"]["category_source"] = "asin_bsr"
+                    log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        # Fallback to keyword
+        if not category_path and keyword:
+            category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+            results["meta"]["category_source"] = category_source
+    results["meta"]["resolved_category"] = category_path
 
     # Step 2: Price Band Intelligence
     log("Step 2/8: Price band intelligence...")
@@ -1110,17 +1220,18 @@ def cmd_pricing_analysis(args):
     my_rc = results["my_product"].get("data", {}).get("ratingCount", 0)
     if my_rc and my_rc >= 50:
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if comp_asins:
         review_results["top_comp"] = safe_call("reviews/analysis", {
-            "asins": [comp_asins[0]], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [comp_asins[0]], "mode": "asin", "period": "6m"
         }, f"reviews {comp_asins[0]}")
     if not review_results and category_path:
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_context")
 
@@ -1157,9 +1268,6 @@ def cmd_daily_radar(args):
     if not asins_str:
         print("ERROR: --asins is required (comma-separated ASINs to track).", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     tracked_asins = [a.strip() for a in asins_str.split(",") if a.strip()]
     category_path = parse_category(category) if category else None
@@ -1175,14 +1283,10 @@ def cmd_daily_radar(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=tracked_asins[0] if tracked_asins else None, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
@@ -1292,10 +1396,9 @@ def cmd_daily_radar(args):
             r = safe_call("reviews/analysis", {
                 "asins": [review_asin],
                 "mode": "asin",
-                "labelType": "painPoints",
                 "period": "6m",
             }, f"reviews {review_asin}")
-            review_results["painPoints"] = r
+            review_results["painPoints"] = _filter_review_insights(r, "painPoints")
             break
     
     if not review_results:
@@ -1324,9 +1427,6 @@ def cmd_listing_audit(args):
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     category_path = parse_category(category) if category else None
     results = {"meta": {"my_asin": my_asin, "keyword": keyword, "category": category, "steps_completed": []}}
@@ -1341,14 +1441,10 @@ def cmd_listing_audit(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Audit Target
@@ -1451,21 +1547,22 @@ def cmd_listing_audit(args):
     if target_rc and target_rc >= 50:
         log(f"  → reviews/analysis ASIN mode: {my_asin}")
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if leader_asins:
         top_leader = leader_asins[0]
         log(f"  → reviews/analysis ASIN mode: {top_leader}")
         review_results["top_leader"] = safe_call("reviews/analysis", {
-            "asins": [top_leader], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [top_leader], "mode": "asin", "period": "6m"
         }, f"reviews {top_leader}")
     # Category fallback
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors", "improvements"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews category {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -1538,14 +1635,9 @@ def cmd_opportunity_scan(args):
         return r
 
     # Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Product Scan (mode-based + custom filters)
@@ -1684,23 +1776,22 @@ def cmd_opportunity_scan(args):
     log("Step 6/6: Consumer insights...")
     review_results = {}
     if category_path:
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
-            log(f"  → category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            if r.get("data") and r.get("data", {}).get("consumerInsights"):
-                review_results[lt] = r
-            else:
-                break
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
+        if r.get("data") and r.get("data", {}).get("consumerInsights"):
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     if not review_results:
         log("  → Falling back to ASIN mode...")
         review_asins = [a for a in top_asins[:3]]
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
+        if review_asins:
             r = safe_call("reviews/analysis", {
-                "asins": review_asins, "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews ASIN {lt}")
-            review_results[lt] = r
+                "asins": review_asins, "mode": "asin", "period": "6m"
+            }, "reviews ASIN")
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["review_mode"] = "category" if category_path and review_results.get("painPoints", {}).get("data", {}).get("consumerInsights") else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
@@ -1743,13 +1834,9 @@ def cmd_review_deepdive(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=target_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Target Identification
@@ -1775,26 +1862,25 @@ def cmd_review_deepdive(args):
     log("Step 2/5: Full review analysis (11 dimensions)...")
     label_types = ["painPoints", "positives", "buyingFactors", "improvements", "userProfiles",
                    "scenarios", "issues", "keywords", "usageTimes", "usageLocations", "behaviors"]
-    
+
     review_results = {}
-    # Target ASIN reviews
+    # Target ASIN reviews (single call, split client-side)
     if target_asin:
+        log(f"  → {target_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [target_asin], "mode": "asin", "period": "6m"
+        }, "reviews target")
         for lt in label_types:
-            log(f"  → {target_asin}: {lt}")
-            r = safe_call("reviews/analysis", {
-                "asins": [target_asin], "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            review_results[f"target_{lt}"] = r
-    
-    # Competitor comparison (top 2)
+            review_results[f"target_{lt}"] = _filter_review_insights(r, lt)
+
+    # Competitor comparison (top 2, single call each)
     for comp_asin in comp_asins[:2]:
-        log(f"  → Competitor {comp_asin}: painPoints + positives")
-        review_results[f"comp_{comp_asin}_painPoints"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+        log(f"  → Competitor {comp_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [comp_asin], "mode": "asin", "period": "6m"
         }, f"reviews comp {comp_asin}")
-        review_results[f"comp_{comp_asin}_positives"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "positives", "period": "6m"
-        }, f"reviews comp+ {comp_asin}")
+        review_results[f"comp_{comp_asin}_painPoints"] = _filter_review_insights(r, "painPoints")
+        review_results[f"comp_{comp_asin}_positives"] = _filter_review_insights(r, "positives")
     
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_analysis")
@@ -1960,12 +2046,19 @@ def cmd_analyze(args):
         print("ERROR: --asin, --asins, or --category is required.", file=sys.stderr)
         sys.exit(1)
 
-    if args.label_type:
-        params["labelType"] = args.label_type
     if args.period:
         params["period"] = args.period
 
     result = api_call("reviews/analysis", params)
+
+    # Client-side filtering by label type (v2 API returns all dimensions in one call)
+    if args.label_type and result.get("data") and result["data"].get("consumerInsights"):
+        requested = [t.strip() for t in args.label_type.split(",")]
+        result["data"]["consumerInsights"] = [
+            i for i in result["data"]["consumerInsights"]
+            if i.get("labelType") in requested
+        ]
+
     output(result, args.format)
 
 
@@ -2246,7 +2339,12 @@ Examples:
     p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+        print(f"ERROR: Unrecognized argument(s): {' '.join(unknown)}", file=sys.stderr)
+        print(f"Run 'apiclaw.py {cmd} --help' to see valid options.", file=sys.stderr)
+        sys.exit(1)
     args.func(args)
 
 

--- a/amazon-market-entry-analyzer/scripts/apiclaw.py
+++ b/amazon-market-entry-analyzer/scripts/apiclaw.py
@@ -234,6 +234,25 @@ def _filter_review_insights(result, label_type):
     return filtered
 
 
+def _fetch_all_history(api_caller, asins, start_date, end_date, log_fn=None):
+    """Fetch products/history for multiple ASINs (one API call per ASIN)."""
+    all_data = []
+    last_response = None
+    for asin in asins:
+        r = api_caller("products/history", {
+            "asin": asin, "startDate": start_date, "endDate": end_date,
+        }, f"history {asin}")
+        last_response = r
+        if r.get("data"):
+            all_data.append(r["data"])
+        elif log_fn:
+            log_fn(f"  ⚠️ No history data for {asin}")
+    if last_response is None:
+        return {"success": False, "data": [], "error": {"message": "No ASINs provided"}}
+    last_response["data"] = all_data
+    return last_response
+
+
 def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
     """
     Resolve categoryPath with multi-level fallback.
@@ -818,11 +837,7 @@ def cmd_market_entry(args):
     round1_asins = top_asins[:3]
     if round1_asins:
         tried_asins.update(round1_asins)
-        r = safe_call("products/history", {
-            "asins": round1_asins,
-            "startDate": thirty_days_ago,
-            "endDate": today,
-        }, "history round 1")
+        r = _fetch_all_history(safe_call, round1_asins, thirty_days_ago, today, log_fn=log)
         history_data = r.get("data", [])
 
     # Round 2: Try oldest products if round 1 was empty
@@ -831,11 +846,7 @@ def cmd_market_entry(args):
         if round2_asins:
             log(f"  → Round 1 empty, trying older ASINs: {round2_asins}")
             tried_asins.update(round2_asins)
-            r = safe_call("products/history", {
-                "asins": round2_asins,
-                "startDate": thirty_days_ago,
-                "endDate": today,
-            }, "history round 2")
+            r = _fetch_all_history(safe_call, round2_asins, thirty_days_ago, today, log_fn=log)
             history_data = r.get("data", [])
 
     results["product_history"] = {"data": history_data, "asins_tried": list(tried_asins)}
@@ -1012,9 +1023,7 @@ def cmd_competitor_analysis(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = ([my_asin] if my_asin else []) + top_asins[:5]
-    r = safe_call("products/history", {
-        "asins": history_asins[:8], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins[:8], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins[:8]}
     results["meta"]["steps_completed"].append("historical_trends")
 
@@ -1198,9 +1207,7 @@ def cmd_pricing_analysis(args):
             break
 
     history_asins = [my_asin] + comp_asins
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("price_trends")
 
@@ -1308,11 +1315,7 @@ def cmd_daily_radar(args):
     tried_asins = set()
     
     # Round 1: All tracked ASINs
-    r = safe_call("products/history", {
-        "asins": tracked_asins,
-        "startDate": seven_days_ago,
-        "endDate": today,
-    }, "history round 1")
+    r = _fetch_all_history(safe_call, tracked_asins, seven_days_ago, today, log_fn=log)
     history_data = r.get("data", [])
     tried_asins.update(tracked_asins)
 
@@ -1571,9 +1574,7 @@ def cmd_listing_audit(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = [my_asin] + leader_asins[:2]
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("trend_context")
 
@@ -1766,9 +1767,7 @@ def cmd_opportunity_scan(args):
     log("Step 5/6: Trend check...")
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
-    r = safe_call("products/history", {
-        "asins": top_asins[:5], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, top_asins[:5], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": top_asins[:5]}
     results["meta"]["steps_completed"].append("trend_check")
 
@@ -1942,9 +1941,7 @@ def cmd_review_deepdive(args):
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     hist_asins = [target_asin] + comp_asins[:2] if target_asin else comp_asins[:3]
     if hist_asins:
-        r = safe_call("products/history", {
-            "asins": hist_asins, "startDate": thirty_ago, "endDate": today
-        }, "history")
+        r = _fetch_all_history(safe_call, hist_asins, thirty_ago, today, log_fn=log)
         results["product_history"] = {"data": r.get("data", []), "asins_tried": hist_asins}
     results["meta"]["steps_completed"].append("price_trend_context")
 
@@ -2119,12 +2116,11 @@ def cmd_brand_detail(args):
 def cmd_product_history(args):
     """Get historical data (price, BSR, sales) for ASINs over a date range."""
     asins = [a.strip() for a in args.asins.split(",")]
-    params = {
-        "asins": asins,
-        "startDate": args.start_date,
-        "endDate": args.end_date,
-    }
-    result = api_call("products/history", params)
+
+    def _api_caller(endpoint, p, label=""):
+        return api_call(endpoint, p)
+
+    result = _fetch_all_history(_api_caller, asins, args.start_date, args.end_date)
     output(result, args.format)
 
 

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -25,9 +25,9 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 
 | File | Purpose |
 |------|---------|
-| `scripts/apiclaw.py` | **Execute** for all API calls (run `--help` for params) |
-| `references/reference.md` | Load for exact field names or response structure |
-| `scan-data/` | Runtime: watchlist.json, baseline.json, alerts.json, history/ (auto-created) |
+| `{skill_base_dir}/scripts/apiclaw.py` | **Execute** for all API calls (run `--help` for params) |
+| `{skill_base_dir}/references/reference.md` | Load for exact field names or response structure |
+| `{skill_base_dir}/scan-data/` | Runtime: watchlist.json, baseline.json, alerts.json, history/ (auto-created) |
 
 ## Credential
 
@@ -53,17 +53,17 @@ Required: 1+ category paths or keywords. Optional: scan depth, metric preference
 3. Record 7 key metrics per subcategory (see Pitfalls #4)
 4. `products --keyword "{sub}" --category "{path}" --mode emerging --page-size 20` per hot subcategory
 5. `products --keyword "{sub}" --category "{path}" --mode new-release --page-size 20` per hot subcategory
-6. Save baseline → `scan-data/baseline.json`, config → `scan-data/watchlist.json`
+6. Save baseline → `{skill_base_dir}/scan-data/baseline.json`, config → `{skill_base_dir}/scan-data/watchlist.json`
 7. Output full trend report (see Output Spec)
 8. Offer Auto-Monitor setup
 
 ## Mode 2: Quick Check (scheduled)
 
-1. Read `scan-data/watchlist.json` + `scan-data/baseline.json`
+1. Read `{skill_base_dir}/scan-data/watchlist.json` + `{skill_base_dir}/scan-data/baseline.json`
 2. `market --category "{path}"` per watched category
 3. Compare vs baseline using signal rules below
 4. 🔴 alerts → notify user; else silent log
-5. Save snapshot to `scan-data/history/{timestamp}.json`, update baseline
+5. Save snapshot to `{skill_base_dir}/scan-data/history/{timestamp}.json`, update baseline
 
 ## Trend Signals
 

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -77,6 +77,24 @@ Required: 1+ category paths or keywords. Optional: scan depth, metric preference
 | Margin change | sampleAPlusRate change >5 percentage points | 🟡 |
 | Minor movement | None of the above triggered | 🟢 Silent log |
 
+### Trend Interpretation & Action Guide
+| Signal Combination | Market Phase | Recommended Action |
+|--------------------|-------------|-------------------|
+| Demand surge + New entrant wave | 🚀 Growth phase | Enter quickly, first-mover advantage matters 💡 |
+| Demand surge + Brand loosening | 🎯 Opportunity window | Best timing — demand up, incumbents losing grip 💡 |
+| Demand surge + Red ocean warning | ⚠️ Late stage growth | High demand but leaders consolidating — need strong differentiation 💡 |
+| Red ocean warning + No demand surge | 🔒 Mature/locked | Avoid — established players dominate with flat demand 💡 |
+| Brand loosening + Price band shift down | 💰 Price war | Wait — margins compressing, enter after shakeout 💡 |
+| New entrant wave + Margin change | 🔄 Disruption | Category being redefined — study new entrants' strategies 🔍 |
+
+### Subcategory Ranking Criteria
+Rank subcategories by composite attractiveness (apply market-entry scoring logic):
+- **Demand**: sampleAvgMonthlySales — higher = more attractive 📊
+- **Competition**: topBrandSalesRate — lower = more open 📊
+- **Entry barrier**: sampleAvgRatingCount — lower = easier entry 📊
+- **Activity**: sampleNewSkuRate — higher = more dynamic 📊
+- **Margin signal**: sampleAvgPrice — higher generally = better margins 🔍
+
 ## Auto-Monitor
 
 After each Full Scan, ask user to enable scheduled monitoring. If yes, generate cron config with: category list, alert thresholds, schedule. Supports OpenClaw /cron, ChatGPT Scheduled Tasks, Claude Projects. Quick Check only notifies on 🔴 alerts.
@@ -85,7 +103,41 @@ After each Full Scan, ask user to enable scheduled monitoring. If yes, generate 
 
 Full Scan: Trend Dashboard (all subcategories) → 🔥 Hot Categories TOP 5 → 🆕 New Entrants Scan → ⚠️ Risk Alerts → Subcategory Detail (per hot category) → Next Steps → Data Provenance → API Usage.
 
-Confidence labels: 📊 Data-backed | 🔍 Inferred | 💡 Directional. Sample bias note required.
+### Language (required)
+
+Output language MUST match the user's input language. If the user asks in Chinese, the entire report is in Chinese. If in English, output in English. Exception: API field names (e.g. `monthlySalesFloor`, `categoryPath`), endpoint names, technical terms (e.g. ASIN, BSR, CR10, FBA, credits) remain in English.
+
+### Disclaimer (required, at the top of every report)
+
+> Data is based on APIClaw API sampling as of [date]. Monthly sales (`monthlySalesFloor`) are lower-bound estimates. This analysis is for reference only and should not be the sole basis for business decisions. Validate with additional sources before acting.
+
+### Confidence Labels (required, tag EVERY conclusion)
+
+- 📊 **Data-backed** — direct API data (e.g. "CR10 = 54.8% 📊")
+- 🔍 **Inferred** — logical reasoning from data (e.g. "brand concentration is moderate 🔍")
+- 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
+
+Rules: Strategy recommendations are NEVER 📊. Anomalies (>200% growth) are always 💡. Sample bias note required. User criteria override AI judgment.
+
+### Data Provenance (required)
+
+Include a table at the end of every report:
+
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+| (e.g. Market Overview) | `markets/search` | categoryPath, topN=10 | 📊 Top N sampling, sales are lower-bound |
+| ... | ... | ... | ... |
+
+Extract endpoint and params from `_query` in JSON output. Add notes: sampling method, T+1 delay, realtime vs DB, minimum review threshold, etc.
+
+### API Usage (required)
+
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+| (each endpoint used) | N | N |
+| **Total** | **N** | **N** |
+
+Extract from `meta.creditsConsumed` per response. End with `Credits remaining: N`.
 
 ## API Budget
 

--- a/amazon-market-trend-scanner/scripts/apiclaw.py
+++ b/amazon-market-trend-scanner/scripts/apiclaw.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import sys
+import random
 import time
 import urllib.request
 import urllib.error
@@ -35,9 +36,15 @@ import urllib.error
 
 BASE_URL = "https://api.apiclaw.io/openapi/v2"  # APIClaw API base URL
 API_DOCS = "https://api.apiclaw.io/api-docs"   # API documentation URL
-MAX_RETRIES = 2       # Maximum number of retry attempts for failed requests
-RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on 429 (rate limit)
+MAX_RETRIES = 3       # Maximum number of retry attempts for failed requests
+RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
+RATE_LIMIT_RETRIES = 4  # Extra retries specifically for 429 rate limits
+RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
+MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
+
+# Global request pacer — prevents burst rate limit violations
+_last_request_time = 0.0
 
 # 13 built-in product selection modes
 # Each maps to a set of products/search filter parameters
@@ -110,6 +117,8 @@ def api_call(endpoint: str, params: dict) -> dict:
     Returns the parsed JSON response on success, with _query metadata injected.
     Exits with a clear error message on failure.
     """
+    global _last_request_time
+
     url = f"{BASE_URL}/{endpoint}"
     api_key = get_api_key()
 
@@ -131,8 +140,16 @@ def api_call(endpoint: str, params: dict) -> dict:
         "User-Agent": "APIClaw-CLI/1.0 (Python)",
     }
 
+    # Rate-limit pacing: enforce minimum interval between requests
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < MIN_REQUEST_INTERVAL:
+        time.sleep(MIN_REQUEST_INTERVAL - elapsed)
+
     delay = RETRY_DELAY
-    for attempt in range(1, MAX_RETRIES + 1):
+    max_attempts = MAX_RETRIES
+    for attempt in range(1, max_attempts + 1):
+        _last_request_time = time.monotonic()
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
@@ -163,9 +180,15 @@ def api_call(endpoint: str, params: dict) -> dict:
                     "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
                     endpoint, actual_params)
             elif status == 429:
-                if attempt < MAX_RETRIES:
-                    print(f"Rate limited (429). Waiting {delay}s before retry {attempt}/{MAX_RETRIES}...", file=sys.stderr)
-                    time.sleep(delay)
+                # Switch to longer retry strategy for rate limits
+                if attempt == 1:
+                    max_attempts = RATE_LIMIT_RETRIES
+                    delay = RATE_LIMIT_DELAY
+                if attempt < max_attempts:
+                    jitter = random.uniform(0, delay * 0.25)
+                    wait = delay + jitter
+                    print(f"Rate limited (429). Waiting {wait:.1f}s before retry {attempt}/{max_attempts}...", file=sys.stderr)
+                    time.sleep(wait)
                     delay *= 2
                     continue
                 else:
@@ -177,17 +200,17 @@ def api_call(endpoint: str, params: dict) -> dict:
                     f"Check {API_DOCS} for current endpoints",
                     endpoint, actual_params)
             else:
-                if attempt < MAX_RETRIES:
-                    print(f"HTTP {status}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                if attempt < max_attempts:
+                    print(f"HTTP {status}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                     time.sleep(delay)
                     continue
                 else:
-                    return _error_result(status, f"HTTP {status} after {MAX_RETRIES} attempts",
+                    return _error_result(status, f"HTTP {status} after {max_attempts} attempts",
                         "Check network or try again later",
                         endpoint, actual_params)
         except Exception as e:
-            if attempt < MAX_RETRIES:
-                print(f"Request failed: {e}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+            if attempt < max_attempts:
+                print(f"Request failed: {e}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                 time.sleep(delay)
                 continue
             else:
@@ -196,6 +219,94 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
 
     return _error_result(0, "Unexpected retry loop exit", "This should not happen", endpoint, actual_params)
+
+
+def _filter_review_insights(result, label_type):
+    """Return a shallow copy of a reviews/analysis result filtered to one labelType."""
+    if not result.get("data") or not result["data"].get("consumerInsights"):
+        return result
+    filtered = dict(result)
+    filtered["data"] = dict(result["data"])
+    filtered["data"]["consumerInsights"] = [
+        i for i in result["data"]["consumerInsights"]
+        if i.get("labelType") == label_type
+    ]
+    return filtered
+
+
+def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
+    """
+    Resolve categoryPath with multi-level fallback.
+    Returns (category_path, category_source) tuple.
+
+    Priority:
+      1. keyword → categories API
+      2. asin → realtime/product → categoryPath or bestsellersRank leaf
+      3. keyword → products/search → first result → realtime/product
+    """
+    category_path = None
+    category_source = "user"
+
+    # Priority 1: keyword → categories
+    if keyword:
+        log_fn("Step 0: Resolving category...")
+        cat_result = api_caller("categories", {"categoryKeyword": keyword}, "categories")
+        if results is not None:
+            results["categories"] = cat_result
+        cat_data = cat_result.get("data", [])
+        if cat_data:
+            category_path = cat_data[0].get("categoryPath")
+            category_source = "keyword"
+
+    # Priority 2: asin → realtime/product
+    if not category_path and asin:
+        log_fn("  → Resolving category from ASIN...")
+        rt = api_caller("realtime/product", {"asin": asin, "marketplace": "US"}, f"realtime {asin}")
+        if results is not None:
+            results.setdefault("_asin_realtime", rt)
+        rt_data = rt.get("data", {}) or {}
+        if rt_data.get("categoryPath"):
+            category_path = rt_data["categoryPath"]
+            category_source = "asin_realtime"
+            log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif rt_data.get("bestsellersRank"):
+            leaf = rt_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log_fn(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "asin_bsr"
+                    log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+
+    # Priority 3: keyword → search → first product → realtime
+    if not category_path and keyword:
+        log_fn("  → Resolving category from top search result...")
+        prod_result = api_caller("products/search", {
+            "keyword": keyword, "sortBy": "monthlySalesFloor", "sortOrder": "desc", "pageSize": 5
+        }, "products (category probe)")
+        prod_data = prod_result.get("data", [])
+        if isinstance(prod_data, list) and prod_data:
+            probe_asin = prod_data[0].get("asin")
+            if probe_asin:
+                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+                rt_data = rt.get("data", {}) or {}
+                if rt_data.get("categoryPath"):
+                    category_path = rt_data["categoryPath"]
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+                elif rt_data.get("bestsellersRank"):
+                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
+                    if leaf:
+                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                        cat_data = cat_result.get("data", [])
+                        if cat_data:
+                            category_path = cat_data[0].get("categoryPath")
+                            category_source = "inferred_from_search"
+                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+
+    return category_path, category_source
 
 
 def _error_result(status: int, message: str, action: str, endpoint: str, params: dict) -> dict:
@@ -344,9 +455,9 @@ def cmd_products(args):
     if args.fulfillment:
         params["fulfillments"] = args.fulfillment
     if args.include_brands:
-        params["includeBrands"] = args.include_brands
+        params["includeBrands"] = [b.strip() for b in args.include_brands.split(",")]
     if args.exclude_brands:
-        params["excludeBrands"] = args.exclude_brands
+        params["excludeBrands"] = [b.strip() for b in args.exclude_brands.split(",")]
 
     params["sortBy"] = args.sort or "monthlySalesFloor"
     params["sortOrder"] = args.order or "desc"
@@ -453,7 +564,7 @@ def cmd_report(args):
     print("Step 3/4: Searching top products...", file=sys.stderr)
     products_result = api_call("products/search", {
         "keyword": keyword,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 50,
     })
@@ -508,7 +619,7 @@ def cmd_opportunity(args):
         "keyword": keyword,
         "monthlySalesMin": 300,
         "ratingCountMax": 50,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 20,
     }
@@ -565,17 +676,9 @@ def cmd_market_entry(args):
         return r
 
     # ── Step 0.5: Category Resolution ──
-    if not category_path and keyword:
-        log("Step 0.5: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked category: {' > '.join(category_path)}")
-        else:
-            log("  ⚠️ No category match, will use keyword-only queries")
-
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # ── Step 1: Market Landscape (3 calls) ──
@@ -744,43 +847,36 @@ def cmd_market_entry(args):
     review_results = {}
     label_types = ["painPoints", "buyingFactors", "improvements"]
 
-    # Priority 1: Category mode
-    category_mode_success = True
+    # Priority 1: Category mode (single call, split client-side)
+    category_mode_success = False
     if category_path:
-        for lt in label_types:
-            log(f"  → reviews/analysis category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path,
-                "mode": "category",
-                "labelType": lt,
-                "period": "6m",
-            }, f"reviews {lt}")
-            if r.get("success") is False or not r.get("data", {}).get("consumerInsights"):
-                category_mode_success = False
-                log(f"  ⚠️ Category mode failed for {lt}")
-                break
-            review_results[lt] = r
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path,
+            "mode": "category",
+            "period": "6m",
+        }, "reviews category")
+        if r.get("success") and r.get("data", {}).get("consumerInsights"):
+            category_mode_success = True
+            for lt in label_types:
+                review_results[lt] = _filter_review_insights(r, lt)
 
     # Priority 2: ASIN mode (if category failed)
-    if not category_mode_success or not category_path:
+    if not category_mode_success:
         log("  → Falling back to ASIN mode...")
-        # Pick ASINs with ratingCount >= 50
         review_asins = [p.get("asin") for p in all_products if (p.get("ratingCount") or 0) >= 50][:3]
         if review_asins:
+            log(f"  → reviews/analysis ASIN mode ({review_asins})")
+            r = safe_call("reviews/analysis", {
+                "asins": review_asins,
+                "mode": "asin",
+                "period": "6m",
+            }, "reviews ASIN")
             for lt in label_types:
-                if lt in review_results:
-                    continue
-                log(f"  → reviews/analysis ASIN mode: {lt} ({review_asins})")
-                r = safe_call("reviews/analysis", {
-                    "asins": review_asins,
-                    "mode": "asin",
-                    "labelType": lt,
-                    "period": "6m",
-                }, f"reviews ASIN {lt}")
-                review_results[lt] = r
+                review_results[lt] = _filter_review_insights(r, lt)
 
     results["reviews"] = review_results
-    results["meta"]["review_mode"] = "category" if category_mode_success and category_path else "asin"
+    results["meta"]["review_mode"] = "category" if category_mode_success else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
 
     # ── Summary ──
@@ -819,14 +915,9 @@ def cmd_competitor_analysis(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
-    results["meta"]["resolved_category"] = category_path
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
 
     # Step 1: Competitor Discovery
     log("Step 1/7: Competitor discovery...")
@@ -844,6 +935,7 @@ def cmd_competitor_analysis(args):
     if category_path:
         comp_params["categoryPath"] = category_path
     results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    results["meta"]["resolved_category"] = category_path
     results["meta"]["steps_completed"].append("competitor_discovery")
 
     # Step 2: Market Context
@@ -931,16 +1023,17 @@ def cmd_competitor_analysis(args):
     review_results = {}
     for asin in top_asins[:5]:
         r = safe_call("reviews/analysis", {
-            "asins": [asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [asin], "mode": "asin", "period": "6m"
         }, f"reviews {asin}")
         if r.get("data") and r.get("data", {}).get("consumerInsights"):
             review_results[asin] = r
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -955,7 +1048,7 @@ def cmd_competitor_analysis(args):
                 bp["keyword"] = keyword
             if category_path:
                 bp["categoryPath"] = category_path
-            bp["includeBrands"] = top_brand
+            bp["includeBrands"] = [top_brand]
             results["top_brand_products"] = safe_call("products/search", bp, f"brand {top_brand}")
     results["meta"]["steps_completed"].append("brand_drilldown")
 
@@ -969,6 +1062,7 @@ def cmd_pricing_analysis(args):
     """
     Composite workflow: Pricing Analysis.
     Runs: realtime(my_asin) → price-band → products/competitors → market/brand → history → realtime(top5) → reviews
+    Category is auto-detected from ASIN if not provided.
     """
     my_asin = args.my_asin
     keyword = args.keyword
@@ -976,9 +1070,6 @@ def cmd_pricing_analysis(args):
 
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
-        sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
         sys.exit(1)
 
     category_path = parse_category(category) if category else None
@@ -993,21 +1084,40 @@ def cmd_pricing_analysis(args):
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
         return r
 
-    # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
-    results["meta"]["resolved_category"] = category_path
-
     # Step 1: Current Price Snapshot
     log("Step 1/8: Current price snapshot...")
     results["my_product"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
+    my_data = results["my_product"].get("data", {}) or {}
+    if not my_data.get("title"):
+        log(f"\n❌ ASIN '{my_asin}' not found or has no data. Please check the ASIN and try again.")
+        results["error"] = {"code": "ASIN_NOT_FOUND", "message": f"ASIN '{my_asin}' not found or returned empty data"}
+        output(results, args.format)
+        return
     results["meta"]["steps_completed"].append("price_snapshot")
+
+    # Step 1.5: Auto Category Detection
+    if not category_path:
+        # For pricing, we already have realtime data — extract directly first
+        if my_data.get("categoryPath"):
+            category_path = my_data["categoryPath"]
+            results["meta"]["category_source"] = "asin_realtime"
+            log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif my_data.get("bestsellersRank"):
+            leaf = my_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = safe_call("categories", {"categoryKeyword": leaf}, "categories")
+                results["categories"] = cat_result
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    results["meta"]["category_source"] = "asin_bsr"
+                    log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        # Fallback to keyword
+        if not category_path and keyword:
+            category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+            results["meta"]["category_source"] = category_source
+    results["meta"]["resolved_category"] = category_path
 
     # Step 2: Price Band Intelligence
     log("Step 2/8: Price band intelligence...")
@@ -1110,17 +1220,18 @@ def cmd_pricing_analysis(args):
     my_rc = results["my_product"].get("data", {}).get("ratingCount", 0)
     if my_rc and my_rc >= 50:
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if comp_asins:
         review_results["top_comp"] = safe_call("reviews/analysis", {
-            "asins": [comp_asins[0]], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [comp_asins[0]], "mode": "asin", "period": "6m"
         }, f"reviews {comp_asins[0]}")
     if not review_results and category_path:
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_context")
 
@@ -1157,9 +1268,6 @@ def cmd_daily_radar(args):
     if not asins_str:
         print("ERROR: --asins is required (comma-separated ASINs to track).", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     tracked_asins = [a.strip() for a in asins_str.split(",") if a.strip()]
     category_path = parse_category(category) if category else None
@@ -1175,14 +1283,10 @@ def cmd_daily_radar(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=tracked_asins[0] if tracked_asins else None, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
@@ -1292,10 +1396,9 @@ def cmd_daily_radar(args):
             r = safe_call("reviews/analysis", {
                 "asins": [review_asin],
                 "mode": "asin",
-                "labelType": "painPoints",
                 "period": "6m",
             }, f"reviews {review_asin}")
-            review_results["painPoints"] = r
+            review_results["painPoints"] = _filter_review_insights(r, "painPoints")
             break
     
     if not review_results:
@@ -1324,9 +1427,6 @@ def cmd_listing_audit(args):
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     category_path = parse_category(category) if category else None
     results = {"meta": {"my_asin": my_asin, "keyword": keyword, "category": category, "steps_completed": []}}
@@ -1341,14 +1441,10 @@ def cmd_listing_audit(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Audit Target
@@ -1451,21 +1547,22 @@ def cmd_listing_audit(args):
     if target_rc and target_rc >= 50:
         log(f"  → reviews/analysis ASIN mode: {my_asin}")
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if leader_asins:
         top_leader = leader_asins[0]
         log(f"  → reviews/analysis ASIN mode: {top_leader}")
         review_results["top_leader"] = safe_call("reviews/analysis", {
-            "asins": [top_leader], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [top_leader], "mode": "asin", "period": "6m"
         }, f"reviews {top_leader}")
     # Category fallback
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors", "improvements"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews category {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -1538,14 +1635,9 @@ def cmd_opportunity_scan(args):
         return r
 
     # Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Product Scan (mode-based + custom filters)
@@ -1684,23 +1776,22 @@ def cmd_opportunity_scan(args):
     log("Step 6/6: Consumer insights...")
     review_results = {}
     if category_path:
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
-            log(f"  → category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            if r.get("data") and r.get("data", {}).get("consumerInsights"):
-                review_results[lt] = r
-            else:
-                break
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
+        if r.get("data") and r.get("data", {}).get("consumerInsights"):
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     if not review_results:
         log("  → Falling back to ASIN mode...")
         review_asins = [a for a in top_asins[:3]]
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
+        if review_asins:
             r = safe_call("reviews/analysis", {
-                "asins": review_asins, "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews ASIN {lt}")
-            review_results[lt] = r
+                "asins": review_asins, "mode": "asin", "period": "6m"
+            }, "reviews ASIN")
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["review_mode"] = "category" if category_path and review_results.get("painPoints", {}).get("data", {}).get("consumerInsights") else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
@@ -1743,13 +1834,9 @@ def cmd_review_deepdive(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=target_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Target Identification
@@ -1775,26 +1862,25 @@ def cmd_review_deepdive(args):
     log("Step 2/5: Full review analysis (11 dimensions)...")
     label_types = ["painPoints", "positives", "buyingFactors", "improvements", "userProfiles",
                    "scenarios", "issues", "keywords", "usageTimes", "usageLocations", "behaviors"]
-    
+
     review_results = {}
-    # Target ASIN reviews
+    # Target ASIN reviews (single call, split client-side)
     if target_asin:
+        log(f"  → {target_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [target_asin], "mode": "asin", "period": "6m"
+        }, "reviews target")
         for lt in label_types:
-            log(f"  → {target_asin}: {lt}")
-            r = safe_call("reviews/analysis", {
-                "asins": [target_asin], "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            review_results[f"target_{lt}"] = r
-    
-    # Competitor comparison (top 2)
+            review_results[f"target_{lt}"] = _filter_review_insights(r, lt)
+
+    # Competitor comparison (top 2, single call each)
     for comp_asin in comp_asins[:2]:
-        log(f"  → Competitor {comp_asin}: painPoints + positives")
-        review_results[f"comp_{comp_asin}_painPoints"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+        log(f"  → Competitor {comp_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [comp_asin], "mode": "asin", "period": "6m"
         }, f"reviews comp {comp_asin}")
-        review_results[f"comp_{comp_asin}_positives"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "positives", "period": "6m"
-        }, f"reviews comp+ {comp_asin}")
+        review_results[f"comp_{comp_asin}_painPoints"] = _filter_review_insights(r, "painPoints")
+        review_results[f"comp_{comp_asin}_positives"] = _filter_review_insights(r, "positives")
     
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_analysis")
@@ -1960,12 +2046,19 @@ def cmd_analyze(args):
         print("ERROR: --asin, --asins, or --category is required.", file=sys.stderr)
         sys.exit(1)
 
-    if args.label_type:
-        params["labelType"] = args.label_type
     if args.period:
         params["period"] = args.period
 
     result = api_call("reviews/analysis", params)
+
+    # Client-side filtering by label type (v2 API returns all dimensions in one call)
+    if args.label_type and result.get("data") and result["data"].get("consumerInsights"):
+        requested = [t.strip() for t in args.label_type.split(",")]
+        result["data"]["consumerInsights"] = [
+            i for i in result["data"]["consumerInsights"]
+            if i.get("labelType") in requested
+        ]
+
     output(result, args.format)
 
 
@@ -2246,7 +2339,12 @@ Examples:
     p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+        print(f"ERROR: Unrecognized argument(s): {' '.join(unknown)}", file=sys.stderr)
+        print(f"Run 'apiclaw.py {cmd} --help' to see valid options.", file=sys.stderr)
+        sys.exit(1)
     args.func(args)
 
 

--- a/amazon-market-trend-scanner/scripts/apiclaw.py
+++ b/amazon-market-trend-scanner/scripts/apiclaw.py
@@ -234,6 +234,25 @@ def _filter_review_insights(result, label_type):
     return filtered
 
 
+def _fetch_all_history(api_caller, asins, start_date, end_date, log_fn=None):
+    """Fetch products/history for multiple ASINs (one API call per ASIN)."""
+    all_data = []
+    last_response = None
+    for asin in asins:
+        r = api_caller("products/history", {
+            "asin": asin, "startDate": start_date, "endDate": end_date,
+        }, f"history {asin}")
+        last_response = r
+        if r.get("data"):
+            all_data.append(r["data"])
+        elif log_fn:
+            log_fn(f"  ⚠️ No history data for {asin}")
+    if last_response is None:
+        return {"success": False, "data": [], "error": {"message": "No ASINs provided"}}
+    last_response["data"] = all_data
+    return last_response
+
+
 def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
     """
     Resolve categoryPath with multi-level fallback.
@@ -818,11 +837,7 @@ def cmd_market_entry(args):
     round1_asins = top_asins[:3]
     if round1_asins:
         tried_asins.update(round1_asins)
-        r = safe_call("products/history", {
-            "asins": round1_asins,
-            "startDate": thirty_days_ago,
-            "endDate": today,
-        }, "history round 1")
+        r = _fetch_all_history(safe_call, round1_asins, thirty_days_ago, today, log_fn=log)
         history_data = r.get("data", [])
 
     # Round 2: Try oldest products if round 1 was empty
@@ -831,11 +846,7 @@ def cmd_market_entry(args):
         if round2_asins:
             log(f"  → Round 1 empty, trying older ASINs: {round2_asins}")
             tried_asins.update(round2_asins)
-            r = safe_call("products/history", {
-                "asins": round2_asins,
-                "startDate": thirty_days_ago,
-                "endDate": today,
-            }, "history round 2")
+            r = _fetch_all_history(safe_call, round2_asins, thirty_days_ago, today, log_fn=log)
             history_data = r.get("data", [])
 
     results["product_history"] = {"data": history_data, "asins_tried": list(tried_asins)}
@@ -1012,9 +1023,7 @@ def cmd_competitor_analysis(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = ([my_asin] if my_asin else []) + top_asins[:5]
-    r = safe_call("products/history", {
-        "asins": history_asins[:8], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins[:8], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins[:8]}
     results["meta"]["steps_completed"].append("historical_trends")
 
@@ -1198,9 +1207,7 @@ def cmd_pricing_analysis(args):
             break
 
     history_asins = [my_asin] + comp_asins
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("price_trends")
 
@@ -1308,11 +1315,7 @@ def cmd_daily_radar(args):
     tried_asins = set()
     
     # Round 1: All tracked ASINs
-    r = safe_call("products/history", {
-        "asins": tracked_asins,
-        "startDate": seven_days_ago,
-        "endDate": today,
-    }, "history round 1")
+    r = _fetch_all_history(safe_call, tracked_asins, seven_days_ago, today, log_fn=log)
     history_data = r.get("data", [])
     tried_asins.update(tracked_asins)
 
@@ -1571,9 +1574,7 @@ def cmd_listing_audit(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = [my_asin] + leader_asins[:2]
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("trend_context")
 
@@ -1766,9 +1767,7 @@ def cmd_opportunity_scan(args):
     log("Step 5/6: Trend check...")
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
-    r = safe_call("products/history", {
-        "asins": top_asins[:5], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, top_asins[:5], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": top_asins[:5]}
     results["meta"]["steps_completed"].append("trend_check")
 
@@ -1942,9 +1941,7 @@ def cmd_review_deepdive(args):
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     hist_asins = [target_asin] + comp_asins[:2] if target_asin else comp_asins[:3]
     if hist_asins:
-        r = safe_call("products/history", {
-            "asins": hist_asins, "startDate": thirty_ago, "endDate": today
-        }, "history")
+        r = _fetch_all_history(safe_call, hist_asins, thirty_ago, today, log_fn=log)
         results["product_history"] = {"data": r.get("data", []), "asins_tried": hist_asins}
     results["meta"]["steps_completed"].append("price_trend_context")
 
@@ -2119,12 +2116,11 @@ def cmd_brand_detail(args):
 def cmd_product_history(args):
     """Get historical data (price, BSR, sales) for ASINs over a date range."""
     asins = [a.strip() for a in args.asins.split(",")]
-    params = {
-        "asins": asins,
-        "startDate": args.start_date,
-        "endDate": args.end_date,
-    }
-    result = api_call("products/history", params)
+
+    def _api_caller(endpoint, p, label=""):
+        return api_call(endpoint, p)
+
+    result = _fetch_all_history(_api_caller, asins, args.start_date, args.end_date)
     output(result, args.format)
 
 

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -20,8 +20,8 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 Tell me your budget and experience. I find opportunities, score them, and rank.
 
 ## Files
-- **Script**: `scripts/apiclaw.py` (execute, don't read) — run `--help` for params
-- **Reference**: `references/reference.md` (field names & response structure)
+- **Script**: `{skill_base_dir}/scripts/apiclaw.py` (execute, don't read) — run `--help` for params
+- **Reference**: `{skill_base_dir}/references/reference.md` (field names & response structure)
 
 ## Credential
 Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apiclaw.io/en/api-keys)
@@ -79,7 +79,7 @@ Scan with `market --keyword "{broad}" --topn 10`, rank subcategories by: newSkuR
 
 ## Composite Command
 ```bash
-python3 scripts/apiclaw.py opportunity-scan --keyword "{kw}" --category "{path}" --modes "beginner,emerging,underserved"
+python3 {skill_base_dir}/scripts/apiclaw.py opportunity-scan --keyword "{kw}" --category "{path}" --modes "beginner,emerging,underserved"
 ```
 Or with custom filters: `--sales-min 300 --ratings-max 100 --price-min 15 --price-max 35`
 

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -32,7 +32,7 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 - **Optional**: fulfillment preference (FBA/FBM), specific filter criteria
 
 ## API Pitfalls (see apiclaw skill for full list)
-- **MUST lock categoryPath first** via `categories` — keyword-only queries contaminate results
+- categoryPath is auto-resolved via `categories`, with fallback to top search result. If `category_source` is `inferred_from_search`, confirm with user — keyword-only queries contaminate results
 - All keyword-based endpoints MUST include `--category` when locked
 - Revenue = `sampleAvgMonthlyRevenue` directly. Sales = `monthlySalesFloor` (lower bound)
 - `reviews/analysis` needs 50+ reviews
@@ -84,10 +84,46 @@ python3 scripts/apiclaw.py opportunity-scan --keyword "{kw}" --category "{path}"
 Or with custom filters: `--sales-min 300 --ratings-max 100 --price-min 15 --price-max 35`
 
 ## Output
-Respond in user's language. Tag every conclusion: 📊 Data-backed / 🔍 Inferred / 💡 Directional.
+Respond in user's language.
 
 Sections: Scan Summary → Top 10 Opportunities Table → Detailed Analysis (Top 3) → Category Heatmap → Risk Alerts → Next Steps (S: buy sample, A: deep-dive, B: watch) → Data Provenance → API Usage
 
-Begin with disclaimer. If user provides COGS, calculate profit. User criteria override: ANY fail → CAUTION/AVOID.
+If user provides COGS, calculate profit. User criteria override: ANY fail → CAUTION/AVOID.
+
+### Language (required)
+
+Output language MUST match the user's input language. If the user asks in Chinese, the entire report is in Chinese. If in English, output in English. Exception: API field names (e.g. `monthlySalesFloor`, `categoryPath`), endpoint names, technical terms (e.g. ASIN, BSR, CR10, FBA, credits) remain in English.
+
+### Disclaimer (required, at the top of every report)
+
+> Data is based on APIClaw API sampling as of [date]. Monthly sales (`monthlySalesFloor`) are lower-bound estimates. This analysis is for reference only and should not be the sole basis for business decisions. Validate with additional sources before acting.
+
+### Confidence Labels (required, tag EVERY conclusion)
+
+- 📊 **Data-backed** — direct API data (e.g. "CR10 = 54.8% 📊")
+- 🔍 **Inferred** — logical reasoning from data (e.g. "brand concentration is moderate 🔍")
+- 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
+
+Rules: Strategy recommendations are NEVER 📊. Anomalies (>200% growth) are always 💡. User criteria override AI judgment.
+
+### Data Provenance (required)
+
+Include a table at the end of every report:
+
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+| (e.g. Market Overview) | `markets/search` | categoryPath, topN=10 | 📊 Top N sampling, sales are lower-bound |
+| ... | ... | ... | ... |
+
+Extract endpoint and params from `_query` in JSON output. Add notes: sampling method, T+1 delay, realtime vs DB, minimum review threshold, etc.
+
+### API Usage (required)
+
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+| (each endpoint used) | N | N |
+| **Total** | **N** | **N** |
+
+Extract from `meta.creditsConsumed` per response. End with `Credits remaining: N`.
 
 ## API Budget: ~50-60 credits

--- a/amazon-opportunity-discoverer/scripts/apiclaw.py
+++ b/amazon-opportunity-discoverer/scripts/apiclaw.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import sys
+import random
 import time
 import urllib.request
 import urllib.error
@@ -35,9 +36,15 @@ import urllib.error
 
 BASE_URL = "https://api.apiclaw.io/openapi/v2"  # APIClaw API base URL
 API_DOCS = "https://api.apiclaw.io/api-docs"   # API documentation URL
-MAX_RETRIES = 2       # Maximum number of retry attempts for failed requests
-RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on 429 (rate limit)
+MAX_RETRIES = 3       # Maximum number of retry attempts for failed requests
+RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
+RATE_LIMIT_RETRIES = 4  # Extra retries specifically for 429 rate limits
+RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
+MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
+
+# Global request pacer — prevents burst rate limit violations
+_last_request_time = 0.0
 
 # 13 built-in product selection modes
 # Each maps to a set of products/search filter parameters
@@ -110,6 +117,8 @@ def api_call(endpoint: str, params: dict) -> dict:
     Returns the parsed JSON response on success, with _query metadata injected.
     Exits with a clear error message on failure.
     """
+    global _last_request_time
+
     url = f"{BASE_URL}/{endpoint}"
     api_key = get_api_key()
 
@@ -131,8 +140,16 @@ def api_call(endpoint: str, params: dict) -> dict:
         "User-Agent": "APIClaw-CLI/1.0 (Python)",
     }
 
+    # Rate-limit pacing: enforce minimum interval between requests
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < MIN_REQUEST_INTERVAL:
+        time.sleep(MIN_REQUEST_INTERVAL - elapsed)
+
     delay = RETRY_DELAY
-    for attempt in range(1, MAX_RETRIES + 1):
+    max_attempts = MAX_RETRIES
+    for attempt in range(1, max_attempts + 1):
+        _last_request_time = time.monotonic()
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
@@ -163,9 +180,15 @@ def api_call(endpoint: str, params: dict) -> dict:
                     "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
                     endpoint, actual_params)
             elif status == 429:
-                if attempt < MAX_RETRIES:
-                    print(f"Rate limited (429). Waiting {delay}s before retry {attempt}/{MAX_RETRIES}...", file=sys.stderr)
-                    time.sleep(delay)
+                # Switch to longer retry strategy for rate limits
+                if attempt == 1:
+                    max_attempts = RATE_LIMIT_RETRIES
+                    delay = RATE_LIMIT_DELAY
+                if attempt < max_attempts:
+                    jitter = random.uniform(0, delay * 0.25)
+                    wait = delay + jitter
+                    print(f"Rate limited (429). Waiting {wait:.1f}s before retry {attempt}/{max_attempts}...", file=sys.stderr)
+                    time.sleep(wait)
                     delay *= 2
                     continue
                 else:
@@ -177,17 +200,17 @@ def api_call(endpoint: str, params: dict) -> dict:
                     f"Check {API_DOCS} for current endpoints",
                     endpoint, actual_params)
             else:
-                if attempt < MAX_RETRIES:
-                    print(f"HTTP {status}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                if attempt < max_attempts:
+                    print(f"HTTP {status}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                     time.sleep(delay)
                     continue
                 else:
-                    return _error_result(status, f"HTTP {status} after {MAX_RETRIES} attempts",
+                    return _error_result(status, f"HTTP {status} after {max_attempts} attempts",
                         "Check network or try again later",
                         endpoint, actual_params)
         except Exception as e:
-            if attempt < MAX_RETRIES:
-                print(f"Request failed: {e}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+            if attempt < max_attempts:
+                print(f"Request failed: {e}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                 time.sleep(delay)
                 continue
             else:
@@ -196,6 +219,94 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
 
     return _error_result(0, "Unexpected retry loop exit", "This should not happen", endpoint, actual_params)
+
+
+def _filter_review_insights(result, label_type):
+    """Return a shallow copy of a reviews/analysis result filtered to one labelType."""
+    if not result.get("data") or not result["data"].get("consumerInsights"):
+        return result
+    filtered = dict(result)
+    filtered["data"] = dict(result["data"])
+    filtered["data"]["consumerInsights"] = [
+        i for i in result["data"]["consumerInsights"]
+        if i.get("labelType") == label_type
+    ]
+    return filtered
+
+
+def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
+    """
+    Resolve categoryPath with multi-level fallback.
+    Returns (category_path, category_source) tuple.
+
+    Priority:
+      1. keyword → categories API
+      2. asin → realtime/product → categoryPath or bestsellersRank leaf
+      3. keyword → products/search → first result → realtime/product
+    """
+    category_path = None
+    category_source = "user"
+
+    # Priority 1: keyword → categories
+    if keyword:
+        log_fn("Step 0: Resolving category...")
+        cat_result = api_caller("categories", {"categoryKeyword": keyword}, "categories")
+        if results is not None:
+            results["categories"] = cat_result
+        cat_data = cat_result.get("data", [])
+        if cat_data:
+            category_path = cat_data[0].get("categoryPath")
+            category_source = "keyword"
+
+    # Priority 2: asin → realtime/product
+    if not category_path and asin:
+        log_fn("  → Resolving category from ASIN...")
+        rt = api_caller("realtime/product", {"asin": asin, "marketplace": "US"}, f"realtime {asin}")
+        if results is not None:
+            results.setdefault("_asin_realtime", rt)
+        rt_data = rt.get("data", {}) or {}
+        if rt_data.get("categoryPath"):
+            category_path = rt_data["categoryPath"]
+            category_source = "asin_realtime"
+            log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif rt_data.get("bestsellersRank"):
+            leaf = rt_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log_fn(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "asin_bsr"
+                    log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+
+    # Priority 3: keyword → search → first product → realtime
+    if not category_path and keyword:
+        log_fn("  → Resolving category from top search result...")
+        prod_result = api_caller("products/search", {
+            "keyword": keyword, "sortBy": "monthlySalesFloor", "sortOrder": "desc", "pageSize": 5
+        }, "products (category probe)")
+        prod_data = prod_result.get("data", [])
+        if isinstance(prod_data, list) and prod_data:
+            probe_asin = prod_data[0].get("asin")
+            if probe_asin:
+                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+                rt_data = rt.get("data", {}) or {}
+                if rt_data.get("categoryPath"):
+                    category_path = rt_data["categoryPath"]
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+                elif rt_data.get("bestsellersRank"):
+                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
+                    if leaf:
+                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                        cat_data = cat_result.get("data", [])
+                        if cat_data:
+                            category_path = cat_data[0].get("categoryPath")
+                            category_source = "inferred_from_search"
+                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+
+    return category_path, category_source
 
 
 def _error_result(status: int, message: str, action: str, endpoint: str, params: dict) -> dict:
@@ -344,9 +455,9 @@ def cmd_products(args):
     if args.fulfillment:
         params["fulfillments"] = args.fulfillment
     if args.include_brands:
-        params["includeBrands"] = args.include_brands
+        params["includeBrands"] = [b.strip() for b in args.include_brands.split(",")]
     if args.exclude_brands:
-        params["excludeBrands"] = args.exclude_brands
+        params["excludeBrands"] = [b.strip() for b in args.exclude_brands.split(",")]
 
     params["sortBy"] = args.sort or "monthlySalesFloor"
     params["sortOrder"] = args.order or "desc"
@@ -453,7 +564,7 @@ def cmd_report(args):
     print("Step 3/4: Searching top products...", file=sys.stderr)
     products_result = api_call("products/search", {
         "keyword": keyword,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 50,
     })
@@ -508,7 +619,7 @@ def cmd_opportunity(args):
         "keyword": keyword,
         "monthlySalesMin": 300,
         "ratingCountMax": 50,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 20,
     }
@@ -565,17 +676,9 @@ def cmd_market_entry(args):
         return r
 
     # ── Step 0.5: Category Resolution ──
-    if not category_path and keyword:
-        log("Step 0.5: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked category: {' > '.join(category_path)}")
-        else:
-            log("  ⚠️ No category match, will use keyword-only queries")
-
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # ── Step 1: Market Landscape (3 calls) ──
@@ -744,43 +847,36 @@ def cmd_market_entry(args):
     review_results = {}
     label_types = ["painPoints", "buyingFactors", "improvements"]
 
-    # Priority 1: Category mode
-    category_mode_success = True
+    # Priority 1: Category mode (single call, split client-side)
+    category_mode_success = False
     if category_path:
-        for lt in label_types:
-            log(f"  → reviews/analysis category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path,
-                "mode": "category",
-                "labelType": lt,
-                "period": "6m",
-            }, f"reviews {lt}")
-            if r.get("success") is False or not r.get("data", {}).get("consumerInsights"):
-                category_mode_success = False
-                log(f"  ⚠️ Category mode failed for {lt}")
-                break
-            review_results[lt] = r
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path,
+            "mode": "category",
+            "period": "6m",
+        }, "reviews category")
+        if r.get("success") and r.get("data", {}).get("consumerInsights"):
+            category_mode_success = True
+            for lt in label_types:
+                review_results[lt] = _filter_review_insights(r, lt)
 
     # Priority 2: ASIN mode (if category failed)
-    if not category_mode_success or not category_path:
+    if not category_mode_success:
         log("  → Falling back to ASIN mode...")
-        # Pick ASINs with ratingCount >= 50
         review_asins = [p.get("asin") for p in all_products if (p.get("ratingCount") or 0) >= 50][:3]
         if review_asins:
+            log(f"  → reviews/analysis ASIN mode ({review_asins})")
+            r = safe_call("reviews/analysis", {
+                "asins": review_asins,
+                "mode": "asin",
+                "period": "6m",
+            }, "reviews ASIN")
             for lt in label_types:
-                if lt in review_results:
-                    continue
-                log(f"  → reviews/analysis ASIN mode: {lt} ({review_asins})")
-                r = safe_call("reviews/analysis", {
-                    "asins": review_asins,
-                    "mode": "asin",
-                    "labelType": lt,
-                    "period": "6m",
-                }, f"reviews ASIN {lt}")
-                review_results[lt] = r
+                review_results[lt] = _filter_review_insights(r, lt)
 
     results["reviews"] = review_results
-    results["meta"]["review_mode"] = "category" if category_mode_success and category_path else "asin"
+    results["meta"]["review_mode"] = "category" if category_mode_success else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
 
     # ── Summary ──
@@ -819,14 +915,9 @@ def cmd_competitor_analysis(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
-    results["meta"]["resolved_category"] = category_path
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
 
     # Step 1: Competitor Discovery
     log("Step 1/7: Competitor discovery...")
@@ -844,6 +935,7 @@ def cmd_competitor_analysis(args):
     if category_path:
         comp_params["categoryPath"] = category_path
     results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    results["meta"]["resolved_category"] = category_path
     results["meta"]["steps_completed"].append("competitor_discovery")
 
     # Step 2: Market Context
@@ -931,16 +1023,17 @@ def cmd_competitor_analysis(args):
     review_results = {}
     for asin in top_asins[:5]:
         r = safe_call("reviews/analysis", {
-            "asins": [asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [asin], "mode": "asin", "period": "6m"
         }, f"reviews {asin}")
         if r.get("data") and r.get("data", {}).get("consumerInsights"):
             review_results[asin] = r
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -955,7 +1048,7 @@ def cmd_competitor_analysis(args):
                 bp["keyword"] = keyword
             if category_path:
                 bp["categoryPath"] = category_path
-            bp["includeBrands"] = top_brand
+            bp["includeBrands"] = [top_brand]
             results["top_brand_products"] = safe_call("products/search", bp, f"brand {top_brand}")
     results["meta"]["steps_completed"].append("brand_drilldown")
 
@@ -969,6 +1062,7 @@ def cmd_pricing_analysis(args):
     """
     Composite workflow: Pricing Analysis.
     Runs: realtime(my_asin) → price-band → products/competitors → market/brand → history → realtime(top5) → reviews
+    Category is auto-detected from ASIN if not provided.
     """
     my_asin = args.my_asin
     keyword = args.keyword
@@ -976,9 +1070,6 @@ def cmd_pricing_analysis(args):
 
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
-        sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
         sys.exit(1)
 
     category_path = parse_category(category) if category else None
@@ -993,21 +1084,40 @@ def cmd_pricing_analysis(args):
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
         return r
 
-    # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
-    results["meta"]["resolved_category"] = category_path
-
     # Step 1: Current Price Snapshot
     log("Step 1/8: Current price snapshot...")
     results["my_product"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
+    my_data = results["my_product"].get("data", {}) or {}
+    if not my_data.get("title"):
+        log(f"\n❌ ASIN '{my_asin}' not found or has no data. Please check the ASIN and try again.")
+        results["error"] = {"code": "ASIN_NOT_FOUND", "message": f"ASIN '{my_asin}' not found or returned empty data"}
+        output(results, args.format)
+        return
     results["meta"]["steps_completed"].append("price_snapshot")
+
+    # Step 1.5: Auto Category Detection
+    if not category_path:
+        # For pricing, we already have realtime data — extract directly first
+        if my_data.get("categoryPath"):
+            category_path = my_data["categoryPath"]
+            results["meta"]["category_source"] = "asin_realtime"
+            log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif my_data.get("bestsellersRank"):
+            leaf = my_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = safe_call("categories", {"categoryKeyword": leaf}, "categories")
+                results["categories"] = cat_result
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    results["meta"]["category_source"] = "asin_bsr"
+                    log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        # Fallback to keyword
+        if not category_path and keyword:
+            category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+            results["meta"]["category_source"] = category_source
+    results["meta"]["resolved_category"] = category_path
 
     # Step 2: Price Band Intelligence
     log("Step 2/8: Price band intelligence...")
@@ -1110,17 +1220,18 @@ def cmd_pricing_analysis(args):
     my_rc = results["my_product"].get("data", {}).get("ratingCount", 0)
     if my_rc and my_rc >= 50:
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if comp_asins:
         review_results["top_comp"] = safe_call("reviews/analysis", {
-            "asins": [comp_asins[0]], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [comp_asins[0]], "mode": "asin", "period": "6m"
         }, f"reviews {comp_asins[0]}")
     if not review_results and category_path:
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_context")
 
@@ -1157,9 +1268,6 @@ def cmd_daily_radar(args):
     if not asins_str:
         print("ERROR: --asins is required (comma-separated ASINs to track).", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     tracked_asins = [a.strip() for a in asins_str.split(",") if a.strip()]
     category_path = parse_category(category) if category else None
@@ -1175,14 +1283,10 @@ def cmd_daily_radar(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=tracked_asins[0] if tracked_asins else None, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
@@ -1292,10 +1396,9 @@ def cmd_daily_radar(args):
             r = safe_call("reviews/analysis", {
                 "asins": [review_asin],
                 "mode": "asin",
-                "labelType": "painPoints",
                 "period": "6m",
             }, f"reviews {review_asin}")
-            review_results["painPoints"] = r
+            review_results["painPoints"] = _filter_review_insights(r, "painPoints")
             break
     
     if not review_results:
@@ -1324,9 +1427,6 @@ def cmd_listing_audit(args):
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     category_path = parse_category(category) if category else None
     results = {"meta": {"my_asin": my_asin, "keyword": keyword, "category": category, "steps_completed": []}}
@@ -1341,14 +1441,10 @@ def cmd_listing_audit(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Audit Target
@@ -1451,21 +1547,22 @@ def cmd_listing_audit(args):
     if target_rc and target_rc >= 50:
         log(f"  → reviews/analysis ASIN mode: {my_asin}")
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if leader_asins:
         top_leader = leader_asins[0]
         log(f"  → reviews/analysis ASIN mode: {top_leader}")
         review_results["top_leader"] = safe_call("reviews/analysis", {
-            "asins": [top_leader], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [top_leader], "mode": "asin", "period": "6m"
         }, f"reviews {top_leader}")
     # Category fallback
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors", "improvements"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews category {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -1538,14 +1635,9 @@ def cmd_opportunity_scan(args):
         return r
 
     # Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Product Scan (mode-based + custom filters)
@@ -1684,23 +1776,22 @@ def cmd_opportunity_scan(args):
     log("Step 6/6: Consumer insights...")
     review_results = {}
     if category_path:
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
-            log(f"  → category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            if r.get("data") and r.get("data", {}).get("consumerInsights"):
-                review_results[lt] = r
-            else:
-                break
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
+        if r.get("data") and r.get("data", {}).get("consumerInsights"):
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     if not review_results:
         log("  → Falling back to ASIN mode...")
         review_asins = [a for a in top_asins[:3]]
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
+        if review_asins:
             r = safe_call("reviews/analysis", {
-                "asins": review_asins, "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews ASIN {lt}")
-            review_results[lt] = r
+                "asins": review_asins, "mode": "asin", "period": "6m"
+            }, "reviews ASIN")
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["review_mode"] = "category" if category_path and review_results.get("painPoints", {}).get("data", {}).get("consumerInsights") else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
@@ -1743,13 +1834,9 @@ def cmd_review_deepdive(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=target_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Target Identification
@@ -1775,26 +1862,25 @@ def cmd_review_deepdive(args):
     log("Step 2/5: Full review analysis (11 dimensions)...")
     label_types = ["painPoints", "positives", "buyingFactors", "improvements", "userProfiles",
                    "scenarios", "issues", "keywords", "usageTimes", "usageLocations", "behaviors"]
-    
+
     review_results = {}
-    # Target ASIN reviews
+    # Target ASIN reviews (single call, split client-side)
     if target_asin:
+        log(f"  → {target_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [target_asin], "mode": "asin", "period": "6m"
+        }, "reviews target")
         for lt in label_types:
-            log(f"  → {target_asin}: {lt}")
-            r = safe_call("reviews/analysis", {
-                "asins": [target_asin], "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            review_results[f"target_{lt}"] = r
-    
-    # Competitor comparison (top 2)
+            review_results[f"target_{lt}"] = _filter_review_insights(r, lt)
+
+    # Competitor comparison (top 2, single call each)
     for comp_asin in comp_asins[:2]:
-        log(f"  → Competitor {comp_asin}: painPoints + positives")
-        review_results[f"comp_{comp_asin}_painPoints"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+        log(f"  → Competitor {comp_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [comp_asin], "mode": "asin", "period": "6m"
         }, f"reviews comp {comp_asin}")
-        review_results[f"comp_{comp_asin}_positives"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "positives", "period": "6m"
-        }, f"reviews comp+ {comp_asin}")
+        review_results[f"comp_{comp_asin}_painPoints"] = _filter_review_insights(r, "painPoints")
+        review_results[f"comp_{comp_asin}_positives"] = _filter_review_insights(r, "positives")
     
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_analysis")
@@ -1960,12 +2046,19 @@ def cmd_analyze(args):
         print("ERROR: --asin, --asins, or --category is required.", file=sys.stderr)
         sys.exit(1)
 
-    if args.label_type:
-        params["labelType"] = args.label_type
     if args.period:
         params["period"] = args.period
 
     result = api_call("reviews/analysis", params)
+
+    # Client-side filtering by label type (v2 API returns all dimensions in one call)
+    if args.label_type and result.get("data") and result["data"].get("consumerInsights"):
+        requested = [t.strip() for t in args.label_type.split(",")]
+        result["data"]["consumerInsights"] = [
+            i for i in result["data"]["consumerInsights"]
+            if i.get("labelType") in requested
+        ]
+
     output(result, args.format)
 
 
@@ -2246,7 +2339,12 @@ Examples:
     p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+        print(f"ERROR: Unrecognized argument(s): {' '.join(unknown)}", file=sys.stderr)
+        print(f"Run 'apiclaw.py {cmd} --help' to see valid options.", file=sys.stderr)
+        sys.exit(1)
     args.func(args)
 
 

--- a/amazon-opportunity-discoverer/scripts/apiclaw.py
+++ b/amazon-opportunity-discoverer/scripts/apiclaw.py
@@ -234,6 +234,25 @@ def _filter_review_insights(result, label_type):
     return filtered
 
 
+def _fetch_all_history(api_caller, asins, start_date, end_date, log_fn=None):
+    """Fetch products/history for multiple ASINs (one API call per ASIN)."""
+    all_data = []
+    last_response = None
+    for asin in asins:
+        r = api_caller("products/history", {
+            "asin": asin, "startDate": start_date, "endDate": end_date,
+        }, f"history {asin}")
+        last_response = r
+        if r.get("data"):
+            all_data.append(r["data"])
+        elif log_fn:
+            log_fn(f"  ⚠️ No history data for {asin}")
+    if last_response is None:
+        return {"success": False, "data": [], "error": {"message": "No ASINs provided"}}
+    last_response["data"] = all_data
+    return last_response
+
+
 def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
     """
     Resolve categoryPath with multi-level fallback.
@@ -818,11 +837,7 @@ def cmd_market_entry(args):
     round1_asins = top_asins[:3]
     if round1_asins:
         tried_asins.update(round1_asins)
-        r = safe_call("products/history", {
-            "asins": round1_asins,
-            "startDate": thirty_days_ago,
-            "endDate": today,
-        }, "history round 1")
+        r = _fetch_all_history(safe_call, round1_asins, thirty_days_ago, today, log_fn=log)
         history_data = r.get("data", [])
 
     # Round 2: Try oldest products if round 1 was empty
@@ -831,11 +846,7 @@ def cmd_market_entry(args):
         if round2_asins:
             log(f"  → Round 1 empty, trying older ASINs: {round2_asins}")
             tried_asins.update(round2_asins)
-            r = safe_call("products/history", {
-                "asins": round2_asins,
-                "startDate": thirty_days_ago,
-                "endDate": today,
-            }, "history round 2")
+            r = _fetch_all_history(safe_call, round2_asins, thirty_days_ago, today, log_fn=log)
             history_data = r.get("data", [])
 
     results["product_history"] = {"data": history_data, "asins_tried": list(tried_asins)}
@@ -1012,9 +1023,7 @@ def cmd_competitor_analysis(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = ([my_asin] if my_asin else []) + top_asins[:5]
-    r = safe_call("products/history", {
-        "asins": history_asins[:8], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins[:8], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins[:8]}
     results["meta"]["steps_completed"].append("historical_trends")
 
@@ -1198,9 +1207,7 @@ def cmd_pricing_analysis(args):
             break
 
     history_asins = [my_asin] + comp_asins
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("price_trends")
 
@@ -1308,11 +1315,7 @@ def cmd_daily_radar(args):
     tried_asins = set()
     
     # Round 1: All tracked ASINs
-    r = safe_call("products/history", {
-        "asins": tracked_asins,
-        "startDate": seven_days_ago,
-        "endDate": today,
-    }, "history round 1")
+    r = _fetch_all_history(safe_call, tracked_asins, seven_days_ago, today, log_fn=log)
     history_data = r.get("data", [])
     tried_asins.update(tracked_asins)
 
@@ -1571,9 +1574,7 @@ def cmd_listing_audit(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = [my_asin] + leader_asins[:2]
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("trend_context")
 
@@ -1766,9 +1767,7 @@ def cmd_opportunity_scan(args):
     log("Step 5/6: Trend check...")
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
-    r = safe_call("products/history", {
-        "asins": top_asins[:5], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, top_asins[:5], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": top_asins[:5]}
     results["meta"]["steps_completed"].append("trend_check")
 
@@ -1942,9 +1941,7 @@ def cmd_review_deepdive(args):
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     hist_asins = [target_asin] + comp_asins[:2] if target_asin else comp_asins[:3]
     if hist_asins:
-        r = safe_call("products/history", {
-            "asins": hist_asins, "startDate": thirty_ago, "endDate": today
-        }, "history")
+        r = _fetch_all_history(safe_call, hist_asins, thirty_ago, today, log_fn=log)
         results["product_history"] = {"data": r.get("data", []), "asins_tried": hist_asins}
     results["meta"]["steps_completed"].append("price_trend_context")
 
@@ -2119,12 +2116,11 @@ def cmd_brand_detail(args):
 def cmd_product_history(args):
     """Get historical data (price, BSR, sales) for ASINs over a date range."""
     asins = [a.strip() for a in args.asins.split(",")]
-    params = {
-        "asins": asins,
-        "startDate": args.start_date,
-        "endDate": args.end_date,
-    }
-    result = api_call("products/history", params)
+
+    def _api_caller(endpoint, p, label=""):
+        return api_call(endpoint, p)
+
+    result = _fetch_all_history(_api_caller, asins, args.start_date, args.end_date)
     output(result, args.format)
 
 

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -22,8 +22,8 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 Give me your ASIN(s). I'll tell you whether to raise, hold, or lower — with data.
 
 ## Files
-- **Script**: `scripts/apiclaw.py` (execute, don't read) — run `--help` for params
-- **Reference**: `references/reference.md` (field names & response structure)
+- **Script**: `{skill_base_dir}/scripts/apiclaw.py` (execute, don't read) — run `--help` for params
+- **Reference**: `{skill_base_dir}/references/reference.md` (field names & response structure)
 
 ## Credential
 Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apiclaw.io/en/api-keys)

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -67,14 +67,65 @@ Highest ratio = best entry point (strong demand + low review barriers).
 3 scenarios: Conservative (current price), Moderate (±$1-2), Aggressive (±$3-5).
 Per scenario: Revenue = Price × Est. Sales − FBA Fee − Referral Fee (15%) − COGS = Net Profit & Margin.
 
+### Profit Margin Interpretation
+| Net Margin | Signal | Interpretation |
+|------------|--------|---------------|
+| >30% | 🟢 Healthy | Strong margin, room for ad spend and promotions 📊 |
+| 15-30% | 🟡 Acceptable | Viable but monitor costs closely 🔍 |
+| 5-15% | 🟠 Thin | One price war or cost increase away from loss 🔍 |
+| <5% | 🔴 Unsustainable | Must raise price, cut costs, or exit 💡 |
+
+### Price Position Analysis
+- **Price < opportunity band min**: Underpriced — likely leaving money on the table if rating ≥ category avg 🔍
+- **Price in opportunity band**: Optimal zone — hold unless competitors shift 🔍
+- **Price in hottest band**: Maximum volume zone — high competition, margin pressure likely 🔍
+- **Price > hottest band max**: Premium positioning — only viable with strong brand/reviews 🔍
+- **DB price ≠ Realtime price** (>5% diff): Likely running a promotion or coupon — flag as temporary 📊
+
 ## Output
-Respond in user's language. Tag every conclusion: 📊 Data-backed / 🔍 Inferred / 💡 Directional.
+Respond in user's language.
 
 **Per ASIN**: Price Signal (RAISE/HOLD/LOWER) → Current Position in Category → Price Band Heatmap (with Sales/Competition Ratio) → Competitor Price Map (top 10 in leaf category) → 30-Day Trend → Profit Simulation (3 scenarios) → BuyBox Analysis → Recommended Price.
 
 **Batch summary** (if multiple ASINs): Overview table (ASIN | Product | Category | Current Price | Signal | Recommended) → Per-ASIN detail.
 
-End with: Data Provenance → API Usage. Begin with disclaimer. Flag DB vs Realtime discrepancies as likely promotions.
+End with: Data Provenance → API Usage. Flag DB vs Realtime discrepancies as likely promotions.
+
+### Language (required)
+
+Output language MUST match the user's input language. If the user asks in Chinese, the entire report is in Chinese. If in English, output in English. Exception: API field names (e.g. `monthlySalesFloor`, `categoryPath`), endpoint names, technical terms (e.g. ASIN, BSR, CR10, FBA, credits) remain in English.
+
+### Disclaimer (required, at the top of every report)
+
+> Data is based on APIClaw API sampling as of [date]. Monthly sales (`monthlySalesFloor`) are lower-bound estimates. This analysis is for reference only and should not be the sole basis for business decisions. Validate with additional sources before acting.
+
+### Confidence Labels (required, tag EVERY conclusion)
+
+- 📊 **Data-backed** — direct API data (e.g. "current price $12.99 📊")
+- 🔍 **Inferred** — logical reasoning from data (e.g. "price is below opportunity band 🔍")
+- 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider raising to $14.99 💡")
+
+Rules: Strategy recommendations and price signals (RAISE/HOLD/LOWER) are NEVER 📊. User criteria override AI judgment.
+
+### Data Provenance (required)
+
+Include a table at the end of every report:
+
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+| (e.g. Market Overview) | `markets/search` | categoryPath, topN=10 | 📊 Top N sampling, sales are lower-bound |
+| ... | ... | ... | ... |
+
+Extract endpoint and params from `_query` in JSON output. Add notes: sampling method, T+1 delay, realtime vs DB, minimum review threshold, etc.
+
+### API Usage (required)
+
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+| (each endpoint used) | N | N |
+| **Total** | **N** | **N** |
+
+Extract from `meta.creditsConsumed` per response. End with `Credits remaining: N`.
 
 ## API Budget
 - Single ASIN: ~20-25 credits

--- a/amazon-pricing-command-center/scripts/apiclaw.py
+++ b/amazon-pricing-command-center/scripts/apiclaw.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import sys
+import random
 import time
 import urllib.request
 import urllib.error
@@ -35,9 +36,15 @@ import urllib.error
 
 BASE_URL = "https://api.apiclaw.io/openapi/v2"  # APIClaw API base URL
 API_DOCS = "https://api.apiclaw.io/api-docs"   # API documentation URL
-MAX_RETRIES = 2       # Maximum number of retry attempts for failed requests
-RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on 429 (rate limit)
+MAX_RETRIES = 3       # Maximum number of retry attempts for failed requests
+RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
+RATE_LIMIT_RETRIES = 4  # Extra retries specifically for 429 rate limits
+RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
+MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
+
+# Global request pacer — prevents burst rate limit violations
+_last_request_time = 0.0
 
 # 13 built-in product selection modes
 # Each maps to a set of products/search filter parameters
@@ -110,6 +117,8 @@ def api_call(endpoint: str, params: dict) -> dict:
     Returns the parsed JSON response on success, with _query metadata injected.
     Exits with a clear error message on failure.
     """
+    global _last_request_time
+
     url = f"{BASE_URL}/{endpoint}"
     api_key = get_api_key()
 
@@ -131,8 +140,16 @@ def api_call(endpoint: str, params: dict) -> dict:
         "User-Agent": "APIClaw-CLI/1.0 (Python)",
     }
 
+    # Rate-limit pacing: enforce minimum interval between requests
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < MIN_REQUEST_INTERVAL:
+        time.sleep(MIN_REQUEST_INTERVAL - elapsed)
+
     delay = RETRY_DELAY
-    for attempt in range(1, MAX_RETRIES + 1):
+    max_attempts = MAX_RETRIES
+    for attempt in range(1, max_attempts + 1):
+        _last_request_time = time.monotonic()
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
@@ -163,9 +180,15 @@ def api_call(endpoint: str, params: dict) -> dict:
                     "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
                     endpoint, actual_params)
             elif status == 429:
-                if attempt < MAX_RETRIES:
-                    print(f"Rate limited (429). Waiting {delay}s before retry {attempt}/{MAX_RETRIES}...", file=sys.stderr)
-                    time.sleep(delay)
+                # Switch to longer retry strategy for rate limits
+                if attempt == 1:
+                    max_attempts = RATE_LIMIT_RETRIES
+                    delay = RATE_LIMIT_DELAY
+                if attempt < max_attempts:
+                    jitter = random.uniform(0, delay * 0.25)
+                    wait = delay + jitter
+                    print(f"Rate limited (429). Waiting {wait:.1f}s before retry {attempt}/{max_attempts}...", file=sys.stderr)
+                    time.sleep(wait)
                     delay *= 2
                     continue
                 else:
@@ -177,17 +200,17 @@ def api_call(endpoint: str, params: dict) -> dict:
                     f"Check {API_DOCS} for current endpoints",
                     endpoint, actual_params)
             else:
-                if attempt < MAX_RETRIES:
-                    print(f"HTTP {status}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                if attempt < max_attempts:
+                    print(f"HTTP {status}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                     time.sleep(delay)
                     continue
                 else:
-                    return _error_result(status, f"HTTP {status} after {MAX_RETRIES} attempts",
+                    return _error_result(status, f"HTTP {status} after {max_attempts} attempts",
                         "Check network or try again later",
                         endpoint, actual_params)
         except Exception as e:
-            if attempt < MAX_RETRIES:
-                print(f"Request failed: {e}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+            if attempt < max_attempts:
+                print(f"Request failed: {e}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                 time.sleep(delay)
                 continue
             else:
@@ -196,6 +219,94 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
 
     return _error_result(0, "Unexpected retry loop exit", "This should not happen", endpoint, actual_params)
+
+
+def _filter_review_insights(result, label_type):
+    """Return a shallow copy of a reviews/analysis result filtered to one labelType."""
+    if not result.get("data") or not result["data"].get("consumerInsights"):
+        return result
+    filtered = dict(result)
+    filtered["data"] = dict(result["data"])
+    filtered["data"]["consumerInsights"] = [
+        i for i in result["data"]["consumerInsights"]
+        if i.get("labelType") == label_type
+    ]
+    return filtered
+
+
+def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
+    """
+    Resolve categoryPath with multi-level fallback.
+    Returns (category_path, category_source) tuple.
+
+    Priority:
+      1. keyword → categories API
+      2. asin → realtime/product → categoryPath or bestsellersRank leaf
+      3. keyword → products/search → first result → realtime/product
+    """
+    category_path = None
+    category_source = "user"
+
+    # Priority 1: keyword → categories
+    if keyword:
+        log_fn("Step 0: Resolving category...")
+        cat_result = api_caller("categories", {"categoryKeyword": keyword}, "categories")
+        if results is not None:
+            results["categories"] = cat_result
+        cat_data = cat_result.get("data", [])
+        if cat_data:
+            category_path = cat_data[0].get("categoryPath")
+            category_source = "keyword"
+
+    # Priority 2: asin → realtime/product
+    if not category_path and asin:
+        log_fn("  → Resolving category from ASIN...")
+        rt = api_caller("realtime/product", {"asin": asin, "marketplace": "US"}, f"realtime {asin}")
+        if results is not None:
+            results.setdefault("_asin_realtime", rt)
+        rt_data = rt.get("data", {}) or {}
+        if rt_data.get("categoryPath"):
+            category_path = rt_data["categoryPath"]
+            category_source = "asin_realtime"
+            log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif rt_data.get("bestsellersRank"):
+            leaf = rt_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log_fn(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "asin_bsr"
+                    log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+
+    # Priority 3: keyword → search → first product → realtime
+    if not category_path and keyword:
+        log_fn("  → Resolving category from top search result...")
+        prod_result = api_caller("products/search", {
+            "keyword": keyword, "sortBy": "monthlySalesFloor", "sortOrder": "desc", "pageSize": 5
+        }, "products (category probe)")
+        prod_data = prod_result.get("data", [])
+        if isinstance(prod_data, list) and prod_data:
+            probe_asin = prod_data[0].get("asin")
+            if probe_asin:
+                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+                rt_data = rt.get("data", {}) or {}
+                if rt_data.get("categoryPath"):
+                    category_path = rt_data["categoryPath"]
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+                elif rt_data.get("bestsellersRank"):
+                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
+                    if leaf:
+                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                        cat_data = cat_result.get("data", [])
+                        if cat_data:
+                            category_path = cat_data[0].get("categoryPath")
+                            category_source = "inferred_from_search"
+                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+
+    return category_path, category_source
 
 
 def _error_result(status: int, message: str, action: str, endpoint: str, params: dict) -> dict:
@@ -344,9 +455,9 @@ def cmd_products(args):
     if args.fulfillment:
         params["fulfillments"] = args.fulfillment
     if args.include_brands:
-        params["includeBrands"] = args.include_brands
+        params["includeBrands"] = [b.strip() for b in args.include_brands.split(",")]
     if args.exclude_brands:
-        params["excludeBrands"] = args.exclude_brands
+        params["excludeBrands"] = [b.strip() for b in args.exclude_brands.split(",")]
 
     params["sortBy"] = args.sort or "monthlySalesFloor"
     params["sortOrder"] = args.order or "desc"
@@ -453,7 +564,7 @@ def cmd_report(args):
     print("Step 3/4: Searching top products...", file=sys.stderr)
     products_result = api_call("products/search", {
         "keyword": keyword,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 50,
     })
@@ -508,7 +619,7 @@ def cmd_opportunity(args):
         "keyword": keyword,
         "monthlySalesMin": 300,
         "ratingCountMax": 50,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 20,
     }
@@ -565,17 +676,9 @@ def cmd_market_entry(args):
         return r
 
     # ── Step 0.5: Category Resolution ──
-    if not category_path and keyword:
-        log("Step 0.5: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked category: {' > '.join(category_path)}")
-        else:
-            log("  ⚠️ No category match, will use keyword-only queries")
-
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # ── Step 1: Market Landscape (3 calls) ──
@@ -744,43 +847,36 @@ def cmd_market_entry(args):
     review_results = {}
     label_types = ["painPoints", "buyingFactors", "improvements"]
 
-    # Priority 1: Category mode
-    category_mode_success = True
+    # Priority 1: Category mode (single call, split client-side)
+    category_mode_success = False
     if category_path:
-        for lt in label_types:
-            log(f"  → reviews/analysis category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path,
-                "mode": "category",
-                "labelType": lt,
-                "period": "6m",
-            }, f"reviews {lt}")
-            if r.get("success") is False or not r.get("data", {}).get("consumerInsights"):
-                category_mode_success = False
-                log(f"  ⚠️ Category mode failed for {lt}")
-                break
-            review_results[lt] = r
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path,
+            "mode": "category",
+            "period": "6m",
+        }, "reviews category")
+        if r.get("success") and r.get("data", {}).get("consumerInsights"):
+            category_mode_success = True
+            for lt in label_types:
+                review_results[lt] = _filter_review_insights(r, lt)
 
     # Priority 2: ASIN mode (if category failed)
-    if not category_mode_success or not category_path:
+    if not category_mode_success:
         log("  → Falling back to ASIN mode...")
-        # Pick ASINs with ratingCount >= 50
         review_asins = [p.get("asin") for p in all_products if (p.get("ratingCount") or 0) >= 50][:3]
         if review_asins:
+            log(f"  → reviews/analysis ASIN mode ({review_asins})")
+            r = safe_call("reviews/analysis", {
+                "asins": review_asins,
+                "mode": "asin",
+                "period": "6m",
+            }, "reviews ASIN")
             for lt in label_types:
-                if lt in review_results:
-                    continue
-                log(f"  → reviews/analysis ASIN mode: {lt} ({review_asins})")
-                r = safe_call("reviews/analysis", {
-                    "asins": review_asins,
-                    "mode": "asin",
-                    "labelType": lt,
-                    "period": "6m",
-                }, f"reviews ASIN {lt}")
-                review_results[lt] = r
+                review_results[lt] = _filter_review_insights(r, lt)
 
     results["reviews"] = review_results
-    results["meta"]["review_mode"] = "category" if category_mode_success and category_path else "asin"
+    results["meta"]["review_mode"] = "category" if category_mode_success else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
 
     # ── Summary ──
@@ -819,14 +915,9 @@ def cmd_competitor_analysis(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
-    results["meta"]["resolved_category"] = category_path
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
 
     # Step 1: Competitor Discovery
     log("Step 1/7: Competitor discovery...")
@@ -844,6 +935,7 @@ def cmd_competitor_analysis(args):
     if category_path:
         comp_params["categoryPath"] = category_path
     results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    results["meta"]["resolved_category"] = category_path
     results["meta"]["steps_completed"].append("competitor_discovery")
 
     # Step 2: Market Context
@@ -931,16 +1023,17 @@ def cmd_competitor_analysis(args):
     review_results = {}
     for asin in top_asins[:5]:
         r = safe_call("reviews/analysis", {
-            "asins": [asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [asin], "mode": "asin", "period": "6m"
         }, f"reviews {asin}")
         if r.get("data") and r.get("data", {}).get("consumerInsights"):
             review_results[asin] = r
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -955,7 +1048,7 @@ def cmd_competitor_analysis(args):
                 bp["keyword"] = keyword
             if category_path:
                 bp["categoryPath"] = category_path
-            bp["includeBrands"] = top_brand
+            bp["includeBrands"] = [top_brand]
             results["top_brand_products"] = safe_call("products/search", bp, f"brand {top_brand}")
     results["meta"]["steps_completed"].append("brand_drilldown")
 
@@ -969,6 +1062,7 @@ def cmd_pricing_analysis(args):
     """
     Composite workflow: Pricing Analysis.
     Runs: realtime(my_asin) → price-band → products/competitors → market/brand → history → realtime(top5) → reviews
+    Category is auto-detected from ASIN if not provided.
     """
     my_asin = args.my_asin
     keyword = args.keyword
@@ -976,9 +1070,6 @@ def cmd_pricing_analysis(args):
 
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
-        sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
         sys.exit(1)
 
     category_path = parse_category(category) if category else None
@@ -993,21 +1084,40 @@ def cmd_pricing_analysis(args):
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
         return r
 
-    # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
-    results["meta"]["resolved_category"] = category_path
-
     # Step 1: Current Price Snapshot
     log("Step 1/8: Current price snapshot...")
     results["my_product"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
+    my_data = results["my_product"].get("data", {}) or {}
+    if not my_data.get("title"):
+        log(f"\n❌ ASIN '{my_asin}' not found or has no data. Please check the ASIN and try again.")
+        results["error"] = {"code": "ASIN_NOT_FOUND", "message": f"ASIN '{my_asin}' not found or returned empty data"}
+        output(results, args.format)
+        return
     results["meta"]["steps_completed"].append("price_snapshot")
+
+    # Step 1.5: Auto Category Detection
+    if not category_path:
+        # For pricing, we already have realtime data — extract directly first
+        if my_data.get("categoryPath"):
+            category_path = my_data["categoryPath"]
+            results["meta"]["category_source"] = "asin_realtime"
+            log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif my_data.get("bestsellersRank"):
+            leaf = my_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = safe_call("categories", {"categoryKeyword": leaf}, "categories")
+                results["categories"] = cat_result
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    results["meta"]["category_source"] = "asin_bsr"
+                    log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        # Fallback to keyword
+        if not category_path and keyword:
+            category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+            results["meta"]["category_source"] = category_source
+    results["meta"]["resolved_category"] = category_path
 
     # Step 2: Price Band Intelligence
     log("Step 2/8: Price band intelligence...")
@@ -1110,17 +1220,18 @@ def cmd_pricing_analysis(args):
     my_rc = results["my_product"].get("data", {}).get("ratingCount", 0)
     if my_rc and my_rc >= 50:
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if comp_asins:
         review_results["top_comp"] = safe_call("reviews/analysis", {
-            "asins": [comp_asins[0]], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [comp_asins[0]], "mode": "asin", "period": "6m"
         }, f"reviews {comp_asins[0]}")
     if not review_results and category_path:
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_context")
 
@@ -1157,9 +1268,6 @@ def cmd_daily_radar(args):
     if not asins_str:
         print("ERROR: --asins is required (comma-separated ASINs to track).", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     tracked_asins = [a.strip() for a in asins_str.split(",") if a.strip()]
     category_path = parse_category(category) if category else None
@@ -1175,14 +1283,10 @@ def cmd_daily_radar(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=tracked_asins[0] if tracked_asins else None, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
@@ -1292,10 +1396,9 @@ def cmd_daily_radar(args):
             r = safe_call("reviews/analysis", {
                 "asins": [review_asin],
                 "mode": "asin",
-                "labelType": "painPoints",
                 "period": "6m",
             }, f"reviews {review_asin}")
-            review_results["painPoints"] = r
+            review_results["painPoints"] = _filter_review_insights(r, "painPoints")
             break
     
     if not review_results:
@@ -1324,9 +1427,6 @@ def cmd_listing_audit(args):
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     category_path = parse_category(category) if category else None
     results = {"meta": {"my_asin": my_asin, "keyword": keyword, "category": category, "steps_completed": []}}
@@ -1341,14 +1441,10 @@ def cmd_listing_audit(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Audit Target
@@ -1451,21 +1547,22 @@ def cmd_listing_audit(args):
     if target_rc and target_rc >= 50:
         log(f"  → reviews/analysis ASIN mode: {my_asin}")
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if leader_asins:
         top_leader = leader_asins[0]
         log(f"  → reviews/analysis ASIN mode: {top_leader}")
         review_results["top_leader"] = safe_call("reviews/analysis", {
-            "asins": [top_leader], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [top_leader], "mode": "asin", "period": "6m"
         }, f"reviews {top_leader}")
     # Category fallback
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors", "improvements"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews category {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -1538,14 +1635,9 @@ def cmd_opportunity_scan(args):
         return r
 
     # Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Product Scan (mode-based + custom filters)
@@ -1684,23 +1776,22 @@ def cmd_opportunity_scan(args):
     log("Step 6/6: Consumer insights...")
     review_results = {}
     if category_path:
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
-            log(f"  → category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            if r.get("data") and r.get("data", {}).get("consumerInsights"):
-                review_results[lt] = r
-            else:
-                break
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
+        if r.get("data") and r.get("data", {}).get("consumerInsights"):
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     if not review_results:
         log("  → Falling back to ASIN mode...")
         review_asins = [a for a in top_asins[:3]]
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
+        if review_asins:
             r = safe_call("reviews/analysis", {
-                "asins": review_asins, "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews ASIN {lt}")
-            review_results[lt] = r
+                "asins": review_asins, "mode": "asin", "period": "6m"
+            }, "reviews ASIN")
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["review_mode"] = "category" if category_path and review_results.get("painPoints", {}).get("data", {}).get("consumerInsights") else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
@@ -1743,13 +1834,9 @@ def cmd_review_deepdive(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=target_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Target Identification
@@ -1775,26 +1862,25 @@ def cmd_review_deepdive(args):
     log("Step 2/5: Full review analysis (11 dimensions)...")
     label_types = ["painPoints", "positives", "buyingFactors", "improvements", "userProfiles",
                    "scenarios", "issues", "keywords", "usageTimes", "usageLocations", "behaviors"]
-    
+
     review_results = {}
-    # Target ASIN reviews
+    # Target ASIN reviews (single call, split client-side)
     if target_asin:
+        log(f"  → {target_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [target_asin], "mode": "asin", "period": "6m"
+        }, "reviews target")
         for lt in label_types:
-            log(f"  → {target_asin}: {lt}")
-            r = safe_call("reviews/analysis", {
-                "asins": [target_asin], "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            review_results[f"target_{lt}"] = r
-    
-    # Competitor comparison (top 2)
+            review_results[f"target_{lt}"] = _filter_review_insights(r, lt)
+
+    # Competitor comparison (top 2, single call each)
     for comp_asin in comp_asins[:2]:
-        log(f"  → Competitor {comp_asin}: painPoints + positives")
-        review_results[f"comp_{comp_asin}_painPoints"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+        log(f"  → Competitor {comp_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [comp_asin], "mode": "asin", "period": "6m"
         }, f"reviews comp {comp_asin}")
-        review_results[f"comp_{comp_asin}_positives"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "positives", "period": "6m"
-        }, f"reviews comp+ {comp_asin}")
+        review_results[f"comp_{comp_asin}_painPoints"] = _filter_review_insights(r, "painPoints")
+        review_results[f"comp_{comp_asin}_positives"] = _filter_review_insights(r, "positives")
     
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_analysis")
@@ -1960,12 +2046,19 @@ def cmd_analyze(args):
         print("ERROR: --asin, --asins, or --category is required.", file=sys.stderr)
         sys.exit(1)
 
-    if args.label_type:
-        params["labelType"] = args.label_type
     if args.period:
         params["period"] = args.period
 
     result = api_call("reviews/analysis", params)
+
+    # Client-side filtering by label type (v2 API returns all dimensions in one call)
+    if args.label_type and result.get("data") and result["data"].get("consumerInsights"):
+        requested = [t.strip() for t in args.label_type.split(",")]
+        result["data"]["consumerInsights"] = [
+            i for i in result["data"]["consumerInsights"]
+            if i.get("labelType") in requested
+        ]
+
     output(result, args.format)
 
 
@@ -2246,7 +2339,12 @@ Examples:
     p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+        print(f"ERROR: Unrecognized argument(s): {' '.join(unknown)}", file=sys.stderr)
+        print(f"Run 'apiclaw.py {cmd} --help' to see valid options.", file=sys.stderr)
+        sys.exit(1)
     args.func(args)
 
 

--- a/amazon-pricing-command-center/scripts/apiclaw.py
+++ b/amazon-pricing-command-center/scripts/apiclaw.py
@@ -234,6 +234,25 @@ def _filter_review_insights(result, label_type):
     return filtered
 
 
+def _fetch_all_history(api_caller, asins, start_date, end_date, log_fn=None):
+    """Fetch products/history for multiple ASINs (one API call per ASIN)."""
+    all_data = []
+    last_response = None
+    for asin in asins:
+        r = api_caller("products/history", {
+            "asin": asin, "startDate": start_date, "endDate": end_date,
+        }, f"history {asin}")
+        last_response = r
+        if r.get("data"):
+            all_data.append(r["data"])
+        elif log_fn:
+            log_fn(f"  ⚠️ No history data for {asin}")
+    if last_response is None:
+        return {"success": False, "data": [], "error": {"message": "No ASINs provided"}}
+    last_response["data"] = all_data
+    return last_response
+
+
 def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
     """
     Resolve categoryPath with multi-level fallback.
@@ -818,11 +837,7 @@ def cmd_market_entry(args):
     round1_asins = top_asins[:3]
     if round1_asins:
         tried_asins.update(round1_asins)
-        r = safe_call("products/history", {
-            "asins": round1_asins,
-            "startDate": thirty_days_ago,
-            "endDate": today,
-        }, "history round 1")
+        r = _fetch_all_history(safe_call, round1_asins, thirty_days_ago, today, log_fn=log)
         history_data = r.get("data", [])
 
     # Round 2: Try oldest products if round 1 was empty
@@ -831,11 +846,7 @@ def cmd_market_entry(args):
         if round2_asins:
             log(f"  → Round 1 empty, trying older ASINs: {round2_asins}")
             tried_asins.update(round2_asins)
-            r = safe_call("products/history", {
-                "asins": round2_asins,
-                "startDate": thirty_days_ago,
-                "endDate": today,
-            }, "history round 2")
+            r = _fetch_all_history(safe_call, round2_asins, thirty_days_ago, today, log_fn=log)
             history_data = r.get("data", [])
 
     results["product_history"] = {"data": history_data, "asins_tried": list(tried_asins)}
@@ -1012,9 +1023,7 @@ def cmd_competitor_analysis(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = ([my_asin] if my_asin else []) + top_asins[:5]
-    r = safe_call("products/history", {
-        "asins": history_asins[:8], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins[:8], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins[:8]}
     results["meta"]["steps_completed"].append("historical_trends")
 
@@ -1198,9 +1207,7 @@ def cmd_pricing_analysis(args):
             break
 
     history_asins = [my_asin] + comp_asins
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("price_trends")
 
@@ -1308,11 +1315,7 @@ def cmd_daily_radar(args):
     tried_asins = set()
     
     # Round 1: All tracked ASINs
-    r = safe_call("products/history", {
-        "asins": tracked_asins,
-        "startDate": seven_days_ago,
-        "endDate": today,
-    }, "history round 1")
+    r = _fetch_all_history(safe_call, tracked_asins, seven_days_ago, today, log_fn=log)
     history_data = r.get("data", [])
     tried_asins.update(tracked_asins)
 
@@ -1571,9 +1574,7 @@ def cmd_listing_audit(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = [my_asin] + leader_asins[:2]
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("trend_context")
 
@@ -1766,9 +1767,7 @@ def cmd_opportunity_scan(args):
     log("Step 5/6: Trend check...")
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
-    r = safe_call("products/history", {
-        "asins": top_asins[:5], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, top_asins[:5], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": top_asins[:5]}
     results["meta"]["steps_completed"].append("trend_check")
 
@@ -1942,9 +1941,7 @@ def cmd_review_deepdive(args):
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     hist_asins = [target_asin] + comp_asins[:2] if target_asin else comp_asins[:3]
     if hist_asins:
-        r = safe_call("products/history", {
-            "asins": hist_asins, "startDate": thirty_ago, "endDate": today
-        }, "history")
+        r = _fetch_all_history(safe_call, hist_asins, thirty_ago, today, log_fn=log)
         results["product_history"] = {"data": r.get("data", []), "asins_tried": hist_asins}
     results["meta"]["steps_completed"].append("price_trend_context")
 
@@ -2119,12 +2116,11 @@ def cmd_brand_detail(args):
 def cmd_product_history(args):
     """Get historical data (price, BSR, sales) for ASINs over a date range."""
     asins = [a.strip() for a in args.asins.split(",")]
-    params = {
-        "asins": asins,
-        "startDate": args.start_date,
-        "endDate": args.end_date,
-    }
-    result = api_call("products/history", params)
+
+    def _api_caller(endpoint, p, label=""):
+        return api_call(endpoint, p)
+
+    result = _fetch_all_history(_api_caller, asins, args.start_date, args.end_date)
     output(result, args.format)
 
 

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -21,8 +21,8 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 Pre-analyzed consumer insights. Pain points, buying factors, user profiles, differentiation gaps.
 
 ## Files
-- **Script**: `scripts/apiclaw.py` (execute, don't read) — run `--help` for params
-- **Reference**: `references/reference.md` (field names & response structure)
+- **Script**: `{skill_base_dir}/scripts/apiclaw.py` (execute, don't read) — run `--help` for params
+- **Reference**: `{skill_base_dir}/references/reference.md` (field names & response structure)
 
 ## Credential
 Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apiclaw.io/en/api-keys)
@@ -83,7 +83,7 @@ Align dimensions (pain points vs pain points) across products. If competitor rev
 
 ## Composite Command
 ```bash
-python3 scripts/apiclaw.py review-deepdive --target-asin "{asin}" [--keyword "{kw}"] [--category "{path}"]
+python3 {skill_base_dir}/scripts/apiclaw.py review-deepdive --target-asin "{asin}" [--keyword "{kw}"] [--category "{path}"]
 ```
 Optional: `--comp-asins "{asin1},{asin2}"` for comparison.
 Runs: reviews × 11 dimensions + competitors + realtime + market context + price/trend.

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -34,10 +34,11 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 
 ## API Pitfalls (see apiclaw skill for full list)
 - `reviews/analysis` needs **50+ reviews** — fallback to `realtime/product` ratingBreakdown
-- **labelType: one per call** — do NOT comma-separate. Make separate calls.
+- **labelType** is NOT an API request parameter — the API returns all 11 dimensions in one call. Filter by `labelType` client-side from the `consumerInsights` array.
 - Category mode needs precise path (≥3 levels) — broad categories = diluted insights
 - Field name is `reviewRate` (not `reviewRate`) for mention frequency
 - ASIN-specific endpoints don't need `--category`; keyword-based ones do
+- **Category auto-detection**: categoryPath is auto-detected from target ASIN. If `category_source` in output is `inferred_from_search`, confirm with user
 
 ## 11 Analysis Dimensions
 `painPoints` · `issues` · `positives` · `improvements` · `buyingFactors` · `keywords` · `userProfiles` · `scenarios` · `usageTimes` · `usageLocations` · `behaviors`
@@ -53,28 +54,82 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 Rank differentiation opportunities by: **frequency × avg rating delta**
 "Top pain point: durability — mentioned in 27/471 reviews (5.7%), avg rating 2.4 when mentioned"
 
+| reviewRate | Frequency Level | Interpretation |
+|------------|----------------|---------------|
+| >10% | 🔴 Critical | Mentioned by 1 in 10 buyers — must address in product design 📊 |
+| 5-10% | 🟡 Significant | Common complaint — differentiator if solved 📊 |
+| 2-5% | 🟠 Notable | Worth mentioning in listing if you solve it 📊 |
+| <2% | 🟢 Minor | Edge case — deprioritize unless easy fix 🔍 |
+
+| avgRating when mentioned | Severity |
+|--------------------------|----------|
+| <2.5 | Severe — causes returns/1-star reviews 📊 |
+| 2.5-3.5 | Moderate — disappoints but doesn't cause returns 🔍 |
+| >3.5 | Mild — noticed but not deal-breaker 🔍 |
+
+**Differentiation Priority** = High frequency + Low avgRating = Biggest opportunity 🔍. If top 3 pain points all have reviewRate >5% and avgRating <3.0, there is a clear product improvement opportunity 💡. If all pain points have reviewRate <2%, the category is well-served — differentiation through reviews is limited 🔍.
+
 ### Consumer Profile Synthesis
 Combine `userProfiles` + `scenarios` + `usageTimes` + `usageLocations` → complete buyer persona.
 
 ### Listing Copy from Reviews
-Quote actual customer words from `positives` — these are proven converting phrases.
+Quote actual customer words from `positives` — these are proven converting phrases. High-frequency positive elements (reviewRate >5%) should appear in title or first bullet 💡.
 
 ### Competitor Comparison
 Align dimensions (pain points vs pain points) across products. If competitor review data unavailable, use brand-detail sampleProducts + note limitation.
+- **Your pain point rate < competitor's**: Advantage — highlight in listing 💡
+- **Your pain point rate > competitor's**: Risk — address in product iteration 💡
+- **Both high on same pain point**: Category-wide issue — solving it is a strong differentiator 🔍
 
 ## Composite Command
 ```bash
-python3 scripts/apiclaw.py review-deepdive --target-asin "{asin}" --keyword "{kw}" --category "{path}"
+python3 scripts/apiclaw.py review-deepdive --target-asin "{asin}" [--keyword "{kw}"] [--category "{path}"]
 ```
 Optional: `--comp-asins "{asin1},{asin2}"` for comparison.
 Runs: reviews × 11 dimensions + competitors + realtime + market context + price/trend.
 
 ## Output
-Respond in user's language. Tag every conclusion: 📊 Data-backed / 🔍 Inferred / 💡 Directional.
+Respond in user's language.
 
 Sections: Review Snapshot → Top 10 Pain Points (with count & %) → Top 10 Positives → Buying Factors → Improvement Wishlist → Consumer Profile → Usage Patterns → Competitor Comparison → Listing Copy Suggestions → Differentiation Roadmap (impact-ranked) → Data Provenance → API Usage
 
 Do NOT invent insights — only report what the API returns. Omit empty dimensions.
 Cross-validate: star distribution (ratingBreakdown) should match sentiment (reviews/analysis).
+
+### Language (required)
+
+Output language MUST match the user's input language. If the user asks in Chinese, the entire report is in Chinese. If in English, output in English. Exception: API field names (e.g. `monthlySalesFloor`, `categoryPath`), endpoint names, technical terms (e.g. ASIN, BSR, CR10, FBA, credits) remain in English.
+
+### Disclaimer (required, at the top of every report)
+
+> Data is based on APIClaw API sampling as of [date]. Monthly sales (`monthlySalesFloor`) are lower-bound estimates. This analysis is for reference only and should not be the sole basis for business decisions. Validate with additional sources before acting.
+
+### Confidence Labels (required, tag EVERY conclusion)
+
+- 📊 **Data-backed** — direct API data (e.g. "painPoint 'durability' mentioned by 27% of reviewers 📊")
+- 🔍 **Inferred** — logical reasoning from data (e.g. "durability is the #1 differentiation opportunity 🔍")
+- 💡 **Directional** — suggestions, predictions, strategy (e.g. "highlight durability in bullet point #1 💡")
+
+Rules: Strategy recommendations and listing copy suggestions are NEVER 📊. User criteria override AI judgment.
+
+### Data Provenance (required)
+
+Include a table at the end of every report:
+
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+| (e.g. Market Overview) | `markets/search` | categoryPath, topN=10 | 📊 Top N sampling, sales are lower-bound |
+| ... | ... | ... | ... |
+
+Extract endpoint and params from `_query` in JSON output. Add notes: sampling method, T+1 delay, realtime vs DB, minimum review threshold, etc.
+
+### API Usage (required)
+
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+| (each endpoint used) | N | N |
+| **Total** | **N** | **N** |
+
+Extract from `meta.creditsConsumed` per response. End with `Credits remaining: N`.
 
 ## API Budget: ~20-30 credits

--- a/amazon-review-intelligence-extractor/scripts/apiclaw.py
+++ b/amazon-review-intelligence-extractor/scripts/apiclaw.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import sys
+import random
 import time
 import urllib.request
 import urllib.error
@@ -35,9 +36,15 @@ import urllib.error
 
 BASE_URL = "https://api.apiclaw.io/openapi/v2"  # APIClaw API base URL
 API_DOCS = "https://api.apiclaw.io/api-docs"   # API documentation URL
-MAX_RETRIES = 2       # Maximum number of retry attempts for failed requests
-RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on 429 (rate limit)
+MAX_RETRIES = 3       # Maximum number of retry attempts for failed requests
+RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
+RATE_LIMIT_RETRIES = 4  # Extra retries specifically for 429 rate limits
+RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
+MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
+
+# Global request pacer — prevents burst rate limit violations
+_last_request_time = 0.0
 
 # 13 built-in product selection modes
 # Each maps to a set of products/search filter parameters
@@ -110,6 +117,8 @@ def api_call(endpoint: str, params: dict) -> dict:
     Returns the parsed JSON response on success, with _query metadata injected.
     Exits with a clear error message on failure.
     """
+    global _last_request_time
+
     url = f"{BASE_URL}/{endpoint}"
     api_key = get_api_key()
 
@@ -131,8 +140,16 @@ def api_call(endpoint: str, params: dict) -> dict:
         "User-Agent": "APIClaw-CLI/1.0 (Python)",
     }
 
+    # Rate-limit pacing: enforce minimum interval between requests
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < MIN_REQUEST_INTERVAL:
+        time.sleep(MIN_REQUEST_INTERVAL - elapsed)
+
     delay = RETRY_DELAY
-    for attempt in range(1, MAX_RETRIES + 1):
+    max_attempts = MAX_RETRIES
+    for attempt in range(1, max_attempts + 1):
+        _last_request_time = time.monotonic()
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
@@ -163,9 +180,15 @@ def api_call(endpoint: str, params: dict) -> dict:
                     "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
                     endpoint, actual_params)
             elif status == 429:
-                if attempt < MAX_RETRIES:
-                    print(f"Rate limited (429). Waiting {delay}s before retry {attempt}/{MAX_RETRIES}...", file=sys.stderr)
-                    time.sleep(delay)
+                # Switch to longer retry strategy for rate limits
+                if attempt == 1:
+                    max_attempts = RATE_LIMIT_RETRIES
+                    delay = RATE_LIMIT_DELAY
+                if attempt < max_attempts:
+                    jitter = random.uniform(0, delay * 0.25)
+                    wait = delay + jitter
+                    print(f"Rate limited (429). Waiting {wait:.1f}s before retry {attempt}/{max_attempts}...", file=sys.stderr)
+                    time.sleep(wait)
                     delay *= 2
                     continue
                 else:
@@ -177,17 +200,17 @@ def api_call(endpoint: str, params: dict) -> dict:
                     f"Check {API_DOCS} for current endpoints",
                     endpoint, actual_params)
             else:
-                if attempt < MAX_RETRIES:
-                    print(f"HTTP {status}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                if attempt < max_attempts:
+                    print(f"HTTP {status}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                     time.sleep(delay)
                     continue
                 else:
-                    return _error_result(status, f"HTTP {status} after {MAX_RETRIES} attempts",
+                    return _error_result(status, f"HTTP {status} after {max_attempts} attempts",
                         "Check network or try again later",
                         endpoint, actual_params)
         except Exception as e:
-            if attempt < MAX_RETRIES:
-                print(f"Request failed: {e}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+            if attempt < max_attempts:
+                print(f"Request failed: {e}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                 time.sleep(delay)
                 continue
             else:
@@ -196,6 +219,94 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
 
     return _error_result(0, "Unexpected retry loop exit", "This should not happen", endpoint, actual_params)
+
+
+def _filter_review_insights(result, label_type):
+    """Return a shallow copy of a reviews/analysis result filtered to one labelType."""
+    if not result.get("data") or not result["data"].get("consumerInsights"):
+        return result
+    filtered = dict(result)
+    filtered["data"] = dict(result["data"])
+    filtered["data"]["consumerInsights"] = [
+        i for i in result["data"]["consumerInsights"]
+        if i.get("labelType") == label_type
+    ]
+    return filtered
+
+
+def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
+    """
+    Resolve categoryPath with multi-level fallback.
+    Returns (category_path, category_source) tuple.
+
+    Priority:
+      1. keyword → categories API
+      2. asin → realtime/product → categoryPath or bestsellersRank leaf
+      3. keyword → products/search → first result → realtime/product
+    """
+    category_path = None
+    category_source = "user"
+
+    # Priority 1: keyword → categories
+    if keyword:
+        log_fn("Step 0: Resolving category...")
+        cat_result = api_caller("categories", {"categoryKeyword": keyword}, "categories")
+        if results is not None:
+            results["categories"] = cat_result
+        cat_data = cat_result.get("data", [])
+        if cat_data:
+            category_path = cat_data[0].get("categoryPath")
+            category_source = "keyword"
+
+    # Priority 2: asin → realtime/product
+    if not category_path and asin:
+        log_fn("  → Resolving category from ASIN...")
+        rt = api_caller("realtime/product", {"asin": asin, "marketplace": "US"}, f"realtime {asin}")
+        if results is not None:
+            results.setdefault("_asin_realtime", rt)
+        rt_data = rt.get("data", {}) or {}
+        if rt_data.get("categoryPath"):
+            category_path = rt_data["categoryPath"]
+            category_source = "asin_realtime"
+            log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif rt_data.get("bestsellersRank"):
+            leaf = rt_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log_fn(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "asin_bsr"
+                    log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+
+    # Priority 3: keyword → search → first product → realtime
+    if not category_path and keyword:
+        log_fn("  → Resolving category from top search result...")
+        prod_result = api_caller("products/search", {
+            "keyword": keyword, "sortBy": "monthlySalesFloor", "sortOrder": "desc", "pageSize": 5
+        }, "products (category probe)")
+        prod_data = prod_result.get("data", [])
+        if isinstance(prod_data, list) and prod_data:
+            probe_asin = prod_data[0].get("asin")
+            if probe_asin:
+                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+                rt_data = rt.get("data", {}) or {}
+                if rt_data.get("categoryPath"):
+                    category_path = rt_data["categoryPath"]
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+                elif rt_data.get("bestsellersRank"):
+                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
+                    if leaf:
+                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                        cat_data = cat_result.get("data", [])
+                        if cat_data:
+                            category_path = cat_data[0].get("categoryPath")
+                            category_source = "inferred_from_search"
+                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+
+    return category_path, category_source
 
 
 def _error_result(status: int, message: str, action: str, endpoint: str, params: dict) -> dict:
@@ -344,9 +455,9 @@ def cmd_products(args):
     if args.fulfillment:
         params["fulfillments"] = args.fulfillment
     if args.include_brands:
-        params["includeBrands"] = args.include_brands
+        params["includeBrands"] = [b.strip() for b in args.include_brands.split(",")]
     if args.exclude_brands:
-        params["excludeBrands"] = args.exclude_brands
+        params["excludeBrands"] = [b.strip() for b in args.exclude_brands.split(",")]
 
     params["sortBy"] = args.sort or "monthlySalesFloor"
     params["sortOrder"] = args.order or "desc"
@@ -453,7 +564,7 @@ def cmd_report(args):
     print("Step 3/4: Searching top products...", file=sys.stderr)
     products_result = api_call("products/search", {
         "keyword": keyword,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 50,
     })
@@ -508,7 +619,7 @@ def cmd_opportunity(args):
         "keyword": keyword,
         "monthlySalesMin": 300,
         "ratingCountMax": 50,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 20,
     }
@@ -565,17 +676,9 @@ def cmd_market_entry(args):
         return r
 
     # ── Step 0.5: Category Resolution ──
-    if not category_path and keyword:
-        log("Step 0.5: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked category: {' > '.join(category_path)}")
-        else:
-            log("  ⚠️ No category match, will use keyword-only queries")
-
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # ── Step 1: Market Landscape (3 calls) ──
@@ -744,43 +847,36 @@ def cmd_market_entry(args):
     review_results = {}
     label_types = ["painPoints", "buyingFactors", "improvements"]
 
-    # Priority 1: Category mode
-    category_mode_success = True
+    # Priority 1: Category mode (single call, split client-side)
+    category_mode_success = False
     if category_path:
-        for lt in label_types:
-            log(f"  → reviews/analysis category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path,
-                "mode": "category",
-                "labelType": lt,
-                "period": "6m",
-            }, f"reviews {lt}")
-            if r.get("success") is False or not r.get("data", {}).get("consumerInsights"):
-                category_mode_success = False
-                log(f"  ⚠️ Category mode failed for {lt}")
-                break
-            review_results[lt] = r
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path,
+            "mode": "category",
+            "period": "6m",
+        }, "reviews category")
+        if r.get("success") and r.get("data", {}).get("consumerInsights"):
+            category_mode_success = True
+            for lt in label_types:
+                review_results[lt] = _filter_review_insights(r, lt)
 
     # Priority 2: ASIN mode (if category failed)
-    if not category_mode_success or not category_path:
+    if not category_mode_success:
         log("  → Falling back to ASIN mode...")
-        # Pick ASINs with ratingCount >= 50
         review_asins = [p.get("asin") for p in all_products if (p.get("ratingCount") or 0) >= 50][:3]
         if review_asins:
+            log(f"  → reviews/analysis ASIN mode ({review_asins})")
+            r = safe_call("reviews/analysis", {
+                "asins": review_asins,
+                "mode": "asin",
+                "period": "6m",
+            }, "reviews ASIN")
             for lt in label_types:
-                if lt in review_results:
-                    continue
-                log(f"  → reviews/analysis ASIN mode: {lt} ({review_asins})")
-                r = safe_call("reviews/analysis", {
-                    "asins": review_asins,
-                    "mode": "asin",
-                    "labelType": lt,
-                    "period": "6m",
-                }, f"reviews ASIN {lt}")
-                review_results[lt] = r
+                review_results[lt] = _filter_review_insights(r, lt)
 
     results["reviews"] = review_results
-    results["meta"]["review_mode"] = "category" if category_mode_success and category_path else "asin"
+    results["meta"]["review_mode"] = "category" if category_mode_success else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
 
     # ── Summary ──
@@ -819,14 +915,9 @@ def cmd_competitor_analysis(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
-    results["meta"]["resolved_category"] = category_path
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
 
     # Step 1: Competitor Discovery
     log("Step 1/7: Competitor discovery...")
@@ -844,6 +935,7 @@ def cmd_competitor_analysis(args):
     if category_path:
         comp_params["categoryPath"] = category_path
     results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    results["meta"]["resolved_category"] = category_path
     results["meta"]["steps_completed"].append("competitor_discovery")
 
     # Step 2: Market Context
@@ -931,16 +1023,17 @@ def cmd_competitor_analysis(args):
     review_results = {}
     for asin in top_asins[:5]:
         r = safe_call("reviews/analysis", {
-            "asins": [asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [asin], "mode": "asin", "period": "6m"
         }, f"reviews {asin}")
         if r.get("data") and r.get("data", {}).get("consumerInsights"):
             review_results[asin] = r
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -955,7 +1048,7 @@ def cmd_competitor_analysis(args):
                 bp["keyword"] = keyword
             if category_path:
                 bp["categoryPath"] = category_path
-            bp["includeBrands"] = top_brand
+            bp["includeBrands"] = [top_brand]
             results["top_brand_products"] = safe_call("products/search", bp, f"brand {top_brand}")
     results["meta"]["steps_completed"].append("brand_drilldown")
 
@@ -969,6 +1062,7 @@ def cmd_pricing_analysis(args):
     """
     Composite workflow: Pricing Analysis.
     Runs: realtime(my_asin) → price-band → products/competitors → market/brand → history → realtime(top5) → reviews
+    Category is auto-detected from ASIN if not provided.
     """
     my_asin = args.my_asin
     keyword = args.keyword
@@ -976,9 +1070,6 @@ def cmd_pricing_analysis(args):
 
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
-        sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
         sys.exit(1)
 
     category_path = parse_category(category) if category else None
@@ -993,21 +1084,40 @@ def cmd_pricing_analysis(args):
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
         return r
 
-    # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
-    results["meta"]["resolved_category"] = category_path
-
     # Step 1: Current Price Snapshot
     log("Step 1/8: Current price snapshot...")
     results["my_product"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
+    my_data = results["my_product"].get("data", {}) or {}
+    if not my_data.get("title"):
+        log(f"\n❌ ASIN '{my_asin}' not found or has no data. Please check the ASIN and try again.")
+        results["error"] = {"code": "ASIN_NOT_FOUND", "message": f"ASIN '{my_asin}' not found or returned empty data"}
+        output(results, args.format)
+        return
     results["meta"]["steps_completed"].append("price_snapshot")
+
+    # Step 1.5: Auto Category Detection
+    if not category_path:
+        # For pricing, we already have realtime data — extract directly first
+        if my_data.get("categoryPath"):
+            category_path = my_data["categoryPath"]
+            results["meta"]["category_source"] = "asin_realtime"
+            log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif my_data.get("bestsellersRank"):
+            leaf = my_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = safe_call("categories", {"categoryKeyword": leaf}, "categories")
+                results["categories"] = cat_result
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    results["meta"]["category_source"] = "asin_bsr"
+                    log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        # Fallback to keyword
+        if not category_path and keyword:
+            category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+            results["meta"]["category_source"] = category_source
+    results["meta"]["resolved_category"] = category_path
 
     # Step 2: Price Band Intelligence
     log("Step 2/8: Price band intelligence...")
@@ -1110,17 +1220,18 @@ def cmd_pricing_analysis(args):
     my_rc = results["my_product"].get("data", {}).get("ratingCount", 0)
     if my_rc and my_rc >= 50:
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if comp_asins:
         review_results["top_comp"] = safe_call("reviews/analysis", {
-            "asins": [comp_asins[0]], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [comp_asins[0]], "mode": "asin", "period": "6m"
         }, f"reviews {comp_asins[0]}")
     if not review_results and category_path:
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_context")
 
@@ -1157,9 +1268,6 @@ def cmd_daily_radar(args):
     if not asins_str:
         print("ERROR: --asins is required (comma-separated ASINs to track).", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     tracked_asins = [a.strip() for a in asins_str.split(",") if a.strip()]
     category_path = parse_category(category) if category else None
@@ -1175,14 +1283,10 @@ def cmd_daily_radar(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=tracked_asins[0] if tracked_asins else None, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
@@ -1292,10 +1396,9 @@ def cmd_daily_radar(args):
             r = safe_call("reviews/analysis", {
                 "asins": [review_asin],
                 "mode": "asin",
-                "labelType": "painPoints",
                 "period": "6m",
             }, f"reviews {review_asin}")
-            review_results["painPoints"] = r
+            review_results["painPoints"] = _filter_review_insights(r, "painPoints")
             break
     
     if not review_results:
@@ -1324,9 +1427,6 @@ def cmd_listing_audit(args):
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     category_path = parse_category(category) if category else None
     results = {"meta": {"my_asin": my_asin, "keyword": keyword, "category": category, "steps_completed": []}}
@@ -1341,14 +1441,10 @@ def cmd_listing_audit(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Audit Target
@@ -1451,21 +1547,22 @@ def cmd_listing_audit(args):
     if target_rc and target_rc >= 50:
         log(f"  → reviews/analysis ASIN mode: {my_asin}")
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if leader_asins:
         top_leader = leader_asins[0]
         log(f"  → reviews/analysis ASIN mode: {top_leader}")
         review_results["top_leader"] = safe_call("reviews/analysis", {
-            "asins": [top_leader], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [top_leader], "mode": "asin", "period": "6m"
         }, f"reviews {top_leader}")
     # Category fallback
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors", "improvements"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews category {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -1538,14 +1635,9 @@ def cmd_opportunity_scan(args):
         return r
 
     # Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Product Scan (mode-based + custom filters)
@@ -1684,23 +1776,22 @@ def cmd_opportunity_scan(args):
     log("Step 6/6: Consumer insights...")
     review_results = {}
     if category_path:
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
-            log(f"  → category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            if r.get("data") and r.get("data", {}).get("consumerInsights"):
-                review_results[lt] = r
-            else:
-                break
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
+        if r.get("data") and r.get("data", {}).get("consumerInsights"):
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     if not review_results:
         log("  → Falling back to ASIN mode...")
         review_asins = [a for a in top_asins[:3]]
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
+        if review_asins:
             r = safe_call("reviews/analysis", {
-                "asins": review_asins, "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews ASIN {lt}")
-            review_results[lt] = r
+                "asins": review_asins, "mode": "asin", "period": "6m"
+            }, "reviews ASIN")
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["review_mode"] = "category" if category_path and review_results.get("painPoints", {}).get("data", {}).get("consumerInsights") else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
@@ -1743,13 +1834,9 @@ def cmd_review_deepdive(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=target_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Target Identification
@@ -1775,26 +1862,25 @@ def cmd_review_deepdive(args):
     log("Step 2/5: Full review analysis (11 dimensions)...")
     label_types = ["painPoints", "positives", "buyingFactors", "improvements", "userProfiles",
                    "scenarios", "issues", "keywords", "usageTimes", "usageLocations", "behaviors"]
-    
+
     review_results = {}
-    # Target ASIN reviews
+    # Target ASIN reviews (single call, split client-side)
     if target_asin:
+        log(f"  → {target_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [target_asin], "mode": "asin", "period": "6m"
+        }, "reviews target")
         for lt in label_types:
-            log(f"  → {target_asin}: {lt}")
-            r = safe_call("reviews/analysis", {
-                "asins": [target_asin], "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            review_results[f"target_{lt}"] = r
-    
-    # Competitor comparison (top 2)
+            review_results[f"target_{lt}"] = _filter_review_insights(r, lt)
+
+    # Competitor comparison (top 2, single call each)
     for comp_asin in comp_asins[:2]:
-        log(f"  → Competitor {comp_asin}: painPoints + positives")
-        review_results[f"comp_{comp_asin}_painPoints"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+        log(f"  → Competitor {comp_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [comp_asin], "mode": "asin", "period": "6m"
         }, f"reviews comp {comp_asin}")
-        review_results[f"comp_{comp_asin}_positives"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "positives", "period": "6m"
-        }, f"reviews comp+ {comp_asin}")
+        review_results[f"comp_{comp_asin}_painPoints"] = _filter_review_insights(r, "painPoints")
+        review_results[f"comp_{comp_asin}_positives"] = _filter_review_insights(r, "positives")
     
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_analysis")
@@ -1960,12 +2046,19 @@ def cmd_analyze(args):
         print("ERROR: --asin, --asins, or --category is required.", file=sys.stderr)
         sys.exit(1)
 
-    if args.label_type:
-        params["labelType"] = args.label_type
     if args.period:
         params["period"] = args.period
 
     result = api_call("reviews/analysis", params)
+
+    # Client-side filtering by label type (v2 API returns all dimensions in one call)
+    if args.label_type and result.get("data") and result["data"].get("consumerInsights"):
+        requested = [t.strip() for t in args.label_type.split(",")]
+        result["data"]["consumerInsights"] = [
+            i for i in result["data"]["consumerInsights"]
+            if i.get("labelType") in requested
+        ]
+
     output(result, args.format)
 
 
@@ -2246,7 +2339,12 @@ Examples:
     p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+        print(f"ERROR: Unrecognized argument(s): {' '.join(unknown)}", file=sys.stderr)
+        print(f"Run 'apiclaw.py {cmd} --help' to see valid options.", file=sys.stderr)
+        sys.exit(1)
     args.func(args)
 
 

--- a/amazon-review-intelligence-extractor/scripts/apiclaw.py
+++ b/amazon-review-intelligence-extractor/scripts/apiclaw.py
@@ -234,6 +234,25 @@ def _filter_review_insights(result, label_type):
     return filtered
 
 
+def _fetch_all_history(api_caller, asins, start_date, end_date, log_fn=None):
+    """Fetch products/history for multiple ASINs (one API call per ASIN)."""
+    all_data = []
+    last_response = None
+    for asin in asins:
+        r = api_caller("products/history", {
+            "asin": asin, "startDate": start_date, "endDate": end_date,
+        }, f"history {asin}")
+        last_response = r
+        if r.get("data"):
+            all_data.append(r["data"])
+        elif log_fn:
+            log_fn(f"  ⚠️ No history data for {asin}")
+    if last_response is None:
+        return {"success": False, "data": [], "error": {"message": "No ASINs provided"}}
+    last_response["data"] = all_data
+    return last_response
+
+
 def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
     """
     Resolve categoryPath with multi-level fallback.
@@ -818,11 +837,7 @@ def cmd_market_entry(args):
     round1_asins = top_asins[:3]
     if round1_asins:
         tried_asins.update(round1_asins)
-        r = safe_call("products/history", {
-            "asins": round1_asins,
-            "startDate": thirty_days_ago,
-            "endDate": today,
-        }, "history round 1")
+        r = _fetch_all_history(safe_call, round1_asins, thirty_days_ago, today, log_fn=log)
         history_data = r.get("data", [])
 
     # Round 2: Try oldest products if round 1 was empty
@@ -831,11 +846,7 @@ def cmd_market_entry(args):
         if round2_asins:
             log(f"  → Round 1 empty, trying older ASINs: {round2_asins}")
             tried_asins.update(round2_asins)
-            r = safe_call("products/history", {
-                "asins": round2_asins,
-                "startDate": thirty_days_ago,
-                "endDate": today,
-            }, "history round 2")
+            r = _fetch_all_history(safe_call, round2_asins, thirty_days_ago, today, log_fn=log)
             history_data = r.get("data", [])
 
     results["product_history"] = {"data": history_data, "asins_tried": list(tried_asins)}
@@ -1012,9 +1023,7 @@ def cmd_competitor_analysis(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = ([my_asin] if my_asin else []) + top_asins[:5]
-    r = safe_call("products/history", {
-        "asins": history_asins[:8], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins[:8], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins[:8]}
     results["meta"]["steps_completed"].append("historical_trends")
 
@@ -1198,9 +1207,7 @@ def cmd_pricing_analysis(args):
             break
 
     history_asins = [my_asin] + comp_asins
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("price_trends")
 
@@ -1308,11 +1315,7 @@ def cmd_daily_radar(args):
     tried_asins = set()
     
     # Round 1: All tracked ASINs
-    r = safe_call("products/history", {
-        "asins": tracked_asins,
-        "startDate": seven_days_ago,
-        "endDate": today,
-    }, "history round 1")
+    r = _fetch_all_history(safe_call, tracked_asins, seven_days_ago, today, log_fn=log)
     history_data = r.get("data", [])
     tried_asins.update(tracked_asins)
 
@@ -1571,9 +1574,7 @@ def cmd_listing_audit(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = [my_asin] + leader_asins[:2]
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("trend_context")
 
@@ -1766,9 +1767,7 @@ def cmd_opportunity_scan(args):
     log("Step 5/6: Trend check...")
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
-    r = safe_call("products/history", {
-        "asins": top_asins[:5], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, top_asins[:5], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": top_asins[:5]}
     results["meta"]["steps_completed"].append("trend_check")
 
@@ -1942,9 +1941,7 @@ def cmd_review_deepdive(args):
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     hist_asins = [target_asin] + comp_asins[:2] if target_asin else comp_asins[:3]
     if hist_asins:
-        r = safe_call("products/history", {
-            "asins": hist_asins, "startDate": thirty_ago, "endDate": today
-        }, "history")
+        r = _fetch_all_history(safe_call, hist_asins, thirty_ago, today, log_fn=log)
         results["product_history"] = {"data": r.get("data", []), "asins_tried": hist_asins}
     results["meta"]["steps_completed"].append("price_trend_context")
 
@@ -2119,12 +2116,11 @@ def cmd_brand_detail(args):
 def cmd_product_history(args):
     """Get historical data (price, BSR, sales) for ASINs over a date range."""
     asins = [a.strip() for a in args.asins.split(",")]
-    params = {
-        "asins": asins,
-        "startDate": args.start_date,
-        "endDate": args.end_date,
-    }
-    result = api_call("products/history", params)
+
+    def _api_caller(endpoint, p, label=""):
+        return api_call(endpoint, p)
+
+    result = _fetch_all_history(_api_caller, asins, args.start_date, args.end_date)
     output(result, args.format)
 
 

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -53,7 +53,7 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 | 8 | `products/price-band-detail` | Full 5-band distribution | priceBands[] with sales, brands, ratings per band |
 | 9 | `products/brand-overview` | Brand concentration | sampleTop10BrandSalesRate (CR10), sampleBrandCount |
 | 10 | `products/brand-detail` | Per-brand breakdown | brands[] with sales, revenue, sampleProducts |
-| 11 | `products/history` | Daily snapshots | price, bsr, subBsr, recentSales |
+| 11 | `products/history` | Time series (single ASIN per call) | timestamps[], price[], bsr[], monthlySalesFloor[], rating[], ratingCount[], sellerCount[], title/imageUrl/bestSeller/newRelease/aPlus/inventoryStatus changelogs |
 
 ## Known Quirks
 - `topN`, `listingAge`, `newProductPeriod` are **strings** (`"10"` not `10`)
@@ -72,11 +72,11 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 
 | Data | markets | products/competitors | realtime | reviews | price-band | brand | history |
 |------|---------|---------------------|----------|---------|------------|-------|---------|
-| Sales | sampleAvgMonthlySales | monthlySalesFloor | ❌ | ❌ | sampleSalesRate | sampleGroupMonthlySales | recentSales |
-| Price | sampleAvgPrice | price | buyboxWinner.price | ❌ | bandMin/MaxPrice | sampleAvgPrice | price |
-| BSR | sampleAvgBsr | bsr (int) | bestsellersRank[] | ❌ | ❌ | ❌ | bsr |
-| Rating | sampleAvgRating | rating | rating | avgRating | sampleAvgRating | sampleAvgRating | ❌ |
-| Reviews | sampleAvgReviewCount | ratingCount | ratingCount | reviewCount | ❌ | sampleAvgRatingCount | ❌ |
+| Sales | sampleAvgMonthlySales | monthlySalesFloor | ❌ | ❌ | sampleSalesRate | sampleGroupMonthlySales | monthlySalesFloor[] |
+| Price | sampleAvgPrice | price | buyboxWinner.price | ❌ | bandMin/MaxPrice | sampleAvgPrice | price[] |
+| BSR | sampleAvgBsr | bsr (int) | bestsellersRank[] | ❌ | ❌ | ❌ | bsr[] |
+| Rating | sampleAvgRating | rating | rating | avgRating | sampleAvgRating | sampleAvgRating | rating[] |
+| Reviews | sampleAvgReviewCount | ratingCount | ratingCount | reviewCount | ❌ | sampleAvgRatingCount | ratingCount[] |
 | Insights | ❌ | ❌ | ❌ | ✅ consumerInsights | ❌ | ❌ | ❌ |
 | Concentration | topSalesRate | ❌ | ❌ | ❌ | sampleTop3BrandSalesRate | CR10 | ❌ |
 | Opportunity | ❌ | ❌ | ❌ | ❌ | sampleOpportunityIndex | ❌ | ❌ |

--- a/apiclaw/references/openapi-reference.md
+++ b/apiclaw/references/openapi-reference.md
@@ -34,7 +34,7 @@ Response: `categoryId`, `categoryName`, `categoryPath`, `hasChildren`, `isRoot`,
 | sampleType | String | `by_sale_100` / `by_bsr_100` / `avg` |
 | dateRange | String | default `30d` |
 | pageSize | Integer | default 20 |
-| sortBy | String | default `sampleAvgMonthlySaleAmt` |
+| sortBy | String | default `sampleAvgMonthlySales` |
 | sortOrder | String | `asc` / `desc` |
 
 Key response fields: `sampleAvgMonthlySales`, `sampleAvgPrice`, `sampleAvgMonthlyRevenue`, `sampleBrandCount`, `sampleSellerCount`, `sampleFbaRate`, `sampleNewSkuRate`, `topSalesRate`, `topBrandSalesRate`, `topSellerSalesRate`, `totalSkuCount`
@@ -92,14 +92,15 @@ Response fields: `asin`, `title`, `brand`, `rating`, `ratingCount`, `ratingBreak
 | mode | String | **Yes** | `asin` or `category` |
 | asins | List\<String\> | When mode=asin | ⚠️ plural, array format |
 | categoryPath | String | When mode=category | Category path |
-| labelType | String | No | Filter to dimension |
-| period | String | No | e.g. `90d` |
+| period | String | No | e.g. `6m` |
 
-labelType values: `scenarios`, `issues`, `positives`, `improvements`, `buyingFactors`, `painPoints`, `keywords`, `userProfiles`, `usageTimes`, `usageLocations`, `behaviors`
+⚠️ `labelType` is **not** an API request parameter. The API returns all 11 dimensions in one call. Filter by `labelType` client-side from the `consumerInsights` array.
 
 Response: `reviewCount`, `avgRating`, `verifiedRate`, `ratingDistribution`, `sentimentDistribution`, `consumerInsights` (list of InsightItem), `topKeywords`
 
 InsightItem: `element`, `labelType`, `count`, `reviewRate`, `avgRating`
+
+labelType values (in response): `scenarios`, `issues`, `positives`, `improvements`, `buyingFactors`, `painPoints`, `keywords`, `userProfiles`, `usageTimes`, `usageLocations`, `behaviors`
 
 ---
 

--- a/apiclaw/references/openapi-reference.md
+++ b/apiclaw/references/openapi-reference.md
@@ -215,22 +215,36 @@ labelType values (in response): `scenarios`, `issues`, `positives`, `improvement
 
 | Parameter | Type | Required | Note |
 |-----------|------|----------|------|
-| asins | List\<String\> | **Yes** | One or more ASINs |
+| asin | String | **Yes** | Single ASIN (one per call) |
 | startDate | String | **Yes** | Start date `YYYY-MM-DD` |
 | endDate | String | **Yes** | End date `YYYY-MM-DD` |
+| marketplace | String | No | Marketplace code, default `US` |
 
-⚠️ Uses `startDate`/`endDate` — NOT `dateRange`. Date format is `YYYY-MM-DD`.
+⚠️ `asin` is a **single string** — NOT an array. For multiple ASINs, make separate calls.
+⚠️ Does NOT support `page`/`pageSize` — returns full date range in one response.
+⚠️ Uses `startDate`/`endDate` — NOT `dateRange`.
 
-**Response:** Array of daily snapshot objects per ASIN.
+**Response:** Single time series object (NOT an array of snapshots).
 
 | Field | Type | Note |
 |-------|------|------|
 | asin | String | Product ASIN |
-| price | Float | Price on that date |
-| bsr | Integer | BSR rank on that date |
-| subBsr | Integer | Sub-category BSR rank |
-| recentSales | Integer | Recent sales estimate |
-| updatedAt | String | Timestamp of the snapshot |
+| timestamps | List\<String\> | Dates (YYYY-MM-DD) |
+| price | List\<Float\> | Price on each date |
+| bsr | List\<Integer\> | BSR on each date |
+| subBsr | List\<Integer\> | Sub-category BSR |
+| monthlySalesFloor | List\<Integer\> | Monthly sales lower bound |
+| rating | List\<Float\> | Rating on each date |
+| ratingCount | List\<Integer\> | Review count on each date |
+| sellerCount | List\<Integer\> | Seller count |
+| title | List\<ChangeLog\> | Title changes `{date, value}` |
+| imageUrl | List\<ChangeLog\> | Main image changes `{date, value}` |
+| bestSeller | List\<ChangeLog\> | Best Seller badge `{date, value}` |
+| amazonChoice | List\<ChangeLog\> | Amazon's Choice badge `{date, value}` |
+| newRelease | List\<ChangeLog\> | New Release badge `{date, value}` |
+| aPlus | List\<ChangeLog\> | A+ content status `{date, value}` |
+| inventoryStatus | List\<ChangeLog\> | Stock status `{date, value}` |
+| currency | String | e.g. `USD` |
 
 ---
 

--- a/apiclaw/references/reference.md
+++ b/apiclaw/references/reference.md
@@ -142,10 +142,11 @@ Request params: `keyword`, `brand`, `asin`, `categoryPath`, `sortBy`, `pageSize`
 - `mode`: `"asin"` or `"category"`
 - `asins`: List<String> (when mode=asin)
 - `categoryPath`: String (when mode=category)
-- `labelType`: filter to specific dimensions. **⚠️ Only ONE value per call — do NOT comma-separate multiple types.** Make separate calls for each labelType needed.
 - `period`: e.g. `"1m"` / `"3m"` / `"6m"` / `"1y"` / `"2y"`
 
-**labelType values (one per call):** `scenarios`, `issues`, `positives`, `improvements`, `buyingFactors`, `painPoints`, `keywords`, `userProfiles`, `usageTimes`, `usageLocations`, `behaviors`
+⚠️ `labelType` is **not** an API request parameter. The API returns all 11 dimensions in a single call. Filter by `labelType` client-side from the `consumerInsights` array.
+
+**labelType values (in response):** `scenarios`, `issues`, `positives`, `improvements`, `buyingFactors`, `painPoints`, `keywords`, `userProfiles`, `usageTimes`, `usageLocations`, `behaviors`
 
 **Response:**
 | Field | Type | Used For |

--- a/apiclaw/references/reference.md
+++ b/apiclaw/references/reference.md
@@ -212,21 +212,34 @@ Request params: `keyword`, `brand`, `asin`, `categoryPath`, `sortBy`, `pageSize`
 ## 11. products/history
 
 **Request:**
-- `asins`: List<String> (required)
+- `asin`: String (required) — Single ASIN (one per call, NOT an array)
 - `startDate`: String "YYYY-MM-DD" (required)
 - `endDate`: String "YYYY-MM-DD" (required)
-⚠️ Does NOT accept `dateRange` — must use startDate + endDate
+- `marketplace`: String (optional, default "US")
+⚠️ `asin` is a **single string** — NOT an array. For multiple ASINs, make separate calls.
+⚠️ Does NOT support `page`/`pageSize` — returns full date range in one response.
+⚠️ Does NOT accept `dateRange` — must use startDate + endDate.
 
-**Response (array of daily snapshots):**
+**Response (single time series object, NOT an array of snapshots):**
 | Field | Type | Used For |
 |-------|------|----------|
-| `asin` | string | Product ID |
-| `price` | float | Price on that day |
-| `bsr` | int | BSR on that day |
-| `subBsr` | int | Sub-category BSR |
-| `recentSales` | int | Recent sales count |
-| `updatedAt` | string | Unix timestamp (string) |
-| `createdAt` | string | Unix timestamp (string) |
+| `asin` | string | Product ASIN |
+| `timestamps` | List\<string\> | Dates (YYYY-MM-DD) |
+| `price` | List\<float\> | Price on each date |
+| `bsr` | List\<int\> | BSR on each date |
+| `subBsr` | List\<int\> | Sub-category BSR |
+| `monthlySalesFloor` | List\<int\> | Monthly sales lower bound |
+| `rating` | List\<float\> | Rating on each date |
+| `ratingCount` | List\<int\> | Review count on each date |
+| `sellerCount` | List\<int\> | Seller count |
+| `title` | List\<ChangeLog\> | Title changes `{date, value}` |
+| `imageUrl` | List\<ChangeLog\> | Main image changes `{date, value}` |
+| `bestSeller` | List\<ChangeLog\> | Best Seller badge `{date, value}` |
+| `amazonChoice` | List\<ChangeLog\> | Amazon's Choice badge `{date, value}` |
+| `newRelease` | List\<ChangeLog\> | New Release badge `{date, value}` |
+| `aPlus` | List\<ChangeLog\> | A+ content status `{date, value}` |
+| `inventoryStatus` | List\<ChangeLog\> | Stock status `{date, value}` |
+| `currency` | string | e.g. "USD" |
 
 ---
 

--- a/apiclaw/scripts/apiclaw.py
+++ b/apiclaw/scripts/apiclaw.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import os
 import sys
+import random
 import time
 import urllib.request
 import urllib.error
@@ -35,9 +36,15 @@ import urllib.error
 
 BASE_URL = "https://api.apiclaw.io/openapi/v2"  # APIClaw API base URL
 API_DOCS = "https://api.apiclaw.io/api-docs"   # API documentation URL
-MAX_RETRIES = 2       # Maximum number of retry attempts for failed requests
-RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on 429 (rate limit)
+MAX_RETRIES = 3       # Maximum number of retry attempts for failed requests
+RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
+RATE_LIMIT_RETRIES = 4  # Extra retries specifically for 429 rate limits
+RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
+MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
+
+# Global request pacer — prevents burst rate limit violations
+_last_request_time = 0.0
 
 # 13 built-in product selection modes
 # Each maps to a set of products/search filter parameters
@@ -110,6 +117,8 @@ def api_call(endpoint: str, params: dict) -> dict:
     Returns the parsed JSON response on success, with _query metadata injected.
     Exits with a clear error message on failure.
     """
+    global _last_request_time
+
     url = f"{BASE_URL}/{endpoint}"
     api_key = get_api_key()
 
@@ -131,8 +140,16 @@ def api_call(endpoint: str, params: dict) -> dict:
         "User-Agent": "APIClaw-CLI/1.0 (Python)",
     }
 
+    # Rate-limit pacing: enforce minimum interval between requests
+    now = time.monotonic()
+    elapsed = now - _last_request_time
+    if elapsed < MIN_REQUEST_INTERVAL:
+        time.sleep(MIN_REQUEST_INTERVAL - elapsed)
+
     delay = RETRY_DELAY
-    for attempt in range(1, MAX_RETRIES + 1):
+    max_attempts = MAX_RETRIES
+    for attempt in range(1, max_attempts + 1):
+        _last_request_time = time.monotonic()
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as resp:
@@ -163,9 +180,15 @@ def api_call(endpoint: str, params: dict) -> dict:
                     "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
                     endpoint, actual_params)
             elif status == 429:
-                if attempt < MAX_RETRIES:
-                    print(f"Rate limited (429). Waiting {delay}s before retry {attempt}/{MAX_RETRIES}...", file=sys.stderr)
-                    time.sleep(delay)
+                # Switch to longer retry strategy for rate limits
+                if attempt == 1:
+                    max_attempts = RATE_LIMIT_RETRIES
+                    delay = RATE_LIMIT_DELAY
+                if attempt < max_attempts:
+                    jitter = random.uniform(0, delay * 0.25)
+                    wait = delay + jitter
+                    print(f"Rate limited (429). Waiting {wait:.1f}s before retry {attempt}/{max_attempts}...", file=sys.stderr)
+                    time.sleep(wait)
                     delay *= 2
                     continue
                 else:
@@ -177,17 +200,17 @@ def api_call(endpoint: str, params: dict) -> dict:
                     f"Check {API_DOCS} for current endpoints",
                     endpoint, actual_params)
             else:
-                if attempt < MAX_RETRIES:
-                    print(f"HTTP {status}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+                if attempt < max_attempts:
+                    print(f"HTTP {status}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                     time.sleep(delay)
                     continue
                 else:
-                    return _error_result(status, f"HTTP {status} after {MAX_RETRIES} attempts",
+                    return _error_result(status, f"HTTP {status} after {max_attempts} attempts",
                         "Check network or try again later",
                         endpoint, actual_params)
         except Exception as e:
-            if attempt < MAX_RETRIES:
-                print(f"Request failed: {e}. Retrying {attempt}/{MAX_RETRIES}...", file=sys.stderr)
+            if attempt < max_attempts:
+                print(f"Request failed: {e}. Retrying {attempt}/{max_attempts}...", file=sys.stderr)
                 time.sleep(delay)
                 continue
             else:
@@ -196,6 +219,94 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
 
     return _error_result(0, "Unexpected retry loop exit", "This should not happen", endpoint, actual_params)
+
+
+def _filter_review_insights(result, label_type):
+    """Return a shallow copy of a reviews/analysis result filtered to one labelType."""
+    if not result.get("data") or not result["data"].get("consumerInsights"):
+        return result
+    filtered = dict(result)
+    filtered["data"] = dict(result["data"])
+    filtered["data"]["consumerInsights"] = [
+        i for i in result["data"]["consumerInsights"]
+        if i.get("labelType") == label_type
+    ]
+    return filtered
+
+
+def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
+    """
+    Resolve categoryPath with multi-level fallback.
+    Returns (category_path, category_source) tuple.
+
+    Priority:
+      1. keyword → categories API
+      2. asin → realtime/product → categoryPath or bestsellersRank leaf
+      3. keyword → products/search → first result → realtime/product
+    """
+    category_path = None
+    category_source = "user"
+
+    # Priority 1: keyword → categories
+    if keyword:
+        log_fn("Step 0: Resolving category...")
+        cat_result = api_caller("categories", {"categoryKeyword": keyword}, "categories")
+        if results is not None:
+            results["categories"] = cat_result
+        cat_data = cat_result.get("data", [])
+        if cat_data:
+            category_path = cat_data[0].get("categoryPath")
+            category_source = "keyword"
+
+    # Priority 2: asin → realtime/product
+    if not category_path and asin:
+        log_fn("  → Resolving category from ASIN...")
+        rt = api_caller("realtime/product", {"asin": asin, "marketplace": "US"}, f"realtime {asin}")
+        if results is not None:
+            results.setdefault("_asin_realtime", rt)
+        rt_data = rt.get("data", {}) or {}
+        if rt_data.get("categoryPath"):
+            category_path = rt_data["categoryPath"]
+            category_source = "asin_realtime"
+            log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif rt_data.get("bestsellersRank"):
+            leaf = rt_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log_fn(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "asin_bsr"
+                    log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
+
+    # Priority 3: keyword → search → first product → realtime
+    if not category_path and keyword:
+        log_fn("  → Resolving category from top search result...")
+        prod_result = api_caller("products/search", {
+            "keyword": keyword, "sortBy": "monthlySalesFloor", "sortOrder": "desc", "pageSize": 5
+        }, "products (category probe)")
+        prod_data = prod_result.get("data", [])
+        if isinstance(prod_data, list) and prod_data:
+            probe_asin = prod_data[0].get("asin")
+            if probe_asin:
+                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+                rt_data = rt.get("data", {}) or {}
+                if rt_data.get("categoryPath"):
+                    category_path = rt_data["categoryPath"]
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+                elif rt_data.get("bestsellersRank"):
+                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
+                    if leaf:
+                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
+                        cat_data = cat_result.get("data", [])
+                        if cat_data:
+                            category_path = cat_data[0].get("categoryPath")
+                            category_source = "inferred_from_search"
+                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+
+    return category_path, category_source
 
 
 def _error_result(status: int, message: str, action: str, endpoint: str, params: dict) -> dict:
@@ -344,9 +455,9 @@ def cmd_products(args):
     if args.fulfillment:
         params["fulfillments"] = args.fulfillment
     if args.include_brands:
-        params["includeBrands"] = args.include_brands
+        params["includeBrands"] = [b.strip() for b in args.include_brands.split(",")]
     if args.exclude_brands:
-        params["excludeBrands"] = args.exclude_brands
+        params["excludeBrands"] = [b.strip() for b in args.exclude_brands.split(",")]
 
     params["sortBy"] = args.sort or "monthlySalesFloor"
     params["sortOrder"] = args.order or "desc"
@@ -453,7 +564,7 @@ def cmd_report(args):
     print("Step 3/4: Searching top products...", file=sys.stderr)
     products_result = api_call("products/search", {
         "keyword": keyword,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 50,
     })
@@ -508,7 +619,7 @@ def cmd_opportunity(args):
         "keyword": keyword,
         "monthlySalesMin": 300,
         "ratingCountMax": 50,
-        "sortBy": "monthlySales",
+        "sortBy": "monthlySalesFloor",
         "sortOrder": "desc",
         "pageSize": 20,
     }
@@ -565,17 +676,9 @@ def cmd_market_entry(args):
         return r
 
     # ── Step 0.5: Category Resolution ──
-    if not category_path and keyword:
-        log("Step 0.5: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked category: {' > '.join(category_path)}")
-        else:
-            log("  ⚠️ No category match, will use keyword-only queries")
-
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # ── Step 1: Market Landscape (3 calls) ──
@@ -744,43 +847,36 @@ def cmd_market_entry(args):
     review_results = {}
     label_types = ["painPoints", "buyingFactors", "improvements"]
 
-    # Priority 1: Category mode
-    category_mode_success = True
+    # Priority 1: Category mode (single call, split client-side)
+    category_mode_success = False
     if category_path:
-        for lt in label_types:
-            log(f"  → reviews/analysis category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path,
-                "mode": "category",
-                "labelType": lt,
-                "period": "6m",
-            }, f"reviews {lt}")
-            if r.get("success") is False or not r.get("data", {}).get("consumerInsights"):
-                category_mode_success = False
-                log(f"  ⚠️ Category mode failed for {lt}")
-                break
-            review_results[lt] = r
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path,
+            "mode": "category",
+            "period": "6m",
+        }, "reviews category")
+        if r.get("success") and r.get("data", {}).get("consumerInsights"):
+            category_mode_success = True
+            for lt in label_types:
+                review_results[lt] = _filter_review_insights(r, lt)
 
     # Priority 2: ASIN mode (if category failed)
-    if not category_mode_success or not category_path:
+    if not category_mode_success:
         log("  → Falling back to ASIN mode...")
-        # Pick ASINs with ratingCount >= 50
         review_asins = [p.get("asin") for p in all_products if (p.get("ratingCount") or 0) >= 50][:3]
         if review_asins:
+            log(f"  → reviews/analysis ASIN mode ({review_asins})")
+            r = safe_call("reviews/analysis", {
+                "asins": review_asins,
+                "mode": "asin",
+                "period": "6m",
+            }, "reviews ASIN")
             for lt in label_types:
-                if lt in review_results:
-                    continue
-                log(f"  → reviews/analysis ASIN mode: {lt} ({review_asins})")
-                r = safe_call("reviews/analysis", {
-                    "asins": review_asins,
-                    "mode": "asin",
-                    "labelType": lt,
-                    "period": "6m",
-                }, f"reviews ASIN {lt}")
-                review_results[lt] = r
+                review_results[lt] = _filter_review_insights(r, lt)
 
     results["reviews"] = review_results
-    results["meta"]["review_mode"] = "category" if category_mode_success and category_path else "asin"
+    results["meta"]["review_mode"] = "category" if category_mode_success else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
 
     # ── Summary ──
@@ -819,14 +915,9 @@ def cmd_competitor_analysis(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
-    results["meta"]["resolved_category"] = category_path
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
 
     # Step 1: Competitor Discovery
     log("Step 1/7: Competitor discovery...")
@@ -844,6 +935,7 @@ def cmd_competitor_analysis(args):
     if category_path:
         comp_params["categoryPath"] = category_path
     results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    results["meta"]["resolved_category"] = category_path
     results["meta"]["steps_completed"].append("competitor_discovery")
 
     # Step 2: Market Context
@@ -931,16 +1023,17 @@ def cmd_competitor_analysis(args):
     review_results = {}
     for asin in top_asins[:5]:
         r = safe_call("reviews/analysis", {
-            "asins": [asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [asin], "mode": "asin", "period": "6m"
         }, f"reviews {asin}")
         if r.get("data") and r.get("data", {}).get("consumerInsights"):
             review_results[asin] = r
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -955,7 +1048,7 @@ def cmd_competitor_analysis(args):
                 bp["keyword"] = keyword
             if category_path:
                 bp["categoryPath"] = category_path
-            bp["includeBrands"] = top_brand
+            bp["includeBrands"] = [top_brand]
             results["top_brand_products"] = safe_call("products/search", bp, f"brand {top_brand}")
     results["meta"]["steps_completed"].append("brand_drilldown")
 
@@ -969,6 +1062,7 @@ def cmd_pricing_analysis(args):
     """
     Composite workflow: Pricing Analysis.
     Runs: realtime(my_asin) → price-band → products/competitors → market/brand → history → realtime(top5) → reviews
+    Category is auto-detected from ASIN if not provided.
     """
     my_asin = args.my_asin
     keyword = args.keyword
@@ -976,9 +1070,6 @@ def cmd_pricing_analysis(args):
 
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
-        sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
         sys.exit(1)
 
     category_path = parse_category(category) if category else None
@@ -993,21 +1084,40 @@ def cmd_pricing_analysis(args):
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
         return r
 
-    # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
-    results["meta"]["resolved_category"] = category_path
-
     # Step 1: Current Price Snapshot
     log("Step 1/8: Current price snapshot...")
     results["my_product"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
+    my_data = results["my_product"].get("data", {}) or {}
+    if not my_data.get("title"):
+        log(f"\n❌ ASIN '{my_asin}' not found or has no data. Please check the ASIN and try again.")
+        results["error"] = {"code": "ASIN_NOT_FOUND", "message": f"ASIN '{my_asin}' not found or returned empty data"}
+        output(results, args.format)
+        return
     results["meta"]["steps_completed"].append("price_snapshot")
+
+    # Step 1.5: Auto Category Detection
+    if not category_path:
+        # For pricing, we already have realtime data — extract directly first
+        if my_data.get("categoryPath"):
+            category_path = my_data["categoryPath"]
+            results["meta"]["category_source"] = "asin_realtime"
+            log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        elif my_data.get("bestsellersRank"):
+            leaf = my_data["bestsellersRank"][-1].get("category", "")
+            if leaf:
+                log(f"  → Resolving category from BSR leaf: {leaf}")
+                cat_result = safe_call("categories", {"categoryKeyword": leaf}, "categories")
+                results["categories"] = cat_result
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    results["meta"]["category_source"] = "asin_bsr"
+                    log(f"  → Auto-detected category: {' > '.join(category_path)}")
+        # Fallback to keyword
+        if not category_path and keyword:
+            category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+            results["meta"]["category_source"] = category_source
+    results["meta"]["resolved_category"] = category_path
 
     # Step 2: Price Band Intelligence
     log("Step 2/8: Price band intelligence...")
@@ -1110,17 +1220,18 @@ def cmd_pricing_analysis(args):
     my_rc = results["my_product"].get("data", {}).get("ratingCount", 0)
     if my_rc and my_rc >= 50:
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if comp_asins:
         review_results["top_comp"] = safe_call("reviews/analysis", {
-            "asins": [comp_asins[0]], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [comp_asins[0]], "mode": "asin", "period": "6m"
         }, f"reviews {comp_asins[0]}")
     if not review_results and category_path:
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews cat {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_context")
 
@@ -1157,9 +1268,6 @@ def cmd_daily_radar(args):
     if not asins_str:
         print("ERROR: --asins is required (comma-separated ASINs to track).", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     tracked_asins = [a.strip() for a in asins_str.split(",") if a.strip()]
     category_path = parse_category(category) if category else None
@@ -1175,14 +1283,10 @@ def cmd_daily_radar(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=tracked_asins[0] if tracked_asins else None, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
@@ -1292,10 +1396,9 @@ def cmd_daily_radar(args):
             r = safe_call("reviews/analysis", {
                 "asins": [review_asin],
                 "mode": "asin",
-                "labelType": "painPoints",
                 "period": "6m",
             }, f"reviews {review_asin}")
-            review_results["painPoints"] = r
+            review_results["painPoints"] = _filter_review_insights(r, "painPoints")
             break
     
     if not review_results:
@@ -1324,9 +1427,6 @@ def cmd_listing_audit(args):
     if not my_asin:
         print("ERROR: --my-asin is required.", file=sys.stderr)
         sys.exit(1)
-    if not keyword and not category:
-        print("ERROR: --keyword or --category is required.", file=sys.stderr)
-        sys.exit(1)
 
     category_path = parse_category(category) if category else None
     results = {"meta": {"my_asin": my_asin, "keyword": keyword, "category": category, "steps_completed": []}}
@@ -1341,14 +1441,10 @@ def cmd_listing_audit(args):
         return r
 
     # Step 0.5: Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=my_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Audit Target
@@ -1451,21 +1547,22 @@ def cmd_listing_audit(args):
     if target_rc and target_rc >= 50:
         log(f"  → reviews/analysis ASIN mode: {my_asin}")
         review_results["my_asin"] = safe_call("reviews/analysis", {
-            "asins": [my_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [my_asin], "mode": "asin", "period": "6m"
         }, f"reviews {my_asin}")
     if leader_asins:
         top_leader = leader_asins[0]
         log(f"  → reviews/analysis ASIN mode: {top_leader}")
         review_results["top_leader"] = safe_call("reviews/analysis", {
-            "asins": [top_leader], "mode": "asin", "labelType": "painPoints", "period": "6m"
+            "asins": [top_leader], "mode": "asin", "period": "6m"
         }, f"reviews {top_leader}")
     # Category fallback
     if not review_results and category_path:
         log("  → Falling back to category mode...")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
         for lt in ["painPoints", "buyingFactors", "improvements"]:
-            review_results[lt] = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews category {lt}")
+            review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_intelligence")
 
@@ -1538,14 +1635,9 @@ def cmd_opportunity_scan(args):
         return r
 
     # Category Resolution
-    if not category_path and keyword:
-        log("Step 0: Resolving category...")
-        cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-        results["categories"] = cat_result
-        cat_data = cat_result.get("data", [])
-        if cat_data:
-            category_path = cat_data[0].get("categoryPath")
-            log(f"  → Locked: {' > '.join(category_path)}")
+    if not category_path:
+        category_path, category_source = _resolve_category(safe_call, log, keyword=keyword, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Product Scan (mode-based + custom filters)
@@ -1684,23 +1776,22 @@ def cmd_opportunity_scan(args):
     log("Step 6/6: Consumer insights...")
     review_results = {}
     if category_path:
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
-            log(f"  → category mode: {lt}")
-            r = safe_call("reviews/analysis", {
-                "categoryPath": category_path, "mode": "category", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            if r.get("data") and r.get("data", {}).get("consumerInsights"):
-                review_results[lt] = r
-            else:
-                break
+        log("  → reviews/analysis category mode")
+        r = safe_call("reviews/analysis", {
+            "categoryPath": category_path, "mode": "category", "period": "6m"
+        }, "reviews category")
+        if r.get("data") and r.get("data", {}).get("consumerInsights"):
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     if not review_results:
         log("  → Falling back to ASIN mode...")
         review_asins = [a for a in top_asins[:3]]
-        for lt in ["painPoints", "buyingFactors", "improvements"]:
+        if review_asins:
             r = safe_call("reviews/analysis", {
-                "asins": review_asins, "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews ASIN {lt}")
-            review_results[lt] = r
+                "asins": review_asins, "mode": "asin", "period": "6m"
+            }, "reviews ASIN")
+            for lt in ["painPoints", "buyingFactors", "improvements"]:
+                review_results[lt] = _filter_review_insights(r, lt)
     results["reviews"] = review_results
     results["meta"]["review_mode"] = "category" if category_path and review_results.get("painPoints", {}).get("data", {}).get("consumerInsights") else "asin"
     results["meta"]["steps_completed"].append("consumer_insights")
@@ -1743,13 +1834,9 @@ def cmd_review_deepdive(args):
 
     # Category Resolution
     if not category_path:
-        if keyword:
-            log("Step 0: Resolving category...")
-            cat_result = safe_call("categories", {"categoryKeyword": keyword}, "categories")
-            results["categories"] = cat_result
-            cat_data = cat_result.get("data", [])
-            if cat_data:
-                category_path = cat_data[0].get("categoryPath")
+        category_path, category_source = _resolve_category(
+            safe_call, log, keyword=keyword, asin=target_asin, results=results)
+        results["meta"]["category_source"] = category_source
     results["meta"]["resolved_category"] = category_path
 
     # Step 1: Target Identification
@@ -1775,26 +1862,25 @@ def cmd_review_deepdive(args):
     log("Step 2/5: Full review analysis (11 dimensions)...")
     label_types = ["painPoints", "positives", "buyingFactors", "improvements", "userProfiles",
                    "scenarios", "issues", "keywords", "usageTimes", "usageLocations", "behaviors"]
-    
+
     review_results = {}
-    # Target ASIN reviews
+    # Target ASIN reviews (single call, split client-side)
     if target_asin:
+        log(f"  → {target_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [target_asin], "mode": "asin", "period": "6m"
+        }, "reviews target")
         for lt in label_types:
-            log(f"  → {target_asin}: {lt}")
-            r = safe_call("reviews/analysis", {
-                "asins": [target_asin], "mode": "asin", "labelType": lt, "period": "6m"
-            }, f"reviews {lt}")
-            review_results[f"target_{lt}"] = r
-    
-    # Competitor comparison (top 2)
+            review_results[f"target_{lt}"] = _filter_review_insights(r, lt)
+
+    # Competitor comparison (top 2, single call each)
     for comp_asin in comp_asins[:2]:
-        log(f"  → Competitor {comp_asin}: painPoints + positives")
-        review_results[f"comp_{comp_asin}_painPoints"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "painPoints", "period": "6m"
+        log(f"  → Competitor {comp_asin}: all dimensions")
+        r = safe_call("reviews/analysis", {
+            "asins": [comp_asin], "mode": "asin", "period": "6m"
         }, f"reviews comp {comp_asin}")
-        review_results[f"comp_{comp_asin}_positives"] = safe_call("reviews/analysis", {
-            "asins": [comp_asin], "mode": "asin", "labelType": "positives", "period": "6m"
-        }, f"reviews comp+ {comp_asin}")
+        review_results[f"comp_{comp_asin}_painPoints"] = _filter_review_insights(r, "painPoints")
+        review_results[f"comp_{comp_asin}_positives"] = _filter_review_insights(r, "positives")
     
     results["reviews"] = review_results
     results["meta"]["steps_completed"].append("review_analysis")
@@ -1960,12 +2046,19 @@ def cmd_analyze(args):
         print("ERROR: --asin, --asins, or --category is required.", file=sys.stderr)
         sys.exit(1)
 
-    if args.label_type:
-        params["labelType"] = args.label_type
     if args.period:
         params["period"] = args.period
 
     result = api_call("reviews/analysis", params)
+
+    # Client-side filtering by label type (v2 API returns all dimensions in one call)
+    if args.label_type and result.get("data") and result["data"].get("consumerInsights"):
+        requested = [t.strip() for t in args.label_type.split(",")]
+        result["data"]["consumerInsights"] = [
+            i for i in result["data"]["consumerInsights"]
+            if i.get("labelType") in requested
+        ]
+
     output(result, args.format)
 
 
@@ -2246,7 +2339,12 @@ Examples:
     p_check = sub.add_parser("check", help="Fetch latest OpenAPI spec to verify available endpoints", allow_abbrev=False)
     p_check.set_defaults(func=cmd_check)
 
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
+    if unknown:
+        cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+        print(f"ERROR: Unrecognized argument(s): {' '.join(unknown)}", file=sys.stderr)
+        print(f"Run 'apiclaw.py {cmd} --help' to see valid options.", file=sys.stderr)
+        sys.exit(1)
     args.func(args)
 
 

--- a/apiclaw/scripts/apiclaw.py
+++ b/apiclaw/scripts/apiclaw.py
@@ -234,6 +234,25 @@ def _filter_review_insights(result, label_type):
     return filtered
 
 
+def _fetch_all_history(api_caller, asins, start_date, end_date, log_fn=None):
+    """Fetch products/history for multiple ASINs (one API call per ASIN)."""
+    all_data = []
+    last_response = None
+    for asin in asins:
+        r = api_caller("products/history", {
+            "asin": asin, "startDate": start_date, "endDate": end_date,
+        }, f"history {asin}")
+        last_response = r
+        if r.get("data"):
+            all_data.append(r["data"])
+        elif log_fn:
+            log_fn(f"  ⚠️ No history data for {asin}")
+    if last_response is None:
+        return {"success": False, "data": [], "error": {"message": "No ASINs provided"}}
+    last_response["data"] = all_data
+    return last_response
+
+
 def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None):
     """
     Resolve categoryPath with multi-level fallback.
@@ -818,11 +837,7 @@ def cmd_market_entry(args):
     round1_asins = top_asins[:3]
     if round1_asins:
         tried_asins.update(round1_asins)
-        r = safe_call("products/history", {
-            "asins": round1_asins,
-            "startDate": thirty_days_ago,
-            "endDate": today,
-        }, "history round 1")
+        r = _fetch_all_history(safe_call, round1_asins, thirty_days_ago, today, log_fn=log)
         history_data = r.get("data", [])
 
     # Round 2: Try oldest products if round 1 was empty
@@ -831,11 +846,7 @@ def cmd_market_entry(args):
         if round2_asins:
             log(f"  → Round 1 empty, trying older ASINs: {round2_asins}")
             tried_asins.update(round2_asins)
-            r = safe_call("products/history", {
-                "asins": round2_asins,
-                "startDate": thirty_days_ago,
-                "endDate": today,
-            }, "history round 2")
+            r = _fetch_all_history(safe_call, round2_asins, thirty_days_ago, today, log_fn=log)
             history_data = r.get("data", [])
 
     results["product_history"] = {"data": history_data, "asins_tried": list(tried_asins)}
@@ -1012,9 +1023,7 @@ def cmd_competitor_analysis(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = ([my_asin] if my_asin else []) + top_asins[:5]
-    r = safe_call("products/history", {
-        "asins": history_asins[:8], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins[:8], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins[:8]}
     results["meta"]["steps_completed"].append("historical_trends")
 
@@ -1198,9 +1207,7 @@ def cmd_pricing_analysis(args):
             break
 
     history_asins = [my_asin] + comp_asins
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("price_trends")
 
@@ -1308,11 +1315,7 @@ def cmd_daily_radar(args):
     tried_asins = set()
     
     # Round 1: All tracked ASINs
-    r = safe_call("products/history", {
-        "asins": tracked_asins,
-        "startDate": seven_days_ago,
-        "endDate": today,
-    }, "history round 1")
+    r = _fetch_all_history(safe_call, tracked_asins, seven_days_ago, today, log_fn=log)
     history_data = r.get("data", [])
     tried_asins.update(tracked_asins)
 
@@ -1571,9 +1574,7 @@ def cmd_listing_audit(args):
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     history_asins = [my_asin] + leader_asins[:2]
-    r = safe_call("products/history", {
-        "asins": history_asins, "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, history_asins, thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": history_asins}
     results["meta"]["steps_completed"].append("trend_context")
 
@@ -1766,9 +1767,7 @@ def cmd_opportunity_scan(args):
     log("Step 5/6: Trend check...")
     today = time.strftime("%Y-%m-%d")
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
-    r = safe_call("products/history", {
-        "asins": top_asins[:5], "startDate": thirty_ago, "endDate": today
-    }, "history")
+    r = _fetch_all_history(safe_call, top_asins[:5], thirty_ago, today, log_fn=log)
     results["product_history"] = {"data": r.get("data", []), "asins_tried": top_asins[:5]}
     results["meta"]["steps_completed"].append("trend_check")
 
@@ -1942,9 +1941,7 @@ def cmd_review_deepdive(args):
     thirty_ago = time.strftime("%Y-%m-%d", time.localtime(time.time() - 30 * 86400))
     hist_asins = [target_asin] + comp_asins[:2] if target_asin else comp_asins[:3]
     if hist_asins:
-        r = safe_call("products/history", {
-            "asins": hist_asins, "startDate": thirty_ago, "endDate": today
-        }, "history")
+        r = _fetch_all_history(safe_call, hist_asins, thirty_ago, today, log_fn=log)
         results["product_history"] = {"data": r.get("data", []), "asins_tried": hist_asins}
     results["meta"]["steps_completed"].append("price_trend_context")
 
@@ -2119,12 +2116,11 @@ def cmd_brand_detail(args):
 def cmd_product_history(args):
     """Get historical data (price, BSR, sales) for ASINs over a date range."""
     asins = [a.strip() for a in args.asins.split(",")]
-    params = {
-        "asins": asins,
-        "startDate": args.start_date,
-        "endDate": args.end_date,
-    }
-    result = api_call("products/history", params)
+
+    def _api_caller(endpoint, p, label=""):
+        return api_call(endpoint, p)
+
+    result = _fetch_all_history(_api_caller, asins, args.start_date, args.end_date)
     output(result, args.format)
 
 


### PR DESCRIPTION
## Summary

- **Bug 1**: Fix reviews/analysis 422 — remove deprecated `labelType` request param, merge 11+ API calls into 1-3 with client-side filtering
- **Bug 2**: Fix 429 rate limiting — add 600ms request pacing + 429-specific retry (4 attempts, exponential backoff with jitter)
- **Bug 3**: Fix products/search 422 — rename `sortBy: "monthlySales"` → `"monthlySalesFloor"` (2 missed spots in report/opportunity commands)
- **Bug 4**: Fix invalid ASIN silent pass — pricing-analysis now validates ASIN data before proceeding; implement auto category detection from ASIN via realtime/product
- **Bug 5**: Fix unfriendly unknown arg error — replace argparse crash with concise error message
- **New**: `includeBrands`/`excludeBrands` must be arrays, not strings (422 fix)
- **New**: `_resolve_category()` shared function with 3-level fallback (keyword → ASIN realtime → search inference), applied to all 7 composite commands
- **New**: All 9 SKILL.md enhanced with analysis frameworks, scoring thresholds, confidence labels, and required output sections (Language, Disclaimer, Data Provenance, API Usage)

## Files changed (13)

| File | Change |
|------|--------|
| `apiclaw/scripts/apiclaw.py` | Core bug fixes + category auto-detection + rate limiting |
| `apiclaw/references/*.md` | Update reviews/analysis and sortBy docs |
| `amazon-*/SKILL.md` (9 files) | Add analysis frameworks, output templates, language rules |
| `amazon-analysis/references/reference.md` | Update reviews/analysis docs |

## Test plan

- [x] 41 unit tests pass
- [x] Manual API test: reviews/analysis returns 200 with all 11 dimensions
- [x] Manual API test: products/search with monthlySalesFloor sortBy works
- [x] Manual API test: includeBrands as array works
- [x] Manual API test: fake ASIN returns clear error
- [x] Manual API test: unknown CLI args show friendly message
- [x] End-to-end: competitor-analysis with keyword only (category auto-detected)
- [x] End-to-end: competitor-analysis with keyword + my-asin
- [x] End-to-end: pricing-analysis with ASIN only (no keyword needed)
- [x] Rate limiting: 5 rapid calls complete without 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)