### PR TITLE
fix: resolve ClawHub security scan warnings

### DIFF
--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -4,6 +4,9 @@ version: 1.1.4
 description: >
   Amazon seller data analysis tool. Features: market research, product selection, competitor analysis, ASIN evaluation, pricing reference, category research.
   Uses {skill_base_dir}/scripts/apiclaw.py to call APIClaw API, requires APICLAW_API_KEY.
+author: SerendipityOneInc
+homepage: https://github.com/SerendipityOneInc/APIClaw-Skills
+metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": "APICLAW_API_KEY"}}
 ---
 
 # APIClaw — Amazon Seller Data Analysis

--- a/amazon-analysis/scripts/apiclaw.py
+++ b/amazon-analysis/scripts/apiclaw.py
@@ -7,7 +7,7 @@
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
 
-Single-script interface for all 5 APIClaw endpoints + composite workflows.
+Single-script interface for all 11 APIClaw endpoints + composite workflows.
 Handles authentication, retries, rate limits, parameter quirks, and output formatting.
 
 Usage:

--- a/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
+++ b/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
@@ -7,7 +7,7 @@
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
 
-Single-script interface for all 5 APIClaw endpoints + composite workflows.
+Single-script interface for all 11 APIClaw endpoints + composite workflows.
 Handles authentication, retries, rate limits, parameter quirks, and output formatting.
 
 Usage:

--- a/amazon-daily-market-radar/scripts/apiclaw.py
+++ b/amazon-daily-market-radar/scripts/apiclaw.py
@@ -7,7 +7,7 @@
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
 
-Single-script interface for all 5 APIClaw endpoints + composite workflows.
+Single-script interface for all 11 APIClaw endpoints + composite workflows.
 Handles authentication, retries, rate limits, parameter quirks, and output formatting.
 
 Usage:

--- a/amazon-listing-audit-pro/scripts/apiclaw.py
+++ b/amazon-listing-audit-pro/scripts/apiclaw.py
@@ -7,7 +7,7 @@
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
 
-Single-script interface for all 5 APIClaw endpoints + composite workflows.
+Single-script interface for all 11 APIClaw endpoints + composite workflows.
 Handles authentication, retries, rate limits, parameter quirks, and output formatting.
 
 Usage:

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -20,7 +20,7 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 One input (keyword/category). Full market viability assessment with sub-market discovery.
 
 ## Files
-- **Script**: `{skill_base_dir}/scripts/apiclaw.py` (execute, don't read) — run `--help` for params
+- **Script**: `{skill_base_dir}/scripts/apiclaw.py` — run `--help` for params
 - **Reference**: `{skill_base_dir}/references/reference.md` (field names & response structure)
 
 ## Credential

--- a/amazon-market-entry-analyzer/scripts/apiclaw.py
+++ b/amazon-market-entry-analyzer/scripts/apiclaw.py
@@ -7,7 +7,7 @@
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
 
-Single-script interface for all 5 APIClaw endpoints + composite workflows.
+Single-script interface for all 11 APIClaw endpoints + composite workflows.
 Handles authentication, retries, rate limits, parameter quirks, and output formatting.
 
 Usage:

--- a/amazon-market-trend-scanner/scripts/apiclaw.py
+++ b/amazon-market-trend-scanner/scripts/apiclaw.py
@@ -7,7 +7,7 @@
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
 
-Single-script interface for all 5 APIClaw endpoints + composite workflows.
+Single-script interface for all 11 APIClaw endpoints + composite workflows.
 Handles authentication, retries, rate limits, parameter quirks, and output formatting.
 
 Usage:

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -20,7 +20,7 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 Tell me your budget and experience. I find opportunities, score them, and rank.
 
 ## Files
-- **Script**: `{skill_base_dir}/scripts/apiclaw.py` (execute, don't read) — run `--help` for params
+- **Script**: `{skill_base_dir}/scripts/apiclaw.py` — run `--help` for params
 - **Reference**: `{skill_base_dir}/references/reference.md` (field names & response structure)
 
 ## Credential

--- a/amazon-opportunity-discoverer/scripts/apiclaw.py
+++ b/amazon-opportunity-discoverer/scripts/apiclaw.py
@@ -7,7 +7,7 @@
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
 
-Single-script interface for all 5 APIClaw endpoints + composite workflows.
+Single-script interface for all 11 APIClaw endpoints + composite workflows.
 Handles authentication, retries, rate limits, parameter quirks, and output formatting.
 
 Usage:

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -22,7 +22,7 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 Give me your ASIN(s). I'll tell you whether to raise, hold, or lower — with data.
 
 ## Files
-- **Script**: `{skill_base_dir}/scripts/apiclaw.py` (execute, don't read) — run `--help` for params
+- **Script**: `{skill_base_dir}/scripts/apiclaw.py` — run `--help` for params
 - **Reference**: `{skill_base_dir}/references/reference.md` (field names & response structure)
 
 ## Credential

--- a/amazon-pricing-command-center/scripts/apiclaw.py
+++ b/amazon-pricing-command-center/scripts/apiclaw.py
@@ -7,7 +7,7 @@
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
 
-Single-script interface for all 5 APIClaw endpoints + composite workflows.
+Single-script interface for all 11 APIClaw endpoints + composite workflows.
 Handles authentication, retries, rate limits, parameter quirks, and output formatting.
 
 Usage:

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -21,7 +21,7 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 Pre-analyzed consumer insights. Pain points, buying factors, user profiles, differentiation gaps.
 
 ## Files
-- **Script**: `{skill_base_dir}/scripts/apiclaw.py` (execute, don't read) — run `--help` for params
+- **Script**: `{skill_base_dir}/scripts/apiclaw.py` — run `--help` for params
 - **Reference**: `{skill_base_dir}/references/reference.md` (field names & response structure)
 
 ## Credential

--- a/amazon-review-intelligence-extractor/scripts/apiclaw.py
+++ b/amazon-review-intelligence-extractor/scripts/apiclaw.py
@@ -7,7 +7,7 @@
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
 
-Single-script interface for all 5 APIClaw endpoints + composite workflows.
+Single-script interface for all 11 APIClaw endpoints + composite workflows.
 Handles authentication, retries, rate limits, parameter quirks, and output formatting.
 
 Usage:

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -12,6 +12,8 @@ description: >
   general commerce data questions. For deep Amazon product selection
   strategies and analysis workflows, use the Amazon-analysis-skill instead.
   Requires APICLAW_API_KEY.
+author: SerendipityOneInc
+homepage: https://github.com/SerendipityOneInc/APIClaw-Skills
 metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": "APICLAW_API_KEY"}}
 ---
 

--- a/apiclaw/scripts/apiclaw.py
+++ b/apiclaw/scripts/apiclaw.py
@@ -7,7 +7,7 @@
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
 
-Single-script interface for all 5 APIClaw endpoints + composite workflows.
+Single-script interface for all 11 APIClaw endpoints + composite workflows.
 Handles authentication, retries, rate limits, parameter quirks, and output formatting.
 
 Usage:


### PR DESCRIPTION
## Summary
- Remove "(execute, don't read)" phrasing from 4 SKILL.md files (flagged by ClawHub as discouraging code review)
- Fix endpoint count mismatch: "5 endpoints" → "11 endpoints" in apiclaw.py docstring (caused doc/code inconsistency warning)
- Add missing `author` and `homepage` fields to `apiclaw/SKILL.md` and `amazon-analysis/SKILL.md`
- Add missing `metadata` block to `amazon-analysis/SKILL.md`

## Context
ClawHub security scanner flagged several skills with "Suspicious" or cautionary ratings due to these issues. This PR fixes the root causes so re-publishing will pass the scan cleanly.

## Affected Skills
| Skill | Fix |
|-------|-----|
| amazon-opportunity-discoverer | Remove "execute, don't read" |
| amazon-market-entry-analyzer | Remove "execute, don't read" |
| amazon-pricing-command-center | Remove "execute, don't read" |
| amazon-review-intelligence-extractor | Remove "execute, don't read" |
| apiclaw | Add author + homepage |
| amazon-analysis | Add author + homepage + metadata |
| All (apiclaw.py) | Fix "5 endpoints" → "11 endpoints" docstring |

## Test plan
- [ ] Verify all SKILL.md files have consistent `author`, `homepage`, `metadata` fields
- [ ] Verify no "execute, don't read" remains in any SKILL.md
- [ ] After merge, re-publish to ClawHub and verify scan results improve

🤖 Generated with [Claude Code](https://claude.com/claude-code)