### PR TITLE
chore: bump patch versions for ClawHub republish

### DIFF
--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Analysis — Full-Spectrum Research & Seller Intelligence
-version: 1.1.4
+version: 1.1.5
 description: >
   Amazon seller data analysis tool. Features: market research, product selection, competitor analysis, ASIN evaluation, pricing reference, category research.
   Uses {skill_base_dir}/scripts/apiclaw.py to call APIClaw API, requires APICLAW_API_KEY.

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Competitor Intelligence Monitor
-version: 1.1.0
+version: 1.1.1
 description: >
   Deep competitor intelligence for Amazon sellers with continuous monitoring.
   Two modes: Full Scan (complete analysis, 28-35 credits) and Quick Check (lightweight monitoring, 5-10 credits).

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Daily Market Radar — Automated Monitoring & Alerts
-version: 1.0.0
+version: 1.0.1
 description: >
   Automated daily market monitoring and alert system for Amazon sellers.
   Tracks price changes, new competitors, BSR movements, review spikes,

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Listing Audit Pro — 8-Dimension Health Check
-version: 1.0.0
+version: 1.0.1
 description: >
   Comprehensive listing health check and optimization engine for Amazon sellers.
   Scores listings across 8 dimensions, benchmarks against category leaders,

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Market Entry Analyzer — GO/CAUTION/AVOID Verdicts
-version: 1.0.0
+version: 1.0.1
 description: >
   One-click market viability assessment for Amazon sellers.
   Analyzes market size, competition intensity, brand landscape, pricing structure,

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Market Radar — Daily Trend Scanner
-version: 1.0.0
+version: 1.0.1
 description: >
   Scan Amazon category landscapes to discover trending subcategories,
   emerging niches, and market shifts. Complements Daily Market Radar

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Opportunity Discoverer — Niche Scanner & Scoring
-version: 1.0.0
+version: 1.0.1
 description: >
   Automated product opportunity scanner for Amazon sellers.
   Scans categories using 14 preset selection strategies, validates candidates with

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Dynamic Pricing Intelligence Agent
-version: 1.1.0
+version: 1.1.1
 description: >
   Data-driven pricing strategy engine for Amazon sellers.
   Give me your ASIN(s) — I auto-detect the leaf category, analyze pricing landscape,

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Review Intelligence Extractor — Consumer Insights from 1B+ Reviews
-version: 1.0.0
+version: 1.0.1
 description: >
   Deep consumer insights from 1B+ pre-analyzed Amazon reviews.
   Extracts pain points, buying factors, user profiles, usage patterns,

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: APIClaw — Amazon Commerce Data, 11 Endpoints
-version: 1.1.0
+version: 1.1.1
 description: >
   General overview, 11 API endpoints.
   AI-powered commerce data infrastructure with 200M+ Amazon products.


### PR DESCRIPTION
## Summary
- Patch version bump for all 10 skills after republishing to ClawHub with security scan fixes
- ClawHub does not allow overwriting existing versions, so patch bumps were required

Skills already published to ClawHub with these new versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)