### PR TITLE
feat: realtime/reviews fallback toolkit + output-quality rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **`/openapi/v2/realtime/reviews` endpoint integration** — cursor-paginated raw review fetch (10 reviews/page, max 100 reviews / 10 pages, 1 credit/page, US+UK only). Spider-live, no AI tags.
+- **Local Review Toolkit in `apiclaw.py`** — prompt-as-data fallback path when `/reviews/analysis` lacks aggregation (ASIN <50 reviews or no daily snapshot). New CLI commands:
+  - `reviews-raw` — fetch raw reviews with auto-pagination + early exit
+  - `review-tag-prompt` — render per-review Map prompt for the caller's own LLM
+  - `review-reduce-prompt` — render per-dimension Reduce prompt for the caller's own LLM
+  - `review-aggregate` — combine raw reviews + Map tags + Reduce clusters into `consumerInsights` output compatible with `/reviews/analysis`
+- **Three-layer sync enforcement docs** in `apiclaw/scripts/apiclaw.py` file header (pre-commit hook + `sync-scripts.sh` + CI workflow).
+- **CONTRIBUTING.md** sections on local branch hygiene and shared CLI script sync mechanism.
+
+### Changed
+- All 8 review-using SKILL.md files now document the realtime/reviews fallback chain (each self-contained, no cross-skill references):
+  - Tier A (deep update): `apiclaw`, `amazon-review-intelligence-extractor`, `amazon-analysis`
+  - Tier B (pitfall expansion): `amazon-competitor-intelligence-monitor`, `amazon-daily-market-radar`, `amazon-listing-audit-pro`, `amazon-market-entry-analyzer`, `amazon-opportunity-discoverer`
+- Reference docs updated with `realtime/reviews` and `reviews/search` schemas (`apiclaw/references/{openapi-reference,reference}.md`, `amazon-review-intelligence-extractor/references/reference.md`).
+- All 9 `amazon-*/scripts/apiclaw.py` copies force-resynced to canonical (one-time cleanup of pre-existing drift; future syncs now safe via AUTO-SYNCED marker in file header).
+
 ## [1.2.0] — 2026-04-03
 
 ### Breaking Changes — API V2 Field Renames

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,36 @@ Thanks for your interest in contributing! We keep things simple.
 6. Push: `git push origin my-feature`
 7. Open a Pull Request
 
+## Local Branch Hygiene
+
+To avoid divergence from `origin/main` (e.g. if your previous branch was
+squash-merged, your local SHA differs from the merged SHA on `main`):
+
+```bash
+# Always start from a fresh main
+git checkout main
+git fetch origin
+git reset --hard origin/main   # safe — discards stale local commits whose
+                               # content has already been merged on origin
+git checkout -b feat/my-thing
+```
+
+## Shared CLI Script — `apiclaw.py`
+
+The canonical script lives at `apiclaw/scripts/apiclaw.py`. Each `amazon-*`
+skill has a synced copy at `<skill>/scripts/apiclaw.py`. **Never edit copies
+directly** — sync is enforced at three layers:
+
+1. **Local pre-commit hook** — auto-syncs copies when canonical is staged.
+   Install once per clone: `bash scripts/install-hooks.sh`
+2. **`scripts/sync-scripts.sh`** — mirrors canonical → copies. Refuses to
+   overwrite copies that differ without an `AUTO-SYNCED` marker.
+3. **CI check** (`.github/workflows/shared-files-distribution.yml`) — every
+   PR touching `scripts/**` or `*scripts/apiclaw.py` runs a strict diff;
+   mismatched copies fail the PR.
+
+See the file header of `apiclaw/scripts/apiclaw.py` for full details.
+
 ## Testing Your Changes
 
 ### For Skill files (SKILL.md, references/)

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Analysis — Full-Spectrum Research & Seller Intelligence
-version: 1.1.5
+version: 1.1.6
 description: >
   Amazon seller data analysis tool. Features: market research, product selection, competitor analysis, ASIN evaluation, pricing reference, category research.
   Uses {skill_base_dir}/scripts/apiclaw.py to call APIClaw API, requires APICLAW_API_KEY.
@@ -34,7 +34,17 @@ User provides: keyword, category, ASIN, or brand — depending on intent. Use in
 1. **Category first**: keyword search is broad → MUST lock `categoryPath` via `categories` endpoint before other calls
 2. **Brand + category**: Brand queries MUST include `--category` to avoid cross-category contamination
 3. **Use API fields directly**: revenue=`sampleAvgMonthlyRevenue` (NEVER calculate price×sales), sales=`monthlySalesFloor` (lower bound), opportunity=`sampleOpportunityIndex`
-4. **reviews/analysis**: needs 50+ reviews per ASIN; try category mode first (single call returns all dimensions), ASIN mode only if category call fails. Filter by `labelType` client-side from the `consumerInsights` array.
+4. **reviews/analysis**: needs 50+ reviews per ASIN; try category mode first (single call returns all dimensions), ASIN mode only if category call fails. Filter by `labelType` client-side from the `consumerInsights` array. Fallback chain when sample is insufficient:
+   1. **Lightweight**: `realtime/product` ratingBreakdown — only star distribution, no themes
+   2. **Full 11-dim insights** — bypass `/reviews/analysis` entirely:
+      a. `apiclaw.py reviews-raw --asin X` → fetch up to 100 raw reviews (10 credits, ~60s)
+      b. For each review: render Map prompt via `apiclaw.py review-tag-prompt --review '<json>'`
+         and have your own LLM produce JSON tags (sentiment + 11 dimensions)
+      c. Collect candidate phrases per dimension; for each dimension render
+         Reduce prompt via `apiclaw.py review-reduce-prompt --label-type X --candidates '[...]'`
+         and have your LLM produce semantic clusters
+      d. `apiclaw.py review-aggregate --reviews R --tagged T --clusters C`
+         → consumerInsights output compatible with `/reviews/analysis`
 5. **Aggregation without categoryPath**: produces severely distorted data
 6. **`.data` is array**: use `.data[0]`, not `.data.field`
 7. **labelType**: NOT an API request parameter — it is a field in the response `consumerInsights` array, used for client-side filtering
@@ -116,6 +126,22 @@ Output language MUST match the user's input language. If the user asks in Chines
 - 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
 
 Rules: Strategy recommendations are NEVER 📊. Anomalies (>200% growth) are always 💡. User criteria override AI judgment.
+
+**Aggregate-label rule (applies to ALL report output, not just fallback)**: NEVER attach 📊 to ANY element that aggregates or groups underlying content when ANY piece of that content is 🔍 or 💡. "Aggregate/grouping elements" include:
+- Section headers at EVERY level (`#`, `##`, `###`, `####`) — including top-level summary sections like "Overall Score", "Verdict", "Executive Summary"
+- Summary/score lines anywhere in the report (e.g. `## Overall Score — 27/100 · Grade F 📊` is WRONG if any Basis row inside is 🔍)
+- Table **column** headers in comparison tables (e.g. `**Target ASIN** 📊` as a column label is WRONG if any cell in that column contains 🔍)
+- Table row headers or row-aggregation labels (when the row aggregates multiple cells of mixed confidence)
+- Any other visual grouping label — bullet-list group titles, callout box titles, etc.
+
+A group-level 📊 implies the whole block/column/row is data-backed, which smuggles inferred/directional content into the 📊 tier via visual grouping. Either (a) **omit the group-level label entirely** (preferred when content mixes tiers), or (b) use the LOWEST confidence present inside (🔍 if any underlying content is 🔍; 💡 if any is 💡). This is a universal output-quality rule — it applies regardless of which fallback path (if any) was triggered.
+
+**Emoji reservation rule (closely related)**: The three confidence symbols `📊 🔍 💡` are RESERVED for confidence labeling. NEVER use them as decorative prefixes on section headers, table headers, or any aggregate element — even when you also include a correct confidence suffix on the same line. Example:
+- ❌ WRONG: `## 📊 Overall Score — 27/100 · Grade F 🔍` (the leading 📊 reads as a data-backed claim even though the trailing 🔍 is correct)
+- ✅ RIGHT: `## Overall Score — 27/100 · Grade F 🔍` (no decorative emoji, just the proper confidence suffix)
+- ✅ RIGHT: `## 🎯 Overall Score — 27/100 · Grade F 🔍` (use non-reserved decorative icons like 🎯 🧭 📋 📝 📂 🏁 🚨 🏆 🔔 when a visual prefix is desired)
+
+Decorative emoji ≠ confidence label — but from a reader's perspective, a leading `📊/🔍/💡` is indistinguishable from a confidence claim. Reserve these three symbols EXCLUSIVELY for confidence annotation to avoid ambiguity.
 
 ### Data Provenance (required)
 

--- a/amazon-analysis/scripts/apiclaw.py
+++ b/amazon-analysis/scripts/apiclaw.py
@@ -1,29 +1,8 @@
 #!/usr/bin/env python3
 # ============================================================
-# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
-# Source of truth: apiclaw/scripts/apiclaw.py
-#
-# Sync is enforced at THREE layers — understand all three before editing:
-#
-#   1. Local pre-commit hook (scripts/pre-commit)
-#      When this file is staged, auto-runs sync-scripts.sh and stages the
-#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
-#
-#   2. Sync script (scripts/sync-scripts.sh)
-#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
-#      any copy that differs without an "AUTO-SYNCED" marker (safety against
-#      destroying manual edits). If you hit a CONFLICT, inspect the diff
-#      first, then either (a) merge the manual edit back into canonical, or
-#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
-#
-#   3. CI check (.github/workflows/shared-files-distribution.yml)
-#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
-#      `diff` against canonical. Mismatched copies fail the PR hard with an
-#      "::error::" annotation — no merge until all 9 copies are identical.
-#
-# If you inherit a repo where copies drift without markers, resolve once by:
-#   bash scripts/sync-scripts.sh   # lists CONFLICTs
-#   # then add the AUTO-SYNCED marker to each copy and re-run
+# Canonical source - do not edit copies under amazon-* skill directories directly
+# Source location: apiclaw/scripts/apiclaw.py
+# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API

--- a/amazon-analysis/scripts/apiclaw.py
+++ b/amazon-analysis/scripts/apiclaw.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python3
 # ============================================================
-# Canonical source - do not edit copies under amazon-* skill directories directly
-# Source location: apiclaw/scripts/apiclaw.py
-# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
+# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
+# Source of truth: apiclaw/scripts/apiclaw.py
+#
+# Sync is enforced at THREE layers — understand all three before editing:
+#
+#   1. Local pre-commit hook (scripts/pre-commit)
+#      When this file is staged, auto-runs sync-scripts.sh and stages the
+#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
+#
+#   2. Sync script (scripts/sync-scripts.sh)
+#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
+#      any copy that differs without an "AUTO-SYNCED" marker (safety against
+#      destroying manual edits). If you hit a CONFLICT, inspect the diff
+#      first, then either (a) merge the manual edit back into canonical, or
+#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
+#
+#   3. CI check (.github/workflows/shared-files-distribution.yml)
+#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
+#      `diff` against canonical. Mismatched copies fail the PR hard with an
+#      "::error::" annotation — no merge until all 9 copies are identical.
+#
+# If you inherit a repo where copies drift without markers, resolve once by:
+#   bash scripts/sync-scripts.sh   # lists CONFLICTs
+#   # then add the AUTO-SYNCED marker to each copy and re-run
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
@@ -376,6 +397,315 @@ def parse_category(cat_str: str) -> list:
     if ">" in cat_str:
         return [c.strip() for c in cat_str.split(">")]
     return [c.strip() for c in cat_str.split(",")]
+
+
+# ─── Review Analysis: Prompt-as-Data Toolkit ───────────────────────────────
+# Used when /reviews/analysis lacks aggregation (ASIN has <50 reviews or no
+# daily snapshot). This module does NOT call any external LLM — it provides
+# raw data, rendered prompts, and a final aggregator. The calling skill's own
+# LLM performs the Map (per-review tagging) and Reduce (semantic clustering)
+# steps, producing JSON that feeds back into `review-aggregate`.
+#
+# Caller flow:
+#   1. apiclaw.py reviews-raw --asin X          → fetch raw reviews
+#   2. For each review, render via:
+#        apiclaw.py review-tag-prompt --review '<json>'
+#      The caller's LLM produces JSON matching REVIEW_MAP_SCHEMA.
+#   3. Collect per-dimension candidate phrases; for each dimension render:
+#        apiclaw.py review-reduce-prompt --label-type <dim> --candidates '[...]'
+#      The caller's LLM produces JSON matching REVIEW_REDUCE_SCHEMA.
+#   4. apiclaw.py review-aggregate --reviews R --tagged T --clusters C
+#      → emits consumerInsights compatible with /reviews/analysis.
+
+REVIEW_MAP_CONCURRENCY = 20           # suggested map parallelism for caller
+REVIEW_REDUCE_KEYWORDS_CHUNK = 150    # suggested chunk size when keywords dim is large
+REALTIME_REVIEWS_MAX_PAGES = 10       # API hard cap = 100 reviews (10 pages × 10)
+
+DIM_TO_LABELTYPE = {
+    "mentioned_scenarios": "scenarios",
+    "mentioned_issues": "issues",
+    "mentioned_positives": "positives",
+    "mentioned_improvements": "improvements",
+    "mentioned_buying_factors": "buyingFactors",
+    "mentioned_pain_points": "painPoints",
+    "user_profiles": "userProfiles",
+    "mentioned_usage_times": "usageTimes",
+    "mentioned_usage_locations": "usageLocations",
+    "mentioned_behaviors": "behaviors",
+    "keywords": "keywords",
+}
+
+_MAP_ARRAY_FIELDS = list(DIM_TO_LABELTYPE.keys())
+
+REVIEW_MAP_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "sentiment": {"type": "STRING", "enum": ["positive", "neutral", "negative"]},
+        **{k: {"type": "ARRAY", "items": {"type": "STRING"}} for k in _MAP_ARRAY_FIELDS},
+    },
+    "required": ["sentiment"] + _MAP_ARRAY_FIELDS,
+}
+
+REVIEW_REDUCE_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "clusters": {
+            "type": "ARRAY",
+            "items": {
+                "type": "OBJECT",
+                "properties": {
+                    "canonical": {"type": "STRING"},
+                    "members": {"type": "ARRAY", "items": {"type": "STRING"}},
+                },
+                "required": ["canonical", "members"],
+            },
+        },
+    },
+    "required": ["clusters"],
+}
+
+
+def render_review_map_prompt(review: dict, product_title: str = "", product_category: str = "") -> str:
+    title = review.get("title") or ""
+    body = review.get("body") or ""
+    full = f"{title}. {body}" if title else body
+    text = full[:500]
+    rating = review.get("rating") or 3
+    verified = bool(review.get("verifiedPurchase"))
+    return f"""IMPORTANT: Respond ONLY with a JSON object matching the schema below. Output must be in English — translate non-English text before extracting.
+
+You are an expert data extraction specialist analyzing product reviews. Extract only what is EXPLICITLY mentioned — do not infer.
+
+JSON schema:
+{{
+  "sentiment": "positive" | "neutral" | "negative",
+  "mentioned_scenarios": [string],      // max 5 noun phrases 1-3 words (Workouts, Gaming)
+  "mentioned_issues": [string],         // max 5 Adjective+Noun for PRODUCT DEFECTS (Poor Sound Quality)
+  "mentioned_positives": [string],      // max 5 Adjective+Noun for praised aspects (Comfortable Fit)
+  "mentioned_improvements": [string],   // max 3 Verb+Noun explicit suggestions (Extend Battery Life)
+  "mentioned_buying_factors": [string], // max 3 noun phrases for purchase reasons (Price Point)
+  "mentioned_pain_points": [string],    // max 3 UX frustrations EXPERIENCED AFTER USE (see rule)
+  "user_profiles": [string],            // max 3 identities stated EXPLICITLY (see rule)
+  "mentioned_usage_times": [string],    // max 3 time/season phrases (Morning, Winter)
+  "mentioned_usage_locations": [string],// max 3 location phrases (Gym, Home)
+  "mentioned_behaviors": [string],      // max 5 Verb+Object (Taking Calls, Running)
+  "keywords": [string]                  // 3-15 salient words from the review
+}}
+
+Rules:
+- sentiment: positive (4-5 stars or praise), neutral (3 stars / mixed), negative (1-2 stars or complaint)
+- pain_points = problems EXPERIENCED AFTER USE. NOT problems the product solves. If the reviewer says the product solved a prior problem (e.g. "cured my foot pain"), that belongs in positives, NOT pain_points.
+- issues vs pain_points: issues = product defects (hardware/software fault); pain_points = UX frustrations
+- user_profiles: include ONLY if the reviewer explicitly states an identity ("I'm a...", "As a..."). NEVER infer.
+- consistent naming across reviews (e.g. always "Workouts", not "At the gym")
+- use empty arrays [] for categories with no mentions, never null
+
+INPUT:
+Product Category: {product_category or '(unknown)'}
+Product Title: {product_title or '(unknown)'}
+Review Rating: {rating}/5 stars
+Verified Purchase: {'Yes' if verified else 'No'}
+Review Text:
+\"\"\"{text}\"\"\"
+
+Return ONLY the JSON object."""
+
+
+def render_review_reduce_prompt(label_type: str, candidates: list) -> str:
+    return f"""Normalize product-review tags. Group semantically equivalent phrases into clusters and pick a concise Title-Case canonical name (1-3 words) for each cluster.
+
+Label type: {label_type}
+
+Rules:
+- A cluster contains phrases describing the SAME underlying concept.
+- Every input phrase MUST appear in exactly one cluster's `members`. No drops, no duplicates across clusters.
+- Phrases with no semantic neighbors go in their own single-member cluster (still Title-Case canonical).
+- Case-insensitive matching. Preserve input phrase strings verbatim in `members`.
+
+Return a JSON object matching:
+{{"clusters": [{{"canonical": "Title Case", "members": ["phrase1", "phrase2"]}}]}}
+
+Input phrases:
+{json.dumps(candidates, ensure_ascii=False)}"""
+
+
+def fetch_realtime_reviews_all(asin: str, marketplace: str = "US",
+                                max_pages: int = REALTIME_REVIEWS_MAX_PAGES,
+                                log_fn=None) -> dict:
+    """Paginate /realtime/reviews with cursor; stop on null cursor or max_pages."""
+    log = log_fn or (lambda m: None)
+    reviews = []
+    cursor = None
+    pages = 0
+    t0 = time.time()
+    for i in range(1, max_pages + 1):
+        params = {"asin": asin, "marketplace": marketplace}
+        if cursor:
+            params["cursor"] = cursor
+        resp = api_call("realtime/reviews", params)
+        if not resp.get("success"):
+            break
+        data = resp.get("data") or {}
+        page_reviews = data.get("reviews") or []
+        cursor = data.get("nextCursor")
+        pages += 1
+        reviews.extend(page_reviews)
+        log(f"  page {i}: {len(page_reviews)} reviews, cursor={'yes' if cursor else 'end'}")
+        if not cursor:
+            break
+    return {
+        "reviews": reviews,
+        "pages": pages,
+        "capped": pages >= max_pages and cursor is not None,
+        "fetchSeconds": round(time.time() - t0, 2),
+    }
+
+
+def aggregate_review_insights(reviews: list, tagged: list, clusters_per_dim: dict) -> dict:
+    """Combine raw reviews + per-review Map tags + per-dimension Reduce clusters
+    into a reviews/analysis-compatible aggregation. No LLM calls."""
+    from collections import defaultdict
+
+    if len(tagged) != len(reviews):
+        raise ValueError(f"tagged length ({len(tagged)}) != reviews length ({len(reviews)})")
+
+    total = len(reviews)
+    ratings = [r.get("rating") or 0 for r in reviews]
+
+    dim_phrase_reviews = {k: defaultdict(set) for k in DIM_TO_LABELTYPE}
+    for i, tags in enumerate(tagged):
+        if not isinstance(tags, dict):
+            continue
+        for dim in DIM_TO_LABELTYPE:
+            for el in (tags.get(dim) or []):
+                if not isinstance(el, str):
+                    continue
+                kl = el.strip().lower()
+                if kl:
+                    dim_phrase_reviews[dim][kl].add(i)
+
+    insights = []
+    for dim, phrases in dim_phrase_reviews.items():
+        if not phrases:
+            continue
+        p2c = {}
+        for cl in (clusters_per_dim.get(dim) or []):
+            canon = (cl.get("canonical") or "").strip()
+            if not canon:
+                continue
+            for m in (cl.get("members") or []):
+                if not isinstance(m, str):
+                    continue
+                ml = m.strip().lower()
+                if ml and ml not in p2c:
+                    p2c[ml] = canon
+        for ph in phrases:
+            p2c.setdefault(ph, ph.title())
+
+        canon_to_reviews = defaultdict(set)
+        for phrase, rs in phrases.items():
+            canon_to_reviews[p2c[phrase]].update(rs)
+
+        lt = DIM_TO_LABELTYPE[dim]
+        for canon, rs in canon_to_reviews.items():
+            c = len(rs)
+            avg = sum(ratings[i] for i in rs) / c if c else 0.0
+            insights.append({
+                "element": canon,
+                "labelType": lt,
+                "count": c,
+                "reviewRate": round(c / total, 4),
+                "avgRating": round(avg, 2),
+            })
+    insights.sort(key=lambda x: (x["labelType"], -x["count"]))
+
+    sentiments = [(t or {}).get("sentiment") for t in tagged]
+    sentiment_dist = {
+        "positive": round(sum(1 for s in sentiments if s == "positive") / total, 4) if total else 0,
+        "neutral": round(sum(1 for s in sentiments if s == "neutral") / total, 4) if total else 0,
+        "negative": round(sum(1 for s in sentiments if s == "negative") / total, 4) if total else 0,
+    }
+    avg_rating = round(sum(ratings) / total, 2) if total else 0.0
+
+    return {
+        "success": True,
+        "data": {
+            "reviewCount": total,
+            "avgRating": avg_rating,
+            "sentimentDistribution": sentiment_dist,
+            "consumerInsights": insights,
+            "topKeywords": [
+                {"element": it["element"], "count": it["count"]}
+                for it in insights if it["labelType"] == "keywords"
+            ][:20],
+        },
+        "_meta": {"source": "prompt-as-data-aggregation", "tagsApplied": total},
+    }
+
+
+def cmd_reviews_raw(args):
+    log_fn = (lambda m: print(m, file=sys.stderr)) if args.verbose else None
+    result = fetch_realtime_reviews_all(args.asin, args.marketplace, args.max_pages, log_fn=log_fn)
+    output({
+        "success": True,
+        "data": result,
+        "_query": {"endpoint": "realtime/reviews",
+                   "params": {"asin": args.asin, "marketplace": args.marketplace,
+                              "maxPages": args.max_pages}},
+    })
+
+
+def _load_json_arg(inline: str, path: str, name: str):
+    """Load JSON from --<name> inline arg or --<name>-file path."""
+    if inline and path:
+        print(f"ERROR: provide either --{name} or --{name}-file, not both", file=sys.stderr)
+        sys.exit(1)
+    if inline:
+        return json.loads(inline)
+    if path:
+        with open(path) as f:
+            return json.load(f)
+    print(f"ERROR: --{name} or --{name}-file is required", file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_review_tag_prompt(args):
+    review = _load_json_arg(args.review, args.review_file, "review")
+    prompt = render_review_map_prompt(
+        review,
+        product_title=args.product_title or "",
+        product_category=args.product_category or "",
+    )
+    print(prompt)
+
+
+def cmd_review_reduce_prompt(args):
+    candidates = _load_json_arg(args.candidates, args.candidates_file, "candidates")
+    if not isinstance(candidates, list):
+        print("ERROR: candidates must be a JSON array of strings", file=sys.stderr)
+        sys.exit(1)
+    prompt = render_review_reduce_prompt(args.label_type, candidates)
+    print(prompt)
+
+
+def cmd_review_aggregate(args):
+    with open(args.reviews) as f:
+        reviews_data = json.load(f)
+    if isinstance(reviews_data, dict):
+        reviews = (reviews_data.get("data") or {}).get("reviews") or reviews_data.get("reviews") or []
+    else:
+        reviews = reviews_data
+
+    with open(args.tagged) as f:
+        tagged = json.load(f)
+    with open(args.clusters) as f:
+        clusters_per_dim = json.load(f)
+
+    result = aggregate_review_insights(reviews, tagged, clusters_per_dim)
+    result["_query"] = {"endpoint": "realtime/reviews+local-aggregate",
+                        "params": {"reviews": args.reviews, "tagged": args.tagged,
+                                    "clusters": args.clusters}}
+    output(result)
 
 
 # ─── Subcommands ─────────────────────────────────────────────────────────────
@@ -2282,6 +2612,38 @@ Examples:
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
     p_rd.add_argument("--category", help="Category path")
     p_rd.set_defaults(func=cmd_review_deepdive)
+
+    # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
+    p_rr = sub.add_parser("reviews-raw", help="Fetch raw reviews from realtime/reviews (cap 100, early-exit on null cursor)", allow_abbrev=False)
+    p_rr.add_argument("--asin", required=True)
+    p_rr.add_argument("--marketplace", default="US", choices=["US", "UK"])
+    p_rr.add_argument("--max-pages", type=int, default=REALTIME_REVIEWS_MAX_PAGES,
+                      help=f"Max pages to fetch (10 reviews each, default {REALTIME_REVIEWS_MAX_PAGES})")
+    p_rr.add_argument("--verbose", action="store_true")
+    p_rr.set_defaults(func=cmd_reviews_raw)
+
+    # ── review-tag-prompt (render Map prompt for one review — caller's LLM runs it) ──
+    p_rtp = sub.add_parser("review-tag-prompt", help="Render the per-review Map prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rtp.add_argument("--review", help="Review object as JSON string")
+    p_rtp.add_argument("--review-file", help="Path to JSON file containing a single review object")
+    p_rtp.add_argument("--product-title", help="Optional product title context")
+    p_rtp.add_argument("--product-category", help="Optional product category context")
+    p_rtp.set_defaults(func=cmd_review_tag_prompt)
+
+    # ── review-reduce-prompt (render Reduce prompt for one dimension — caller's LLM runs it) ──
+    p_rrp = sub.add_parser("review-reduce-prompt", help="Render the per-dimension Reduce prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rrp.add_argument("--label-type", required=True,
+                       help="Dimension to cluster (scenarios, issues, positives, improvements, buyingFactors, painPoints, userProfiles, usageTimes, usageLocations, behaviors, keywords)")
+    p_rrp.add_argument("--candidates", help="Candidate phrases as JSON array string")
+    p_rrp.add_argument("--candidates-file", help="Path to JSON file containing candidate phrases array")
+    p_rrp.set_defaults(func=cmd_review_reduce_prompt)
+
+    # ── review-aggregate (build reviews/analysis-compatible output from tags + clusters) ──
+    p_rag = sub.add_parser("review-aggregate", help="Aggregate per-review tags + per-dim clusters into consumerInsights", allow_abbrev=False)
+    p_rag.add_argument("--reviews", required=True, help="Path to JSON from reviews-raw (or raw reviews array)")
+    p_rag.add_argument("--tagged", required=True, help="Path to JSON array of Map outputs (same order as reviews)")
+    p_rag.add_argument("--clusters", required=True, help="Path to JSON {dim_key: [{canonical, members}]} from Reduce")
+    p_rag.set_defaults(func=cmd_review_aggregate)
 
     # ── analyze (reviews) ──
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Competitor Intelligence Monitor
-version: 1.1.1
+version: 1.1.2
 description: >
   Deep competitor intelligence for Amazon sellers with continuous monitoring.
   Two modes: Full Scan (complete analysis, 28-35 credits) and Quick Check (lightweight monitoring, 5-10 credits).
@@ -43,7 +43,24 @@ Brand queries MUST also include confirmed `--category`.
 2. **All keyword-based endpoints MUST include `--category`**; ASIN-specific endpoints do NOT need it
 3. **Brand + category**: a brand sells across categories — only analyze within locked subcategory
 4. **Use API fields directly**: revenue=`sampleAvgMonthlyRevenue` (NEVER price×sales), sales=`monthlySalesFloor`, concentration=`sampleTop10BrandSalesRate`
-5. **reviews/analysis**: needs 50+ reviews; fallback to ratingBreakdown from realtime/product
+5. **reviews/analysis**: needs 50+ reviews. Fallback chain when sample is insufficient:
+   1. **Lightweight**: `realtime/product` ratingBreakdown — only star distribution, no themes
+   2. **Full 11-dim insights** — bypass `/reviews/analysis` entirely:
+      a. `apiclaw.py reviews-raw --asin X` → fetch up to 100 raw reviews (10 credits, ~60s)
+      b. For each review: render Map prompt via `apiclaw.py review-tag-prompt --review '<json>'`
+         and have your own LLM produce JSON tags (sentiment + 11 dimensions)
+      c. Collect candidate phrases per dimension; for each dimension render
+         Reduce prompt via `apiclaw.py review-reduce-prompt --label-type X --candidates '[...]'`
+         and have your LLM produce semantic clusters
+      d. `apiclaw.py review-aggregate --reviews R --tagged T --clusters C`
+         → consumerInsights output compatible with `/reviews/analysis`
+   3. **Fallback caveats** (apply to the 4-step chain above — lessons from end-to-end validation):
+      - **Working dir**: `WORK=/tmp/review_<ASIN>_$(date +%s) && mkdir -p $WORK`
+      - **Step b CLI behavior**: `review-tag-prompt` RENDERS the prompt only; YOUR LLM produces the JSON. Render once to learn the schema, then produce tags for all N reviews in one in-context pass (don't call the CLI N times).
+      - **Step c candidate extraction** (Python one-liner):
+        `candidates = {d: sorted({el.strip().lower() for t in tagged for el in (t.get(d) or [])}) for d in DIMS}`
+      - **Small-sample rule (reviewCount<50)**: demote single-mention items 📊→🔍; NEVER attach table-level or section-header 📊 when any row inside is 🔍; suppress "🔴 Critical" verdicts on count=1
+      - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (competitor metrics, brand ranking, pricing, etc.) remain valid — do not re-run them.
 
 ## Mode Selection
 
@@ -119,6 +136,22 @@ Output language MUST match the user's input language. If the user asks in Chines
 - 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
 
 Rules: Strategy recommendations are NEVER 📊. Anomalies (>200% growth) are always 💡. User criteria override AI judgment.
+
+**Aggregate-label rule (applies to ALL report output, not just fallback)**: NEVER attach 📊 to ANY element that aggregates or groups underlying content when ANY piece of that content is 🔍 or 💡. "Aggregate/grouping elements" include:
+- Section headers at EVERY level (`#`, `##`, `###`, `####`) — including top-level summary sections like "Overall Score", "Verdict", "Executive Summary"
+- Summary/score lines anywhere in the report (e.g. `## Overall Score — 27/100 · Grade F 📊` is WRONG if any Basis row inside is 🔍)
+- Table **column** headers in comparison tables (e.g. `**Target ASIN** 📊` as a column label is WRONG if any cell in that column contains 🔍)
+- Table row headers or row-aggregation labels (when the row aggregates multiple cells of mixed confidence)
+- Any other visual grouping label — bullet-list group titles, callout box titles, etc.
+
+A group-level 📊 implies the whole block/column/row is data-backed, which smuggles inferred/directional content into the 📊 tier via visual grouping. Either (a) **omit the group-level label entirely** (preferred when content mixes tiers), or (b) use the LOWEST confidence present inside (🔍 if any underlying content is 🔍; 💡 if any is 💡). This is a universal output-quality rule — it applies regardless of which fallback path (if any) was triggered.
+
+**Emoji reservation rule (closely related)**: The three confidence symbols `📊 🔍 💡` are RESERVED for confidence labeling. NEVER use them as decorative prefixes on section headers, table headers, or any aggregate element — even when you also include a correct confidence suffix on the same line. Example:
+- ❌ WRONG: `## 📊 Overall Score — 27/100 · Grade F 🔍` (the leading 📊 reads as a data-backed claim even though the trailing 🔍 is correct)
+- ✅ RIGHT: `## Overall Score — 27/100 · Grade F 🔍` (no decorative emoji, just the proper confidence suffix)
+- ✅ RIGHT: `## 🎯 Overall Score — 27/100 · Grade F 🔍` (use non-reserved decorative icons like 🎯 🧭 📋 📝 📂 🏁 🚨 🏆 🔔 when a visual prefix is desired)
+
+Decorative emoji ≠ confidence label — but from a reader's perspective, a leading `📊/🔍/💡` is indistinguishable from a confidence claim. Reserve these three symbols EXCLUSIVELY for confidence annotation to avoid ambiguity.
 
 ### Data Provenance (required)
 

--- a/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
+++ b/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
@@ -1,29 +1,8 @@
 #!/usr/bin/env python3
 # ============================================================
-# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
-# Source of truth: apiclaw/scripts/apiclaw.py
-#
-# Sync is enforced at THREE layers — understand all three before editing:
-#
-#   1. Local pre-commit hook (scripts/pre-commit)
-#      When this file is staged, auto-runs sync-scripts.sh and stages the
-#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
-#
-#   2. Sync script (scripts/sync-scripts.sh)
-#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
-#      any copy that differs without an "AUTO-SYNCED" marker (safety against
-#      destroying manual edits). If you hit a CONFLICT, inspect the diff
-#      first, then either (a) merge the manual edit back into canonical, or
-#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
-#
-#   3. CI check (.github/workflows/shared-files-distribution.yml)
-#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
-#      `diff` against canonical. Mismatched copies fail the PR hard with an
-#      "::error::" annotation — no merge until all 9 copies are identical.
-#
-# If you inherit a repo where copies drift without markers, resolve once by:
-#   bash scripts/sync-scripts.sh   # lists CONFLICTs
-#   # then add the AUTO-SYNCED marker to each copy and re-run
+# Canonical source - do not edit copies under amazon-* skill directories directly
+# Source location: apiclaw/scripts/apiclaw.py
+# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API

--- a/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
+++ b/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python3
 # ============================================================
-# Canonical source - do not edit copies under amazon-* skill directories directly
-# Source location: apiclaw/scripts/apiclaw.py
-# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
+# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
+# Source of truth: apiclaw/scripts/apiclaw.py
+#
+# Sync is enforced at THREE layers — understand all three before editing:
+#
+#   1. Local pre-commit hook (scripts/pre-commit)
+#      When this file is staged, auto-runs sync-scripts.sh and stages the
+#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
+#
+#   2. Sync script (scripts/sync-scripts.sh)
+#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
+#      any copy that differs without an "AUTO-SYNCED" marker (safety against
+#      destroying manual edits). If you hit a CONFLICT, inspect the diff
+#      first, then either (a) merge the manual edit back into canonical, or
+#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
+#
+#   3. CI check (.github/workflows/shared-files-distribution.yml)
+#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
+#      `diff` against canonical. Mismatched copies fail the PR hard with an
+#      "::error::" annotation — no merge until all 9 copies are identical.
+#
+# If you inherit a repo where copies drift without markers, resolve once by:
+#   bash scripts/sync-scripts.sh   # lists CONFLICTs
+#   # then add the AUTO-SYNCED marker to each copy and re-run
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
@@ -376,6 +397,315 @@ def parse_category(cat_str: str) -> list:
     if ">" in cat_str:
         return [c.strip() for c in cat_str.split(">")]
     return [c.strip() for c in cat_str.split(",")]
+
+
+# ─── Review Analysis: Prompt-as-Data Toolkit ───────────────────────────────
+# Used when /reviews/analysis lacks aggregation (ASIN has <50 reviews or no
+# daily snapshot). This module does NOT call any external LLM — it provides
+# raw data, rendered prompts, and a final aggregator. The calling skill's own
+# LLM performs the Map (per-review tagging) and Reduce (semantic clustering)
+# steps, producing JSON that feeds back into `review-aggregate`.
+#
+# Caller flow:
+#   1. apiclaw.py reviews-raw --asin X          → fetch raw reviews
+#   2. For each review, render via:
+#        apiclaw.py review-tag-prompt --review '<json>'
+#      The caller's LLM produces JSON matching REVIEW_MAP_SCHEMA.
+#   3. Collect per-dimension candidate phrases; for each dimension render:
+#        apiclaw.py review-reduce-prompt --label-type <dim> --candidates '[...]'
+#      The caller's LLM produces JSON matching REVIEW_REDUCE_SCHEMA.
+#   4. apiclaw.py review-aggregate --reviews R --tagged T --clusters C
+#      → emits consumerInsights compatible with /reviews/analysis.
+
+REVIEW_MAP_CONCURRENCY = 20           # suggested map parallelism for caller
+REVIEW_REDUCE_KEYWORDS_CHUNK = 150    # suggested chunk size when keywords dim is large
+REALTIME_REVIEWS_MAX_PAGES = 10       # API hard cap = 100 reviews (10 pages × 10)
+
+DIM_TO_LABELTYPE = {
+    "mentioned_scenarios": "scenarios",
+    "mentioned_issues": "issues",
+    "mentioned_positives": "positives",
+    "mentioned_improvements": "improvements",
+    "mentioned_buying_factors": "buyingFactors",
+    "mentioned_pain_points": "painPoints",
+    "user_profiles": "userProfiles",
+    "mentioned_usage_times": "usageTimes",
+    "mentioned_usage_locations": "usageLocations",
+    "mentioned_behaviors": "behaviors",
+    "keywords": "keywords",
+}
+
+_MAP_ARRAY_FIELDS = list(DIM_TO_LABELTYPE.keys())
+
+REVIEW_MAP_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "sentiment": {"type": "STRING", "enum": ["positive", "neutral", "negative"]},
+        **{k: {"type": "ARRAY", "items": {"type": "STRING"}} for k in _MAP_ARRAY_FIELDS},
+    },
+    "required": ["sentiment"] + _MAP_ARRAY_FIELDS,
+}
+
+REVIEW_REDUCE_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "clusters": {
+            "type": "ARRAY",
+            "items": {
+                "type": "OBJECT",
+                "properties": {
+                    "canonical": {"type": "STRING"},
+                    "members": {"type": "ARRAY", "items": {"type": "STRING"}},
+                },
+                "required": ["canonical", "members"],
+            },
+        },
+    },
+    "required": ["clusters"],
+}
+
+
+def render_review_map_prompt(review: dict, product_title: str = "", product_category: str = "") -> str:
+    title = review.get("title") or ""
+    body = review.get("body") or ""
+    full = f"{title}. {body}" if title else body
+    text = full[:500]
+    rating = review.get("rating") or 3
+    verified = bool(review.get("verifiedPurchase"))
+    return f"""IMPORTANT: Respond ONLY with a JSON object matching the schema below. Output must be in English — translate non-English text before extracting.
+
+You are an expert data extraction specialist analyzing product reviews. Extract only what is EXPLICITLY mentioned — do not infer.
+
+JSON schema:
+{{
+  "sentiment": "positive" | "neutral" | "negative",
+  "mentioned_scenarios": [string],      // max 5 noun phrases 1-3 words (Workouts, Gaming)
+  "mentioned_issues": [string],         // max 5 Adjective+Noun for PRODUCT DEFECTS (Poor Sound Quality)
+  "mentioned_positives": [string],      // max 5 Adjective+Noun for praised aspects (Comfortable Fit)
+  "mentioned_improvements": [string],   // max 3 Verb+Noun explicit suggestions (Extend Battery Life)
+  "mentioned_buying_factors": [string], // max 3 noun phrases for purchase reasons (Price Point)
+  "mentioned_pain_points": [string],    // max 3 UX frustrations EXPERIENCED AFTER USE (see rule)
+  "user_profiles": [string],            // max 3 identities stated EXPLICITLY (see rule)
+  "mentioned_usage_times": [string],    // max 3 time/season phrases (Morning, Winter)
+  "mentioned_usage_locations": [string],// max 3 location phrases (Gym, Home)
+  "mentioned_behaviors": [string],      // max 5 Verb+Object (Taking Calls, Running)
+  "keywords": [string]                  // 3-15 salient words from the review
+}}
+
+Rules:
+- sentiment: positive (4-5 stars or praise), neutral (3 stars / mixed), negative (1-2 stars or complaint)
+- pain_points = problems EXPERIENCED AFTER USE. NOT problems the product solves. If the reviewer says the product solved a prior problem (e.g. "cured my foot pain"), that belongs in positives, NOT pain_points.
+- issues vs pain_points: issues = product defects (hardware/software fault); pain_points = UX frustrations
+- user_profiles: include ONLY if the reviewer explicitly states an identity ("I'm a...", "As a..."). NEVER infer.
+- consistent naming across reviews (e.g. always "Workouts", not "At the gym")
+- use empty arrays [] for categories with no mentions, never null
+
+INPUT:
+Product Category: {product_category or '(unknown)'}
+Product Title: {product_title or '(unknown)'}
+Review Rating: {rating}/5 stars
+Verified Purchase: {'Yes' if verified else 'No'}
+Review Text:
+\"\"\"{text}\"\"\"
+
+Return ONLY the JSON object."""
+
+
+def render_review_reduce_prompt(label_type: str, candidates: list) -> str:
+    return f"""Normalize product-review tags. Group semantically equivalent phrases into clusters and pick a concise Title-Case canonical name (1-3 words) for each cluster.
+
+Label type: {label_type}
+
+Rules:
+- A cluster contains phrases describing the SAME underlying concept.
+- Every input phrase MUST appear in exactly one cluster's `members`. No drops, no duplicates across clusters.
+- Phrases with no semantic neighbors go in their own single-member cluster (still Title-Case canonical).
+- Case-insensitive matching. Preserve input phrase strings verbatim in `members`.
+
+Return a JSON object matching:
+{{"clusters": [{{"canonical": "Title Case", "members": ["phrase1", "phrase2"]}}]}}
+
+Input phrases:
+{json.dumps(candidates, ensure_ascii=False)}"""
+
+
+def fetch_realtime_reviews_all(asin: str, marketplace: str = "US",
+                                max_pages: int = REALTIME_REVIEWS_MAX_PAGES,
+                                log_fn=None) -> dict:
+    """Paginate /realtime/reviews with cursor; stop on null cursor or max_pages."""
+    log = log_fn or (lambda m: None)
+    reviews = []
+    cursor = None
+    pages = 0
+    t0 = time.time()
+    for i in range(1, max_pages + 1):
+        params = {"asin": asin, "marketplace": marketplace}
+        if cursor:
+            params["cursor"] = cursor
+        resp = api_call("realtime/reviews", params)
+        if not resp.get("success"):
+            break
+        data = resp.get("data") or {}
+        page_reviews = data.get("reviews") or []
+        cursor = data.get("nextCursor")
+        pages += 1
+        reviews.extend(page_reviews)
+        log(f"  page {i}: {len(page_reviews)} reviews, cursor={'yes' if cursor else 'end'}")
+        if not cursor:
+            break
+    return {
+        "reviews": reviews,
+        "pages": pages,
+        "capped": pages >= max_pages and cursor is not None,
+        "fetchSeconds": round(time.time() - t0, 2),
+    }
+
+
+def aggregate_review_insights(reviews: list, tagged: list, clusters_per_dim: dict) -> dict:
+    """Combine raw reviews + per-review Map tags + per-dimension Reduce clusters
+    into a reviews/analysis-compatible aggregation. No LLM calls."""
+    from collections import defaultdict
+
+    if len(tagged) != len(reviews):
+        raise ValueError(f"tagged length ({len(tagged)}) != reviews length ({len(reviews)})")
+
+    total = len(reviews)
+    ratings = [r.get("rating") or 0 for r in reviews]
+
+    dim_phrase_reviews = {k: defaultdict(set) for k in DIM_TO_LABELTYPE}
+    for i, tags in enumerate(tagged):
+        if not isinstance(tags, dict):
+            continue
+        for dim in DIM_TO_LABELTYPE:
+            for el in (tags.get(dim) or []):
+                if not isinstance(el, str):
+                    continue
+                kl = el.strip().lower()
+                if kl:
+                    dim_phrase_reviews[dim][kl].add(i)
+
+    insights = []
+    for dim, phrases in dim_phrase_reviews.items():
+        if not phrases:
+            continue
+        p2c = {}
+        for cl in (clusters_per_dim.get(dim) or []):
+            canon = (cl.get("canonical") or "").strip()
+            if not canon:
+                continue
+            for m in (cl.get("members") or []):
+                if not isinstance(m, str):
+                    continue
+                ml = m.strip().lower()
+                if ml and ml not in p2c:
+                    p2c[ml] = canon
+        for ph in phrases:
+            p2c.setdefault(ph, ph.title())
+
+        canon_to_reviews = defaultdict(set)
+        for phrase, rs in phrases.items():
+            canon_to_reviews[p2c[phrase]].update(rs)
+
+        lt = DIM_TO_LABELTYPE[dim]
+        for canon, rs in canon_to_reviews.items():
+            c = len(rs)
+            avg = sum(ratings[i] for i in rs) / c if c else 0.0
+            insights.append({
+                "element": canon,
+                "labelType": lt,
+                "count": c,
+                "reviewRate": round(c / total, 4),
+                "avgRating": round(avg, 2),
+            })
+    insights.sort(key=lambda x: (x["labelType"], -x["count"]))
+
+    sentiments = [(t or {}).get("sentiment") for t in tagged]
+    sentiment_dist = {
+        "positive": round(sum(1 for s in sentiments if s == "positive") / total, 4) if total else 0,
+        "neutral": round(sum(1 for s in sentiments if s == "neutral") / total, 4) if total else 0,
+        "negative": round(sum(1 for s in sentiments if s == "negative") / total, 4) if total else 0,
+    }
+    avg_rating = round(sum(ratings) / total, 2) if total else 0.0
+
+    return {
+        "success": True,
+        "data": {
+            "reviewCount": total,
+            "avgRating": avg_rating,
+            "sentimentDistribution": sentiment_dist,
+            "consumerInsights": insights,
+            "topKeywords": [
+                {"element": it["element"], "count": it["count"]}
+                for it in insights if it["labelType"] == "keywords"
+            ][:20],
+        },
+        "_meta": {"source": "prompt-as-data-aggregation", "tagsApplied": total},
+    }
+
+
+def cmd_reviews_raw(args):
+    log_fn = (lambda m: print(m, file=sys.stderr)) if args.verbose else None
+    result = fetch_realtime_reviews_all(args.asin, args.marketplace, args.max_pages, log_fn=log_fn)
+    output({
+        "success": True,
+        "data": result,
+        "_query": {"endpoint": "realtime/reviews",
+                   "params": {"asin": args.asin, "marketplace": args.marketplace,
+                              "maxPages": args.max_pages}},
+    })
+
+
+def _load_json_arg(inline: str, path: str, name: str):
+    """Load JSON from --<name> inline arg or --<name>-file path."""
+    if inline and path:
+        print(f"ERROR: provide either --{name} or --{name}-file, not both", file=sys.stderr)
+        sys.exit(1)
+    if inline:
+        return json.loads(inline)
+    if path:
+        with open(path) as f:
+            return json.load(f)
+    print(f"ERROR: --{name} or --{name}-file is required", file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_review_tag_prompt(args):
+    review = _load_json_arg(args.review, args.review_file, "review")
+    prompt = render_review_map_prompt(
+        review,
+        product_title=args.product_title or "",
+        product_category=args.product_category or "",
+    )
+    print(prompt)
+
+
+def cmd_review_reduce_prompt(args):
+    candidates = _load_json_arg(args.candidates, args.candidates_file, "candidates")
+    if not isinstance(candidates, list):
+        print("ERROR: candidates must be a JSON array of strings", file=sys.stderr)
+        sys.exit(1)
+    prompt = render_review_reduce_prompt(args.label_type, candidates)
+    print(prompt)
+
+
+def cmd_review_aggregate(args):
+    with open(args.reviews) as f:
+        reviews_data = json.load(f)
+    if isinstance(reviews_data, dict):
+        reviews = (reviews_data.get("data") or {}).get("reviews") or reviews_data.get("reviews") or []
+    else:
+        reviews = reviews_data
+
+    with open(args.tagged) as f:
+        tagged = json.load(f)
+    with open(args.clusters) as f:
+        clusters_per_dim = json.load(f)
+
+    result = aggregate_review_insights(reviews, tagged, clusters_per_dim)
+    result["_query"] = {"endpoint": "realtime/reviews+local-aggregate",
+                        "params": {"reviews": args.reviews, "tagged": args.tagged,
+                                    "clusters": args.clusters}}
+    output(result)
 
 
 # ─── Subcommands ─────────────────────────────────────────────────────────────
@@ -2282,6 +2612,38 @@ Examples:
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
     p_rd.add_argument("--category", help="Category path")
     p_rd.set_defaults(func=cmd_review_deepdive)
+
+    # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
+    p_rr = sub.add_parser("reviews-raw", help="Fetch raw reviews from realtime/reviews (cap 100, early-exit on null cursor)", allow_abbrev=False)
+    p_rr.add_argument("--asin", required=True)
+    p_rr.add_argument("--marketplace", default="US", choices=["US", "UK"])
+    p_rr.add_argument("--max-pages", type=int, default=REALTIME_REVIEWS_MAX_PAGES,
+                      help=f"Max pages to fetch (10 reviews each, default {REALTIME_REVIEWS_MAX_PAGES})")
+    p_rr.add_argument("--verbose", action="store_true")
+    p_rr.set_defaults(func=cmd_reviews_raw)
+
+    # ── review-tag-prompt (render Map prompt for one review — caller's LLM runs it) ──
+    p_rtp = sub.add_parser("review-tag-prompt", help="Render the per-review Map prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rtp.add_argument("--review", help="Review object as JSON string")
+    p_rtp.add_argument("--review-file", help="Path to JSON file containing a single review object")
+    p_rtp.add_argument("--product-title", help="Optional product title context")
+    p_rtp.add_argument("--product-category", help="Optional product category context")
+    p_rtp.set_defaults(func=cmd_review_tag_prompt)
+
+    # ── review-reduce-prompt (render Reduce prompt for one dimension — caller's LLM runs it) ──
+    p_rrp = sub.add_parser("review-reduce-prompt", help="Render the per-dimension Reduce prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rrp.add_argument("--label-type", required=True,
+                       help="Dimension to cluster (scenarios, issues, positives, improvements, buyingFactors, painPoints, userProfiles, usageTimes, usageLocations, behaviors, keywords)")
+    p_rrp.add_argument("--candidates", help="Candidate phrases as JSON array string")
+    p_rrp.add_argument("--candidates-file", help="Path to JSON file containing candidate phrases array")
+    p_rrp.set_defaults(func=cmd_review_reduce_prompt)
+
+    # ── review-aggregate (build reviews/analysis-compatible output from tags + clusters) ──
+    p_rag = sub.add_parser("review-aggregate", help="Aggregate per-review tags + per-dim clusters into consumerInsights", allow_abbrev=False)
+    p_rag.add_argument("--reviews", required=True, help="Path to JSON from reviews-raw (or raw reviews array)")
+    p_rag.add_argument("--tagged", required=True, help="Path to JSON array of Map outputs (same order as reviews)")
+    p_rag.add_argument("--clusters", required=True, help="Path to JSON {dim_key: [{canonical, members}]} from Reduce")
+    p_rag.set_defaults(func=cmd_review_aggregate)
 
     # ── analyze (reviews) ──
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Daily Market Radar — Automated Monitoring & Alerts
-version: 1.0.1
+version: 1.0.2
 description: >
   Automated daily market monitoring and alert system for Amazon sellers.
   Tracks price changes, new competitors, BSR movements, review spikes,
@@ -41,7 +41,24 @@ Collect in ONE message: ✅ my_asins (1-10) | 💡 competitor_asins (up to 20) |
 1. **Category auto-detection**: categoryPath is auto-detected from tracked ASINs. If `category_source` in output is `inferred_from_search`, confirm with user
 2. **All keyword-based endpoints MUST include `--category`**; ASIN-specific endpoints do NOT
 3. **Use API fields directly**: revenue=`sampleAvgMonthlyRevenue` (NEVER price×sales), sales=`monthlySalesFloor`, concentration=`sampleTop10BrandSalesRate`
-4. **reviews/analysis**: needs 50+ reviews
+4. **reviews/analysis**: needs 50+ reviews. Fallback chain when sample is insufficient:
+   1. **Lightweight**: `realtime/product` ratingBreakdown — only star distribution, no themes
+   2. **Full 11-dim insights** — bypass `/reviews/analysis` entirely:
+      a. `apiclaw.py reviews-raw --asin X` → fetch up to 100 raw reviews (10 credits, ~60s)
+      b. For each review: render Map prompt via `apiclaw.py review-tag-prompt --review '<json>'`
+         and have your own LLM produce JSON tags (sentiment + 11 dimensions)
+      c. Collect candidate phrases per dimension; for each dimension render
+         Reduce prompt via `apiclaw.py review-reduce-prompt --label-type X --candidates '[...]'`
+         and have your LLM produce semantic clusters
+      d. `apiclaw.py review-aggregate --reviews R --tagged T --clusters C`
+         → consumerInsights output compatible with `/reviews/analysis`
+   3. **Fallback caveats** (apply to the 4-step chain above — lessons from end-to-end validation):
+      - **Working dir**: `WORK=/tmp/review_<ASIN>_$(date +%s) && mkdir -p $WORK`
+      - **Step b CLI behavior**: `review-tag-prompt` RENDERS the prompt only; YOUR LLM produces the JSON. Render once to learn the schema, then produce tags for all N reviews in one in-context pass (don't call the CLI N times).
+      - **Step c candidate extraction** (Python one-liner):
+        `candidates = {d: sorted({el.strip().lower() for t in tagged for el in (t.get(d) or [])}) for d in DIMS}`
+      - **Small-sample rule (reviewCount<50)**: demote single-mention items 📊→🔍; NEVER attach table-level or section-header 📊 when any row inside is 🔍; suppress "🔴 Critical" verdicts on count=1
+      - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (price/BSR/sales deltas, alerts, watchlist baseline) remain valid — do not re-run them.
 5. **Aggregation without categoryPath**: severely distorted data
 
 ## Execution
@@ -104,6 +121,22 @@ Output language MUST match the user's input language. If the user asks in Chines
 - 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
 
 Rules: Strategy recommendations are NEVER 📊. Anomalies (>200% growth) are always 💡. User criteria override AI judgment.
+
+**Aggregate-label rule (applies to ALL report output, not just fallback)**: NEVER attach 📊 to ANY element that aggregates or groups underlying content when ANY piece of that content is 🔍 or 💡. "Aggregate/grouping elements" include:
+- Section headers at EVERY level (`#`, `##`, `###`, `####`) — including top-level summary sections like "Overall Score", "Verdict", "Executive Summary"
+- Summary/score lines anywhere in the report (e.g. `## Overall Score — 27/100 · Grade F 📊` is WRONG if any Basis row inside is 🔍)
+- Table **column** headers in comparison tables (e.g. `**Target ASIN** 📊` as a column label is WRONG if any cell in that column contains 🔍)
+- Table row headers or row-aggregation labels (when the row aggregates multiple cells of mixed confidence)
+- Any other visual grouping label — bullet-list group titles, callout box titles, etc.
+
+A group-level 📊 implies the whole block/column/row is data-backed, which smuggles inferred/directional content into the 📊 tier via visual grouping. Either (a) **omit the group-level label entirely** (preferred when content mixes tiers), or (b) use the LOWEST confidence present inside (🔍 if any underlying content is 🔍; 💡 if any is 💡). This is a universal output-quality rule — it applies regardless of which fallback path (if any) was triggered.
+
+**Emoji reservation rule (closely related)**: The three confidence symbols `📊 🔍 💡` are RESERVED for confidence labeling. NEVER use them as decorative prefixes on section headers, table headers, or any aggregate element — even when you also include a correct confidence suffix on the same line. Example:
+- ❌ WRONG: `## 📊 Overall Score — 27/100 · Grade F 🔍` (the leading 📊 reads as a data-backed claim even though the trailing 🔍 is correct)
+- ✅ RIGHT: `## Overall Score — 27/100 · Grade F 🔍` (no decorative emoji, just the proper confidence suffix)
+- ✅ RIGHT: `## 🎯 Overall Score — 27/100 · Grade F 🔍` (use non-reserved decorative icons like 🎯 🧭 📋 📝 📂 🏁 🚨 🏆 🔔 when a visual prefix is desired)
+
+Decorative emoji ≠ confidence label — but from a reader's perspective, a leading `📊/🔍/💡` is indistinguishable from a confidence claim. Reserve these three symbols EXCLUSIVELY for confidence annotation to avoid ambiguity.
 
 Sample bias: "Based on Top [N] by sales volume; niche/new products may be underrepresented."
 

--- a/amazon-daily-market-radar/scripts/apiclaw.py
+++ b/amazon-daily-market-radar/scripts/apiclaw.py
@@ -1,29 +1,8 @@
 #!/usr/bin/env python3
 # ============================================================
-# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
-# Source of truth: apiclaw/scripts/apiclaw.py
-#
-# Sync is enforced at THREE layers — understand all three before editing:
-#
-#   1. Local pre-commit hook (scripts/pre-commit)
-#      When this file is staged, auto-runs sync-scripts.sh and stages the
-#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
-#
-#   2. Sync script (scripts/sync-scripts.sh)
-#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
-#      any copy that differs without an "AUTO-SYNCED" marker (safety against
-#      destroying manual edits). If you hit a CONFLICT, inspect the diff
-#      first, then either (a) merge the manual edit back into canonical, or
-#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
-#
-#   3. CI check (.github/workflows/shared-files-distribution.yml)
-#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
-#      `diff` against canonical. Mismatched copies fail the PR hard with an
-#      "::error::" annotation — no merge until all 9 copies are identical.
-#
-# If you inherit a repo where copies drift without markers, resolve once by:
-#   bash scripts/sync-scripts.sh   # lists CONFLICTs
-#   # then add the AUTO-SYNCED marker to each copy and re-run
+# Canonical source - do not edit copies under amazon-* skill directories directly
+# Source location: apiclaw/scripts/apiclaw.py
+# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API

--- a/amazon-daily-market-radar/scripts/apiclaw.py
+++ b/amazon-daily-market-radar/scripts/apiclaw.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python3
 # ============================================================
-# Canonical source - do not edit copies under amazon-* skill directories directly
-# Source location: apiclaw/scripts/apiclaw.py
-# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
+# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
+# Source of truth: apiclaw/scripts/apiclaw.py
+#
+# Sync is enforced at THREE layers — understand all three before editing:
+#
+#   1. Local pre-commit hook (scripts/pre-commit)
+#      When this file is staged, auto-runs sync-scripts.sh and stages the
+#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
+#
+#   2. Sync script (scripts/sync-scripts.sh)
+#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
+#      any copy that differs without an "AUTO-SYNCED" marker (safety against
+#      destroying manual edits). If you hit a CONFLICT, inspect the diff
+#      first, then either (a) merge the manual edit back into canonical, or
+#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
+#
+#   3. CI check (.github/workflows/shared-files-distribution.yml)
+#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
+#      `diff` against canonical. Mismatched copies fail the PR hard with an
+#      "::error::" annotation — no merge until all 9 copies are identical.
+#
+# If you inherit a repo where copies drift without markers, resolve once by:
+#   bash scripts/sync-scripts.sh   # lists CONFLICTs
+#   # then add the AUTO-SYNCED marker to each copy and re-run
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
@@ -376,6 +397,315 @@ def parse_category(cat_str: str) -> list:
     if ">" in cat_str:
         return [c.strip() for c in cat_str.split(">")]
     return [c.strip() for c in cat_str.split(",")]
+
+
+# ─── Review Analysis: Prompt-as-Data Toolkit ───────────────────────────────
+# Used when /reviews/analysis lacks aggregation (ASIN has <50 reviews or no
+# daily snapshot). This module does NOT call any external LLM — it provides
+# raw data, rendered prompts, and a final aggregator. The calling skill's own
+# LLM performs the Map (per-review tagging) and Reduce (semantic clustering)
+# steps, producing JSON that feeds back into `review-aggregate`.
+#
+# Caller flow:
+#   1. apiclaw.py reviews-raw --asin X          → fetch raw reviews
+#   2. For each review, render via:
+#        apiclaw.py review-tag-prompt --review '<json>'
+#      The caller's LLM produces JSON matching REVIEW_MAP_SCHEMA.
+#   3. Collect per-dimension candidate phrases; for each dimension render:
+#        apiclaw.py review-reduce-prompt --label-type <dim> --candidates '[...]'
+#      The caller's LLM produces JSON matching REVIEW_REDUCE_SCHEMA.
+#   4. apiclaw.py review-aggregate --reviews R --tagged T --clusters C
+#      → emits consumerInsights compatible with /reviews/analysis.
+
+REVIEW_MAP_CONCURRENCY = 20           # suggested map parallelism for caller
+REVIEW_REDUCE_KEYWORDS_CHUNK = 150    # suggested chunk size when keywords dim is large
+REALTIME_REVIEWS_MAX_PAGES = 10       # API hard cap = 100 reviews (10 pages × 10)
+
+DIM_TO_LABELTYPE = {
+    "mentioned_scenarios": "scenarios",
+    "mentioned_issues": "issues",
+    "mentioned_positives": "positives",
+    "mentioned_improvements": "improvements",
+    "mentioned_buying_factors": "buyingFactors",
+    "mentioned_pain_points": "painPoints",
+    "user_profiles": "userProfiles",
+    "mentioned_usage_times": "usageTimes",
+    "mentioned_usage_locations": "usageLocations",
+    "mentioned_behaviors": "behaviors",
+    "keywords": "keywords",
+}
+
+_MAP_ARRAY_FIELDS = list(DIM_TO_LABELTYPE.keys())
+
+REVIEW_MAP_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "sentiment": {"type": "STRING", "enum": ["positive", "neutral", "negative"]},
+        **{k: {"type": "ARRAY", "items": {"type": "STRING"}} for k in _MAP_ARRAY_FIELDS},
+    },
+    "required": ["sentiment"] + _MAP_ARRAY_FIELDS,
+}
+
+REVIEW_REDUCE_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "clusters": {
+            "type": "ARRAY",
+            "items": {
+                "type": "OBJECT",
+                "properties": {
+                    "canonical": {"type": "STRING"},
+                    "members": {"type": "ARRAY", "items": {"type": "STRING"}},
+                },
+                "required": ["canonical", "members"],
+            },
+        },
+    },
+    "required": ["clusters"],
+}
+
+
+def render_review_map_prompt(review: dict, product_title: str = "", product_category: str = "") -> str:
+    title = review.get("title") or ""
+    body = review.get("body") or ""
+    full = f"{title}. {body}" if title else body
+    text = full[:500]
+    rating = review.get("rating") or 3
+    verified = bool(review.get("verifiedPurchase"))
+    return f"""IMPORTANT: Respond ONLY with a JSON object matching the schema below. Output must be in English — translate non-English text before extracting.
+
+You are an expert data extraction specialist analyzing product reviews. Extract only what is EXPLICITLY mentioned — do not infer.
+
+JSON schema:
+{{
+  "sentiment": "positive" | "neutral" | "negative",
+  "mentioned_scenarios": [string],      // max 5 noun phrases 1-3 words (Workouts, Gaming)
+  "mentioned_issues": [string],         // max 5 Adjective+Noun for PRODUCT DEFECTS (Poor Sound Quality)
+  "mentioned_positives": [string],      // max 5 Adjective+Noun for praised aspects (Comfortable Fit)
+  "mentioned_improvements": [string],   // max 3 Verb+Noun explicit suggestions (Extend Battery Life)
+  "mentioned_buying_factors": [string], // max 3 noun phrases for purchase reasons (Price Point)
+  "mentioned_pain_points": [string],    // max 3 UX frustrations EXPERIENCED AFTER USE (see rule)
+  "user_profiles": [string],            // max 3 identities stated EXPLICITLY (see rule)
+  "mentioned_usage_times": [string],    // max 3 time/season phrases (Morning, Winter)
+  "mentioned_usage_locations": [string],// max 3 location phrases (Gym, Home)
+  "mentioned_behaviors": [string],      // max 5 Verb+Object (Taking Calls, Running)
+  "keywords": [string]                  // 3-15 salient words from the review
+}}
+
+Rules:
+- sentiment: positive (4-5 stars or praise), neutral (3 stars / mixed), negative (1-2 stars or complaint)
+- pain_points = problems EXPERIENCED AFTER USE. NOT problems the product solves. If the reviewer says the product solved a prior problem (e.g. "cured my foot pain"), that belongs in positives, NOT pain_points.
+- issues vs pain_points: issues = product defects (hardware/software fault); pain_points = UX frustrations
+- user_profiles: include ONLY if the reviewer explicitly states an identity ("I'm a...", "As a..."). NEVER infer.
+- consistent naming across reviews (e.g. always "Workouts", not "At the gym")
+- use empty arrays [] for categories with no mentions, never null
+
+INPUT:
+Product Category: {product_category or '(unknown)'}
+Product Title: {product_title or '(unknown)'}
+Review Rating: {rating}/5 stars
+Verified Purchase: {'Yes' if verified else 'No'}
+Review Text:
+\"\"\"{text}\"\"\"
+
+Return ONLY the JSON object."""
+
+
+def render_review_reduce_prompt(label_type: str, candidates: list) -> str:
+    return f"""Normalize product-review tags. Group semantically equivalent phrases into clusters and pick a concise Title-Case canonical name (1-3 words) for each cluster.
+
+Label type: {label_type}
+
+Rules:
+- A cluster contains phrases describing the SAME underlying concept.
+- Every input phrase MUST appear in exactly one cluster's `members`. No drops, no duplicates across clusters.
+- Phrases with no semantic neighbors go in their own single-member cluster (still Title-Case canonical).
+- Case-insensitive matching. Preserve input phrase strings verbatim in `members`.
+
+Return a JSON object matching:
+{{"clusters": [{{"canonical": "Title Case", "members": ["phrase1", "phrase2"]}}]}}
+
+Input phrases:
+{json.dumps(candidates, ensure_ascii=False)}"""
+
+
+def fetch_realtime_reviews_all(asin: str, marketplace: str = "US",
+                                max_pages: int = REALTIME_REVIEWS_MAX_PAGES,
+                                log_fn=None) -> dict:
+    """Paginate /realtime/reviews with cursor; stop on null cursor or max_pages."""
+    log = log_fn or (lambda m: None)
+    reviews = []
+    cursor = None
+    pages = 0
+    t0 = time.time()
+    for i in range(1, max_pages + 1):
+        params = {"asin": asin, "marketplace": marketplace}
+        if cursor:
+            params["cursor"] = cursor
+        resp = api_call("realtime/reviews", params)
+        if not resp.get("success"):
+            break
+        data = resp.get("data") or {}
+        page_reviews = data.get("reviews") or []
+        cursor = data.get("nextCursor")
+        pages += 1
+        reviews.extend(page_reviews)
+        log(f"  page {i}: {len(page_reviews)} reviews, cursor={'yes' if cursor else 'end'}")
+        if not cursor:
+            break
+    return {
+        "reviews": reviews,
+        "pages": pages,
+        "capped": pages >= max_pages and cursor is not None,
+        "fetchSeconds": round(time.time() - t0, 2),
+    }
+
+
+def aggregate_review_insights(reviews: list, tagged: list, clusters_per_dim: dict) -> dict:
+    """Combine raw reviews + per-review Map tags + per-dimension Reduce clusters
+    into a reviews/analysis-compatible aggregation. No LLM calls."""
+    from collections import defaultdict
+
+    if len(tagged) != len(reviews):
+        raise ValueError(f"tagged length ({len(tagged)}) != reviews length ({len(reviews)})")
+
+    total = len(reviews)
+    ratings = [r.get("rating") or 0 for r in reviews]
+
+    dim_phrase_reviews = {k: defaultdict(set) for k in DIM_TO_LABELTYPE}
+    for i, tags in enumerate(tagged):
+        if not isinstance(tags, dict):
+            continue
+        for dim in DIM_TO_LABELTYPE:
+            for el in (tags.get(dim) or []):
+                if not isinstance(el, str):
+                    continue
+                kl = el.strip().lower()
+                if kl:
+                    dim_phrase_reviews[dim][kl].add(i)
+
+    insights = []
+    for dim, phrases in dim_phrase_reviews.items():
+        if not phrases:
+            continue
+        p2c = {}
+        for cl in (clusters_per_dim.get(dim) or []):
+            canon = (cl.get("canonical") or "").strip()
+            if not canon:
+                continue
+            for m in (cl.get("members") or []):
+                if not isinstance(m, str):
+                    continue
+                ml = m.strip().lower()
+                if ml and ml not in p2c:
+                    p2c[ml] = canon
+        for ph in phrases:
+            p2c.setdefault(ph, ph.title())
+
+        canon_to_reviews = defaultdict(set)
+        for phrase, rs in phrases.items():
+            canon_to_reviews[p2c[phrase]].update(rs)
+
+        lt = DIM_TO_LABELTYPE[dim]
+        for canon, rs in canon_to_reviews.items():
+            c = len(rs)
+            avg = sum(ratings[i] for i in rs) / c if c else 0.0
+            insights.append({
+                "element": canon,
+                "labelType": lt,
+                "count": c,
+                "reviewRate": round(c / total, 4),
+                "avgRating": round(avg, 2),
+            })
+    insights.sort(key=lambda x: (x["labelType"], -x["count"]))
+
+    sentiments = [(t or {}).get("sentiment") for t in tagged]
+    sentiment_dist = {
+        "positive": round(sum(1 for s in sentiments if s == "positive") / total, 4) if total else 0,
+        "neutral": round(sum(1 for s in sentiments if s == "neutral") / total, 4) if total else 0,
+        "negative": round(sum(1 for s in sentiments if s == "negative") / total, 4) if total else 0,
+    }
+    avg_rating = round(sum(ratings) / total, 2) if total else 0.0
+
+    return {
+        "success": True,
+        "data": {
+            "reviewCount": total,
+            "avgRating": avg_rating,
+            "sentimentDistribution": sentiment_dist,
+            "consumerInsights": insights,
+            "topKeywords": [
+                {"element": it["element"], "count": it["count"]}
+                for it in insights if it["labelType"] == "keywords"
+            ][:20],
+        },
+        "_meta": {"source": "prompt-as-data-aggregation", "tagsApplied": total},
+    }
+
+
+def cmd_reviews_raw(args):
+    log_fn = (lambda m: print(m, file=sys.stderr)) if args.verbose else None
+    result = fetch_realtime_reviews_all(args.asin, args.marketplace, args.max_pages, log_fn=log_fn)
+    output({
+        "success": True,
+        "data": result,
+        "_query": {"endpoint": "realtime/reviews",
+                   "params": {"asin": args.asin, "marketplace": args.marketplace,
+                              "maxPages": args.max_pages}},
+    })
+
+
+def _load_json_arg(inline: str, path: str, name: str):
+    """Load JSON from --<name> inline arg or --<name>-file path."""
+    if inline and path:
+        print(f"ERROR: provide either --{name} or --{name}-file, not both", file=sys.stderr)
+        sys.exit(1)
+    if inline:
+        return json.loads(inline)
+    if path:
+        with open(path) as f:
+            return json.load(f)
+    print(f"ERROR: --{name} or --{name}-file is required", file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_review_tag_prompt(args):
+    review = _load_json_arg(args.review, args.review_file, "review")
+    prompt = render_review_map_prompt(
+        review,
+        product_title=args.product_title or "",
+        product_category=args.product_category or "",
+    )
+    print(prompt)
+
+
+def cmd_review_reduce_prompt(args):
+    candidates = _load_json_arg(args.candidates, args.candidates_file, "candidates")
+    if not isinstance(candidates, list):
+        print("ERROR: candidates must be a JSON array of strings", file=sys.stderr)
+        sys.exit(1)
+    prompt = render_review_reduce_prompt(args.label_type, candidates)
+    print(prompt)
+
+
+def cmd_review_aggregate(args):
+    with open(args.reviews) as f:
+        reviews_data = json.load(f)
+    if isinstance(reviews_data, dict):
+        reviews = (reviews_data.get("data") or {}).get("reviews") or reviews_data.get("reviews") or []
+    else:
+        reviews = reviews_data
+
+    with open(args.tagged) as f:
+        tagged = json.load(f)
+    with open(args.clusters) as f:
+        clusters_per_dim = json.load(f)
+
+    result = aggregate_review_insights(reviews, tagged, clusters_per_dim)
+    result["_query"] = {"endpoint": "realtime/reviews+local-aggregate",
+                        "params": {"reviews": args.reviews, "tagged": args.tagged,
+                                    "clusters": args.clusters}}
+    output(result)
 
 
 # ─── Subcommands ─────────────────────────────────────────────────────────────
@@ -2282,6 +2612,38 @@ Examples:
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
     p_rd.add_argument("--category", help="Category path")
     p_rd.set_defaults(func=cmd_review_deepdive)
+
+    # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
+    p_rr = sub.add_parser("reviews-raw", help="Fetch raw reviews from realtime/reviews (cap 100, early-exit on null cursor)", allow_abbrev=False)
+    p_rr.add_argument("--asin", required=True)
+    p_rr.add_argument("--marketplace", default="US", choices=["US", "UK"])
+    p_rr.add_argument("--max-pages", type=int, default=REALTIME_REVIEWS_MAX_PAGES,
+                      help=f"Max pages to fetch (10 reviews each, default {REALTIME_REVIEWS_MAX_PAGES})")
+    p_rr.add_argument("--verbose", action="store_true")
+    p_rr.set_defaults(func=cmd_reviews_raw)
+
+    # ── review-tag-prompt (render Map prompt for one review — caller's LLM runs it) ──
+    p_rtp = sub.add_parser("review-tag-prompt", help="Render the per-review Map prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rtp.add_argument("--review", help="Review object as JSON string")
+    p_rtp.add_argument("--review-file", help="Path to JSON file containing a single review object")
+    p_rtp.add_argument("--product-title", help="Optional product title context")
+    p_rtp.add_argument("--product-category", help="Optional product category context")
+    p_rtp.set_defaults(func=cmd_review_tag_prompt)
+
+    # ── review-reduce-prompt (render Reduce prompt for one dimension — caller's LLM runs it) ──
+    p_rrp = sub.add_parser("review-reduce-prompt", help="Render the per-dimension Reduce prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rrp.add_argument("--label-type", required=True,
+                       help="Dimension to cluster (scenarios, issues, positives, improvements, buyingFactors, painPoints, userProfiles, usageTimes, usageLocations, behaviors, keywords)")
+    p_rrp.add_argument("--candidates", help="Candidate phrases as JSON array string")
+    p_rrp.add_argument("--candidates-file", help="Path to JSON file containing candidate phrases array")
+    p_rrp.set_defaults(func=cmd_review_reduce_prompt)
+
+    # ── review-aggregate (build reviews/analysis-compatible output from tags + clusters) ──
+    p_rag = sub.add_parser("review-aggregate", help="Aggregate per-review tags + per-dim clusters into consumerInsights", allow_abbrev=False)
+    p_rag.add_argument("--reviews", required=True, help="Path to JSON from reviews-raw (or raw reviews array)")
+    p_rag.add_argument("--tagged", required=True, help="Path to JSON array of Map outputs (same order as reviews)")
+    p_rag.add_argument("--clusters", required=True, help="Path to JSON {dim_key: [{canonical, members}]} from Reduce")
+    p_rag.set_defaults(func=cmd_review_aggregate)
 
     # ── analyze (reviews) ──
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Listing Audit Pro — 8-Dimension Health Check
-version: 1.0.1
+version: 1.0.2
 description: >
   Comprehensive listing health check and optimization engine for Amazon sellers.
   Scores listings across 8 dimensions, benchmarks against category leaders,
@@ -41,7 +41,24 @@ Required: my_asin. Optional: keyword, category. Category is auto-detected from A
 1. **Category auto-detection**: categoryPath is auto-detected from ASIN. If `category_source` in output is `inferred_from_search`, confirm with user
 2. **All keyword-based endpoints MUST include `--category`**; ASIN-specific endpoints do NOT
 3. **Use API fields directly**: revenue=`sampleAvgMonthlyRevenue` (NEVER price×sales), sales=`monthlySalesFloor`, opportunity=`sampleOpportunityIndex`
-4. **reviews/analysis**: needs 50+ reviews; ASIN mode first, category fallback
+4. **reviews/analysis**: needs 50+ reviews; ASIN mode first, category fallback. Fallback chain when both fail:
+   1. **Lightweight**: `realtime/product` ratingBreakdown — only star distribution, no themes
+   2. **Full 11-dim insights** — bypass `/reviews/analysis` entirely:
+      a. `apiclaw.py reviews-raw --asin X` → fetch up to 100 raw reviews (10 credits, ~60s)
+      b. For each review: render Map prompt via `apiclaw.py review-tag-prompt --review '<json>'`
+         and have your own LLM produce JSON tags (sentiment + 11 dimensions)
+      c. Collect candidate phrases per dimension; for each dimension render
+         Reduce prompt via `apiclaw.py review-reduce-prompt --label-type X --candidates '[...]'`
+         and have your LLM produce semantic clusters
+      d. `apiclaw.py review-aggregate --reviews R --tagged T --clusters C`
+         → consumerInsights output compatible with `/reviews/analysis`
+   3. **Fallback caveats** (apply to the 4-step chain above — lessons from end-to-end validation):
+      - **Working dir**: `WORK=/tmp/review_<ASIN>_$(date +%s) && mkdir -p $WORK`
+      - **Step b CLI behavior**: `review-tag-prompt` RENDERS the prompt only; YOUR LLM produces the JSON. Render once to learn the schema, then produce tags for all N reviews in one in-context pass (don't call the CLI N times).
+      - **Step c candidate extraction** (Python one-liner):
+        `candidates = {d: sorted({el.strip().lower() for t in tagged for el in (t.get(d) or [])}) for d in DIMS}`
+      - **Small-sample rule (reviewCount<50)**: demote single-mention items 📊→🔍; NEVER attach table-level or section-header 📊 when any row inside is 🔍; suppress "🔴 Critical" verdicts on count=1
+      - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (8-dimension audit scores, title/bullet/A+ checks, category-leader benchmarks) remain valid — do not re-run them.
 5. **Sales null fallback**: Monthly sales ≈ 300,000 / BSR^0.65, tag 🔍
 
 ## Execution
@@ -85,6 +102,22 @@ Output language MUST match the user's input language. If the user asks in Chines
 - 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
 
 Rules: Strategy recommendations are NEVER 📊. User criteria override AI judgment.
+
+**Aggregate-label rule (applies to ALL report output, not just fallback)**: NEVER attach 📊 to ANY element that aggregates or groups underlying content when ANY piece of that content is 🔍 or 💡. "Aggregate/grouping elements" include:
+- Section headers at EVERY level (`#`, `##`, `###`, `####`) — including top-level summary sections like "Overall Score", "Verdict", "Executive Summary"
+- Summary/score lines anywhere in the report (e.g. `## Overall Score — 27/100 · Grade F 📊` is WRONG if any Basis row inside is 🔍)
+- Table **column** headers in comparison tables (e.g. `**Target ASIN** 📊` as a column label is WRONG if any cell in that column contains 🔍)
+- Table row headers or row-aggregation labels (when the row aggregates multiple cells of mixed confidence)
+- Any other visual grouping label — bullet-list group titles, callout box titles, etc.
+
+A group-level 📊 implies the whole block/column/row is data-backed, which smuggles inferred/directional content into the 📊 tier via visual grouping. Either (a) **omit the group-level label entirely** (preferred when content mixes tiers), or (b) use the LOWEST confidence present inside (🔍 if any underlying content is 🔍; 💡 if any is 💡). This is a universal output-quality rule — it applies regardless of which fallback path (if any) was triggered.
+
+**Emoji reservation rule (closely related)**: The three confidence symbols `📊 🔍 💡` are RESERVED for confidence labeling. NEVER use them as decorative prefixes on section headers, table headers, or any aggregate element — even when you also include a correct confidence suffix on the same line. Example:
+- ❌ WRONG: `## 📊 Overall Score — 27/100 · Grade F 🔍` (the leading 📊 reads as a data-backed claim even though the trailing 🔍 is correct)
+- ✅ RIGHT: `## Overall Score — 27/100 · Grade F 🔍` (no decorative emoji, just the proper confidence suffix)
+- ✅ RIGHT: `## 🎯 Overall Score — 27/100 · Grade F 🔍` (use non-reserved decorative icons like 🎯 🧭 📋 📝 📂 🏁 🚨 🏆 🔔 when a visual prefix is desired)
+
+Decorative emoji ≠ confidence label — but from a reader's perspective, a leading `📊/🔍/💡` is indistinguishable from a confidence claim. Reserve these three symbols EXCLUSIVELY for confidence annotation to avoid ambiguity.
 
 Bulk audit: share market data across ASINs, run audit per ASIN.
 

--- a/amazon-listing-audit-pro/scripts/apiclaw.py
+++ b/amazon-listing-audit-pro/scripts/apiclaw.py
@@ -1,29 +1,8 @@
 #!/usr/bin/env python3
 # ============================================================
-# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
-# Source of truth: apiclaw/scripts/apiclaw.py
-#
-# Sync is enforced at THREE layers — understand all three before editing:
-#
-#   1. Local pre-commit hook (scripts/pre-commit)
-#      When this file is staged, auto-runs sync-scripts.sh and stages the
-#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
-#
-#   2. Sync script (scripts/sync-scripts.sh)
-#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
-#      any copy that differs without an "AUTO-SYNCED" marker (safety against
-#      destroying manual edits). If you hit a CONFLICT, inspect the diff
-#      first, then either (a) merge the manual edit back into canonical, or
-#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
-#
-#   3. CI check (.github/workflows/shared-files-distribution.yml)
-#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
-#      `diff` against canonical. Mismatched copies fail the PR hard with an
-#      "::error::" annotation — no merge until all 9 copies are identical.
-#
-# If you inherit a repo where copies drift without markers, resolve once by:
-#   bash scripts/sync-scripts.sh   # lists CONFLICTs
-#   # then add the AUTO-SYNCED marker to each copy and re-run
+# Canonical source - do not edit copies under amazon-* skill directories directly
+# Source location: apiclaw/scripts/apiclaw.py
+# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API

--- a/amazon-listing-audit-pro/scripts/apiclaw.py
+++ b/amazon-listing-audit-pro/scripts/apiclaw.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python3
 # ============================================================
-# Canonical source - do not edit copies under amazon-* skill directories directly
-# Source location: apiclaw/scripts/apiclaw.py
-# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
+# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
+# Source of truth: apiclaw/scripts/apiclaw.py
+#
+# Sync is enforced at THREE layers — understand all three before editing:
+#
+#   1. Local pre-commit hook (scripts/pre-commit)
+#      When this file is staged, auto-runs sync-scripts.sh and stages the
+#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
+#
+#   2. Sync script (scripts/sync-scripts.sh)
+#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
+#      any copy that differs without an "AUTO-SYNCED" marker (safety against
+#      destroying manual edits). If you hit a CONFLICT, inspect the diff
+#      first, then either (a) merge the manual edit back into canonical, or
+#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
+#
+#   3. CI check (.github/workflows/shared-files-distribution.yml)
+#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
+#      `diff` against canonical. Mismatched copies fail the PR hard with an
+#      "::error::" annotation — no merge until all 9 copies are identical.
+#
+# If you inherit a repo where copies drift without markers, resolve once by:
+#   bash scripts/sync-scripts.sh   # lists CONFLICTs
+#   # then add the AUTO-SYNCED marker to each copy and re-run
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
@@ -376,6 +397,315 @@ def parse_category(cat_str: str) -> list:
     if ">" in cat_str:
         return [c.strip() for c in cat_str.split(">")]
     return [c.strip() for c in cat_str.split(",")]
+
+
+# ─── Review Analysis: Prompt-as-Data Toolkit ───────────────────────────────
+# Used when /reviews/analysis lacks aggregation (ASIN has <50 reviews or no
+# daily snapshot). This module does NOT call any external LLM — it provides
+# raw data, rendered prompts, and a final aggregator. The calling skill's own
+# LLM performs the Map (per-review tagging) and Reduce (semantic clustering)
+# steps, producing JSON that feeds back into `review-aggregate`.
+#
+# Caller flow:
+#   1. apiclaw.py reviews-raw --asin X          → fetch raw reviews
+#   2. For each review, render via:
+#        apiclaw.py review-tag-prompt --review '<json>'
+#      The caller's LLM produces JSON matching REVIEW_MAP_SCHEMA.
+#   3. Collect per-dimension candidate phrases; for each dimension render:
+#        apiclaw.py review-reduce-prompt --label-type <dim> --candidates '[...]'
+#      The caller's LLM produces JSON matching REVIEW_REDUCE_SCHEMA.
+#   4. apiclaw.py review-aggregate --reviews R --tagged T --clusters C
+#      → emits consumerInsights compatible with /reviews/analysis.
+
+REVIEW_MAP_CONCURRENCY = 20           # suggested map parallelism for caller
+REVIEW_REDUCE_KEYWORDS_CHUNK = 150    # suggested chunk size when keywords dim is large
+REALTIME_REVIEWS_MAX_PAGES = 10       # API hard cap = 100 reviews (10 pages × 10)
+
+DIM_TO_LABELTYPE = {
+    "mentioned_scenarios": "scenarios",
+    "mentioned_issues": "issues",
+    "mentioned_positives": "positives",
+    "mentioned_improvements": "improvements",
+    "mentioned_buying_factors": "buyingFactors",
+    "mentioned_pain_points": "painPoints",
+    "user_profiles": "userProfiles",
+    "mentioned_usage_times": "usageTimes",
+    "mentioned_usage_locations": "usageLocations",
+    "mentioned_behaviors": "behaviors",
+    "keywords": "keywords",
+}
+
+_MAP_ARRAY_FIELDS = list(DIM_TO_LABELTYPE.keys())
+
+REVIEW_MAP_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "sentiment": {"type": "STRING", "enum": ["positive", "neutral", "negative"]},
+        **{k: {"type": "ARRAY", "items": {"type": "STRING"}} for k in _MAP_ARRAY_FIELDS},
+    },
+    "required": ["sentiment"] + _MAP_ARRAY_FIELDS,
+}
+
+REVIEW_REDUCE_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "clusters": {
+            "type": "ARRAY",
+            "items": {
+                "type": "OBJECT",
+                "properties": {
+                    "canonical": {"type": "STRING"},
+                    "members": {"type": "ARRAY", "items": {"type": "STRING"}},
+                },
+                "required": ["canonical", "members"],
+            },
+        },
+    },
+    "required": ["clusters"],
+}
+
+
+def render_review_map_prompt(review: dict, product_title: str = "", product_category: str = "") -> str:
+    title = review.get("title") or ""
+    body = review.get("body") or ""
+    full = f"{title}. {body}" if title else body
+    text = full[:500]
+    rating = review.get("rating") or 3
+    verified = bool(review.get("verifiedPurchase"))
+    return f"""IMPORTANT: Respond ONLY with a JSON object matching the schema below. Output must be in English — translate non-English text before extracting.
+
+You are an expert data extraction specialist analyzing product reviews. Extract only what is EXPLICITLY mentioned — do not infer.
+
+JSON schema:
+{{
+  "sentiment": "positive" | "neutral" | "negative",
+  "mentioned_scenarios": [string],      // max 5 noun phrases 1-3 words (Workouts, Gaming)
+  "mentioned_issues": [string],         // max 5 Adjective+Noun for PRODUCT DEFECTS (Poor Sound Quality)
+  "mentioned_positives": [string],      // max 5 Adjective+Noun for praised aspects (Comfortable Fit)
+  "mentioned_improvements": [string],   // max 3 Verb+Noun explicit suggestions (Extend Battery Life)
+  "mentioned_buying_factors": [string], // max 3 noun phrases for purchase reasons (Price Point)
+  "mentioned_pain_points": [string],    // max 3 UX frustrations EXPERIENCED AFTER USE (see rule)
+  "user_profiles": [string],            // max 3 identities stated EXPLICITLY (see rule)
+  "mentioned_usage_times": [string],    // max 3 time/season phrases (Morning, Winter)
+  "mentioned_usage_locations": [string],// max 3 location phrases (Gym, Home)
+  "mentioned_behaviors": [string],      // max 5 Verb+Object (Taking Calls, Running)
+  "keywords": [string]                  // 3-15 salient words from the review
+}}
+
+Rules:
+- sentiment: positive (4-5 stars or praise), neutral (3 stars / mixed), negative (1-2 stars or complaint)
+- pain_points = problems EXPERIENCED AFTER USE. NOT problems the product solves. If the reviewer says the product solved a prior problem (e.g. "cured my foot pain"), that belongs in positives, NOT pain_points.
+- issues vs pain_points: issues = product defects (hardware/software fault); pain_points = UX frustrations
+- user_profiles: include ONLY if the reviewer explicitly states an identity ("I'm a...", "As a..."). NEVER infer.
+- consistent naming across reviews (e.g. always "Workouts", not "At the gym")
+- use empty arrays [] for categories with no mentions, never null
+
+INPUT:
+Product Category: {product_category or '(unknown)'}
+Product Title: {product_title or '(unknown)'}
+Review Rating: {rating}/5 stars
+Verified Purchase: {'Yes' if verified else 'No'}
+Review Text:
+\"\"\"{text}\"\"\"
+
+Return ONLY the JSON object."""
+
+
+def render_review_reduce_prompt(label_type: str, candidates: list) -> str:
+    return f"""Normalize product-review tags. Group semantically equivalent phrases into clusters and pick a concise Title-Case canonical name (1-3 words) for each cluster.
+
+Label type: {label_type}
+
+Rules:
+- A cluster contains phrases describing the SAME underlying concept.
+- Every input phrase MUST appear in exactly one cluster's `members`. No drops, no duplicates across clusters.
+- Phrases with no semantic neighbors go in their own single-member cluster (still Title-Case canonical).
+- Case-insensitive matching. Preserve input phrase strings verbatim in `members`.
+
+Return a JSON object matching:
+{{"clusters": [{{"canonical": "Title Case", "members": ["phrase1", "phrase2"]}}]}}
+
+Input phrases:
+{json.dumps(candidates, ensure_ascii=False)}"""
+
+
+def fetch_realtime_reviews_all(asin: str, marketplace: str = "US",
+                                max_pages: int = REALTIME_REVIEWS_MAX_PAGES,
+                                log_fn=None) -> dict:
+    """Paginate /realtime/reviews with cursor; stop on null cursor or max_pages."""
+    log = log_fn or (lambda m: None)
+    reviews = []
+    cursor = None
+    pages = 0
+    t0 = time.time()
+    for i in range(1, max_pages + 1):
+        params = {"asin": asin, "marketplace": marketplace}
+        if cursor:
+            params["cursor"] = cursor
+        resp = api_call("realtime/reviews", params)
+        if not resp.get("success"):
+            break
+        data = resp.get("data") or {}
+        page_reviews = data.get("reviews") or []
+        cursor = data.get("nextCursor")
+        pages += 1
+        reviews.extend(page_reviews)
+        log(f"  page {i}: {len(page_reviews)} reviews, cursor={'yes' if cursor else 'end'}")
+        if not cursor:
+            break
+    return {
+        "reviews": reviews,
+        "pages": pages,
+        "capped": pages >= max_pages and cursor is not None,
+        "fetchSeconds": round(time.time() - t0, 2),
+    }
+
+
+def aggregate_review_insights(reviews: list, tagged: list, clusters_per_dim: dict) -> dict:
+    """Combine raw reviews + per-review Map tags + per-dimension Reduce clusters
+    into a reviews/analysis-compatible aggregation. No LLM calls."""
+    from collections import defaultdict
+
+    if len(tagged) != len(reviews):
+        raise ValueError(f"tagged length ({len(tagged)}) != reviews length ({len(reviews)})")
+
+    total = len(reviews)
+    ratings = [r.get("rating") or 0 for r in reviews]
+
+    dim_phrase_reviews = {k: defaultdict(set) for k in DIM_TO_LABELTYPE}
+    for i, tags in enumerate(tagged):
+        if not isinstance(tags, dict):
+            continue
+        for dim in DIM_TO_LABELTYPE:
+            for el in (tags.get(dim) or []):
+                if not isinstance(el, str):
+                    continue
+                kl = el.strip().lower()
+                if kl:
+                    dim_phrase_reviews[dim][kl].add(i)
+
+    insights = []
+    for dim, phrases in dim_phrase_reviews.items():
+        if not phrases:
+            continue
+        p2c = {}
+        for cl in (clusters_per_dim.get(dim) or []):
+            canon = (cl.get("canonical") or "").strip()
+            if not canon:
+                continue
+            for m in (cl.get("members") or []):
+                if not isinstance(m, str):
+                    continue
+                ml = m.strip().lower()
+                if ml and ml not in p2c:
+                    p2c[ml] = canon
+        for ph in phrases:
+            p2c.setdefault(ph, ph.title())
+
+        canon_to_reviews = defaultdict(set)
+        for phrase, rs in phrases.items():
+            canon_to_reviews[p2c[phrase]].update(rs)
+
+        lt = DIM_TO_LABELTYPE[dim]
+        for canon, rs in canon_to_reviews.items():
+            c = len(rs)
+            avg = sum(ratings[i] for i in rs) / c if c else 0.0
+            insights.append({
+                "element": canon,
+                "labelType": lt,
+                "count": c,
+                "reviewRate": round(c / total, 4),
+                "avgRating": round(avg, 2),
+            })
+    insights.sort(key=lambda x: (x["labelType"], -x["count"]))
+
+    sentiments = [(t or {}).get("sentiment") for t in tagged]
+    sentiment_dist = {
+        "positive": round(sum(1 for s in sentiments if s == "positive") / total, 4) if total else 0,
+        "neutral": round(sum(1 for s in sentiments if s == "neutral") / total, 4) if total else 0,
+        "negative": round(sum(1 for s in sentiments if s == "negative") / total, 4) if total else 0,
+    }
+    avg_rating = round(sum(ratings) / total, 2) if total else 0.0
+
+    return {
+        "success": True,
+        "data": {
+            "reviewCount": total,
+            "avgRating": avg_rating,
+            "sentimentDistribution": sentiment_dist,
+            "consumerInsights": insights,
+            "topKeywords": [
+                {"element": it["element"], "count": it["count"]}
+                for it in insights if it["labelType"] == "keywords"
+            ][:20],
+        },
+        "_meta": {"source": "prompt-as-data-aggregation", "tagsApplied": total},
+    }
+
+
+def cmd_reviews_raw(args):
+    log_fn = (lambda m: print(m, file=sys.stderr)) if args.verbose else None
+    result = fetch_realtime_reviews_all(args.asin, args.marketplace, args.max_pages, log_fn=log_fn)
+    output({
+        "success": True,
+        "data": result,
+        "_query": {"endpoint": "realtime/reviews",
+                   "params": {"asin": args.asin, "marketplace": args.marketplace,
+                              "maxPages": args.max_pages}},
+    })
+
+
+def _load_json_arg(inline: str, path: str, name: str):
+    """Load JSON from --<name> inline arg or --<name>-file path."""
+    if inline and path:
+        print(f"ERROR: provide either --{name} or --{name}-file, not both", file=sys.stderr)
+        sys.exit(1)
+    if inline:
+        return json.loads(inline)
+    if path:
+        with open(path) as f:
+            return json.load(f)
+    print(f"ERROR: --{name} or --{name}-file is required", file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_review_tag_prompt(args):
+    review = _load_json_arg(args.review, args.review_file, "review")
+    prompt = render_review_map_prompt(
+        review,
+        product_title=args.product_title or "",
+        product_category=args.product_category or "",
+    )
+    print(prompt)
+
+
+def cmd_review_reduce_prompt(args):
+    candidates = _load_json_arg(args.candidates, args.candidates_file, "candidates")
+    if not isinstance(candidates, list):
+        print("ERROR: candidates must be a JSON array of strings", file=sys.stderr)
+        sys.exit(1)
+    prompt = render_review_reduce_prompt(args.label_type, candidates)
+    print(prompt)
+
+
+def cmd_review_aggregate(args):
+    with open(args.reviews) as f:
+        reviews_data = json.load(f)
+    if isinstance(reviews_data, dict):
+        reviews = (reviews_data.get("data") or {}).get("reviews") or reviews_data.get("reviews") or []
+    else:
+        reviews = reviews_data
+
+    with open(args.tagged) as f:
+        tagged = json.load(f)
+    with open(args.clusters) as f:
+        clusters_per_dim = json.load(f)
+
+    result = aggregate_review_insights(reviews, tagged, clusters_per_dim)
+    result["_query"] = {"endpoint": "realtime/reviews+local-aggregate",
+                        "params": {"reviews": args.reviews, "tagged": args.tagged,
+                                    "clusters": args.clusters}}
+    output(result)
 
 
 # ─── Subcommands ─────────────────────────────────────────────────────────────
@@ -2282,6 +2612,38 @@ Examples:
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
     p_rd.add_argument("--category", help="Category path")
     p_rd.set_defaults(func=cmd_review_deepdive)
+
+    # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
+    p_rr = sub.add_parser("reviews-raw", help="Fetch raw reviews from realtime/reviews (cap 100, early-exit on null cursor)", allow_abbrev=False)
+    p_rr.add_argument("--asin", required=True)
+    p_rr.add_argument("--marketplace", default="US", choices=["US", "UK"])
+    p_rr.add_argument("--max-pages", type=int, default=REALTIME_REVIEWS_MAX_PAGES,
+                      help=f"Max pages to fetch (10 reviews each, default {REALTIME_REVIEWS_MAX_PAGES})")
+    p_rr.add_argument("--verbose", action="store_true")
+    p_rr.set_defaults(func=cmd_reviews_raw)
+
+    # ── review-tag-prompt (render Map prompt for one review — caller's LLM runs it) ──
+    p_rtp = sub.add_parser("review-tag-prompt", help="Render the per-review Map prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rtp.add_argument("--review", help="Review object as JSON string")
+    p_rtp.add_argument("--review-file", help="Path to JSON file containing a single review object")
+    p_rtp.add_argument("--product-title", help="Optional product title context")
+    p_rtp.add_argument("--product-category", help="Optional product category context")
+    p_rtp.set_defaults(func=cmd_review_tag_prompt)
+
+    # ── review-reduce-prompt (render Reduce prompt for one dimension — caller's LLM runs it) ──
+    p_rrp = sub.add_parser("review-reduce-prompt", help="Render the per-dimension Reduce prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rrp.add_argument("--label-type", required=True,
+                       help="Dimension to cluster (scenarios, issues, positives, improvements, buyingFactors, painPoints, userProfiles, usageTimes, usageLocations, behaviors, keywords)")
+    p_rrp.add_argument("--candidates", help="Candidate phrases as JSON array string")
+    p_rrp.add_argument("--candidates-file", help="Path to JSON file containing candidate phrases array")
+    p_rrp.set_defaults(func=cmd_review_reduce_prompt)
+
+    # ── review-aggregate (build reviews/analysis-compatible output from tags + clusters) ──
+    p_rag = sub.add_parser("review-aggregate", help="Aggregate per-review tags + per-dim clusters into consumerInsights", allow_abbrev=False)
+    p_rag.add_argument("--reviews", required=True, help="Path to JSON from reviews-raw (or raw reviews array)")
+    p_rag.add_argument("--tagged", required=True, help="Path to JSON array of Map outputs (same order as reviews)")
+    p_rag.add_argument("--clusters", required=True, help="Path to JSON {dim_key: [{canonical, members}]} from Reduce")
+    p_rag.set_defaults(func=cmd_review_aggregate)
 
     # ── analyze (reviews) ──
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Market Entry Analyzer — GO/CAUTION/AVOID Verdicts
-version: 1.0.1
+version: 1.0.2
 description: >
   One-click market viability assessment for Amazon sellers.
   Analyzes market size, competition intensity, brand landscape, pricing structure,
@@ -36,7 +36,24 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 - Revenue = `sampleAvgMonthlyRevenue` (NEVER calculate avgPrice × totalSales — overestimates 30-70%)
 - Sales = `monthlySalesFloor` (lower bound). Fallback: 300,000 / BSR^0.65, tag 🔍
 - Use `sampleOpportunityIndex`, `sampleTop10BrandSalesRate` directly — never reinvent
-- `reviews/analysis` needs 50+ reviews; fallback to realtime ratingBreakdown
+- `reviews/analysis` needs 50+ reviews. Fallback chain when sample is insufficient:
+  1. **Lightweight**: `realtime/product` ratingBreakdown — only star distribution, no themes
+  2. **Full 11-dim insights** — bypass `/reviews/analysis` entirely:
+     a. `apiclaw.py reviews-raw --asin X` → fetch up to 100 raw reviews (10 credits, ~60s)
+     b. For each review: render Map prompt via `apiclaw.py review-tag-prompt --review '<json>'`
+        and have your own LLM produce JSON tags (sentiment + 11 dimensions)
+     c. Collect candidate phrases per dimension; for each dimension render
+        Reduce prompt via `apiclaw.py review-reduce-prompt --label-type X --candidates '[...]'`
+        and have your LLM produce semantic clusters
+     d. `apiclaw.py review-aggregate --reviews R --tagged T --clusters C`
+        → consumerInsights output compatible with `/reviews/analysis`
+  3. **Fallback caveats** (apply to the 4-step chain above — lessons from end-to-end validation):
+     - **Working dir**: `WORK=/tmp/review_<ASIN>_$(date +%s) && mkdir -p $WORK`
+     - **Step b CLI behavior**: `review-tag-prompt` RENDERS the prompt only; YOUR LLM produces the JSON. Render once to learn the schema, then produce tags for all N reviews in one in-context pass (don't call the CLI N times).
+     - **Step c candidate extraction** (Python one-liner):
+       `candidates = {d: sorted({el.strip().lower() for t in tagged for el in (t.get(d) or [])}) for d in DIMS}`
+     - **Small-sample rule (reviewCount<50)**: demote single-mention items 📊→🔍; NEVER attach table-level or section-header 📊 when any row inside is 🔍; suppress "🔴 Critical" verdicts on count=1
+     - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (GO/CAUTION/AVOID verdict, market size, brand/price analysis) remain valid — do not re-run them.
 - Aggregation endpoints without categoryPath produce severely distorted data
 
 ## Unique Logic
@@ -106,6 +123,22 @@ Output language MUST match the user's input language. If the user asks in Chines
 - 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
 
 Rules: Strategy recommendations are NEVER 📊. Anomalies (>200% growth) are always 💡. User criteria override AI judgment.
+
+**Aggregate-label rule (applies to ALL report output, not just fallback)**: NEVER attach 📊 to ANY element that aggregates or groups underlying content when ANY piece of that content is 🔍 or 💡. "Aggregate/grouping elements" include:
+- Section headers at EVERY level (`#`, `##`, `###`, `####`) — including top-level summary sections like "Overall Score", "Verdict", "Executive Summary"
+- Summary/score lines anywhere in the report (e.g. `## Overall Score — 27/100 · Grade F 📊` is WRONG if any Basis row inside is 🔍)
+- Table **column** headers in comparison tables (e.g. `**Target ASIN** 📊` as a column label is WRONG if any cell in that column contains 🔍)
+- Table row headers or row-aggregation labels (when the row aggregates multiple cells of mixed confidence)
+- Any other visual grouping label — bullet-list group titles, callout box titles, etc.
+
+A group-level 📊 implies the whole block/column/row is data-backed, which smuggles inferred/directional content into the 📊 tier via visual grouping. Either (a) **omit the group-level label entirely** (preferred when content mixes tiers), or (b) use the LOWEST confidence present inside (🔍 if any underlying content is 🔍; 💡 if any is 💡). This is a universal output-quality rule — it applies regardless of which fallback path (if any) was triggered.
+
+**Emoji reservation rule (closely related)**: The three confidence symbols `📊 🔍 💡` are RESERVED for confidence labeling. NEVER use them as decorative prefixes on section headers, table headers, or any aggregate element — even when you also include a correct confidence suffix on the same line. Example:
+- ❌ WRONG: `## 📊 Overall Score — 27/100 · Grade F 🔍` (the leading 📊 reads as a data-backed claim even though the trailing 🔍 is correct)
+- ✅ RIGHT: `## Overall Score — 27/100 · Grade F 🔍` (no decorative emoji, just the proper confidence suffix)
+- ✅ RIGHT: `## 🎯 Overall Score — 27/100 · Grade F 🔍` (use non-reserved decorative icons like 🎯 🧭 📋 📝 📂 🏁 🚨 🏆 🔔 when a visual prefix is desired)
+
+Decorative emoji ≠ confidence label — but from a reader's perspective, a leading `📊/🔍/💡` is indistinguishable from a confidence claim. Reserve these three symbols EXCLUSIVELY for confidence annotation to avoid ambiguity.
 
 ### Data Provenance (required)
 

--- a/amazon-market-entry-analyzer/scripts/apiclaw.py
+++ b/amazon-market-entry-analyzer/scripts/apiclaw.py
@@ -1,29 +1,8 @@
 #!/usr/bin/env python3
 # ============================================================
-# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
-# Source of truth: apiclaw/scripts/apiclaw.py
-#
-# Sync is enforced at THREE layers — understand all three before editing:
-#
-#   1. Local pre-commit hook (scripts/pre-commit)
-#      When this file is staged, auto-runs sync-scripts.sh and stages the
-#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
-#
-#   2. Sync script (scripts/sync-scripts.sh)
-#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
-#      any copy that differs without an "AUTO-SYNCED" marker (safety against
-#      destroying manual edits). If you hit a CONFLICT, inspect the diff
-#      first, then either (a) merge the manual edit back into canonical, or
-#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
-#
-#   3. CI check (.github/workflows/shared-files-distribution.yml)
-#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
-#      `diff` against canonical. Mismatched copies fail the PR hard with an
-#      "::error::" annotation — no merge until all 9 copies are identical.
-#
-# If you inherit a repo where copies drift without markers, resolve once by:
-#   bash scripts/sync-scripts.sh   # lists CONFLICTs
-#   # then add the AUTO-SYNCED marker to each copy and re-run
+# Canonical source - do not edit copies under amazon-* skill directories directly
+# Source location: apiclaw/scripts/apiclaw.py
+# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API

--- a/amazon-market-entry-analyzer/scripts/apiclaw.py
+++ b/amazon-market-entry-analyzer/scripts/apiclaw.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python3
 # ============================================================
-# Canonical source - do not edit copies under amazon-* skill directories directly
-# Source location: apiclaw/scripts/apiclaw.py
-# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
+# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
+# Source of truth: apiclaw/scripts/apiclaw.py
+#
+# Sync is enforced at THREE layers — understand all three before editing:
+#
+#   1. Local pre-commit hook (scripts/pre-commit)
+#      When this file is staged, auto-runs sync-scripts.sh and stages the
+#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
+#
+#   2. Sync script (scripts/sync-scripts.sh)
+#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
+#      any copy that differs without an "AUTO-SYNCED" marker (safety against
+#      destroying manual edits). If you hit a CONFLICT, inspect the diff
+#      first, then either (a) merge the manual edit back into canonical, or
+#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
+#
+#   3. CI check (.github/workflows/shared-files-distribution.yml)
+#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
+#      `diff` against canonical. Mismatched copies fail the PR hard with an
+#      "::error::" annotation — no merge until all 9 copies are identical.
+#
+# If you inherit a repo where copies drift without markers, resolve once by:
+#   bash scripts/sync-scripts.sh   # lists CONFLICTs
+#   # then add the AUTO-SYNCED marker to each copy and re-run
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
@@ -376,6 +397,315 @@ def parse_category(cat_str: str) -> list:
     if ">" in cat_str:
         return [c.strip() for c in cat_str.split(">")]
     return [c.strip() for c in cat_str.split(",")]
+
+
+# ─── Review Analysis: Prompt-as-Data Toolkit ───────────────────────────────
+# Used when /reviews/analysis lacks aggregation (ASIN has <50 reviews or no
+# daily snapshot). This module does NOT call any external LLM — it provides
+# raw data, rendered prompts, and a final aggregator. The calling skill's own
+# LLM performs the Map (per-review tagging) and Reduce (semantic clustering)
+# steps, producing JSON that feeds back into `review-aggregate`.
+#
+# Caller flow:
+#   1. apiclaw.py reviews-raw --asin X          → fetch raw reviews
+#   2. For each review, render via:
+#        apiclaw.py review-tag-prompt --review '<json>'
+#      The caller's LLM produces JSON matching REVIEW_MAP_SCHEMA.
+#   3. Collect per-dimension candidate phrases; for each dimension render:
+#        apiclaw.py review-reduce-prompt --label-type <dim> --candidates '[...]'
+#      The caller's LLM produces JSON matching REVIEW_REDUCE_SCHEMA.
+#   4. apiclaw.py review-aggregate --reviews R --tagged T --clusters C
+#      → emits consumerInsights compatible with /reviews/analysis.
+
+REVIEW_MAP_CONCURRENCY = 20           # suggested map parallelism for caller
+REVIEW_REDUCE_KEYWORDS_CHUNK = 150    # suggested chunk size when keywords dim is large
+REALTIME_REVIEWS_MAX_PAGES = 10       # API hard cap = 100 reviews (10 pages × 10)
+
+DIM_TO_LABELTYPE = {
+    "mentioned_scenarios": "scenarios",
+    "mentioned_issues": "issues",
+    "mentioned_positives": "positives",
+    "mentioned_improvements": "improvements",
+    "mentioned_buying_factors": "buyingFactors",
+    "mentioned_pain_points": "painPoints",
+    "user_profiles": "userProfiles",
+    "mentioned_usage_times": "usageTimes",
+    "mentioned_usage_locations": "usageLocations",
+    "mentioned_behaviors": "behaviors",
+    "keywords": "keywords",
+}
+
+_MAP_ARRAY_FIELDS = list(DIM_TO_LABELTYPE.keys())
+
+REVIEW_MAP_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "sentiment": {"type": "STRING", "enum": ["positive", "neutral", "negative"]},
+        **{k: {"type": "ARRAY", "items": {"type": "STRING"}} for k in _MAP_ARRAY_FIELDS},
+    },
+    "required": ["sentiment"] + _MAP_ARRAY_FIELDS,
+}
+
+REVIEW_REDUCE_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "clusters": {
+            "type": "ARRAY",
+            "items": {
+                "type": "OBJECT",
+                "properties": {
+                    "canonical": {"type": "STRING"},
+                    "members": {"type": "ARRAY", "items": {"type": "STRING"}},
+                },
+                "required": ["canonical", "members"],
+            },
+        },
+    },
+    "required": ["clusters"],
+}
+
+
+def render_review_map_prompt(review: dict, product_title: str = "", product_category: str = "") -> str:
+    title = review.get("title") or ""
+    body = review.get("body") or ""
+    full = f"{title}. {body}" if title else body
+    text = full[:500]
+    rating = review.get("rating") or 3
+    verified = bool(review.get("verifiedPurchase"))
+    return f"""IMPORTANT: Respond ONLY with a JSON object matching the schema below. Output must be in English — translate non-English text before extracting.
+
+You are an expert data extraction specialist analyzing product reviews. Extract only what is EXPLICITLY mentioned — do not infer.
+
+JSON schema:
+{{
+  "sentiment": "positive" | "neutral" | "negative",
+  "mentioned_scenarios": [string],      // max 5 noun phrases 1-3 words (Workouts, Gaming)
+  "mentioned_issues": [string],         // max 5 Adjective+Noun for PRODUCT DEFECTS (Poor Sound Quality)
+  "mentioned_positives": [string],      // max 5 Adjective+Noun for praised aspects (Comfortable Fit)
+  "mentioned_improvements": [string],   // max 3 Verb+Noun explicit suggestions (Extend Battery Life)
+  "mentioned_buying_factors": [string], // max 3 noun phrases for purchase reasons (Price Point)
+  "mentioned_pain_points": [string],    // max 3 UX frustrations EXPERIENCED AFTER USE (see rule)
+  "user_profiles": [string],            // max 3 identities stated EXPLICITLY (see rule)
+  "mentioned_usage_times": [string],    // max 3 time/season phrases (Morning, Winter)
+  "mentioned_usage_locations": [string],// max 3 location phrases (Gym, Home)
+  "mentioned_behaviors": [string],      // max 5 Verb+Object (Taking Calls, Running)
+  "keywords": [string]                  // 3-15 salient words from the review
+}}
+
+Rules:
+- sentiment: positive (4-5 stars or praise), neutral (3 stars / mixed), negative (1-2 stars or complaint)
+- pain_points = problems EXPERIENCED AFTER USE. NOT problems the product solves. If the reviewer says the product solved a prior problem (e.g. "cured my foot pain"), that belongs in positives, NOT pain_points.
+- issues vs pain_points: issues = product defects (hardware/software fault); pain_points = UX frustrations
+- user_profiles: include ONLY if the reviewer explicitly states an identity ("I'm a...", "As a..."). NEVER infer.
+- consistent naming across reviews (e.g. always "Workouts", not "At the gym")
+- use empty arrays [] for categories with no mentions, never null
+
+INPUT:
+Product Category: {product_category or '(unknown)'}
+Product Title: {product_title or '(unknown)'}
+Review Rating: {rating}/5 stars
+Verified Purchase: {'Yes' if verified else 'No'}
+Review Text:
+\"\"\"{text}\"\"\"
+
+Return ONLY the JSON object."""
+
+
+def render_review_reduce_prompt(label_type: str, candidates: list) -> str:
+    return f"""Normalize product-review tags. Group semantically equivalent phrases into clusters and pick a concise Title-Case canonical name (1-3 words) for each cluster.
+
+Label type: {label_type}
+
+Rules:
+- A cluster contains phrases describing the SAME underlying concept.
+- Every input phrase MUST appear in exactly one cluster's `members`. No drops, no duplicates across clusters.
+- Phrases with no semantic neighbors go in their own single-member cluster (still Title-Case canonical).
+- Case-insensitive matching. Preserve input phrase strings verbatim in `members`.
+
+Return a JSON object matching:
+{{"clusters": [{{"canonical": "Title Case", "members": ["phrase1", "phrase2"]}}]}}
+
+Input phrases:
+{json.dumps(candidates, ensure_ascii=False)}"""
+
+
+def fetch_realtime_reviews_all(asin: str, marketplace: str = "US",
+                                max_pages: int = REALTIME_REVIEWS_MAX_PAGES,
+                                log_fn=None) -> dict:
+    """Paginate /realtime/reviews with cursor; stop on null cursor or max_pages."""
+    log = log_fn or (lambda m: None)
+    reviews = []
+    cursor = None
+    pages = 0
+    t0 = time.time()
+    for i in range(1, max_pages + 1):
+        params = {"asin": asin, "marketplace": marketplace}
+        if cursor:
+            params["cursor"] = cursor
+        resp = api_call("realtime/reviews", params)
+        if not resp.get("success"):
+            break
+        data = resp.get("data") or {}
+        page_reviews = data.get("reviews") or []
+        cursor = data.get("nextCursor")
+        pages += 1
+        reviews.extend(page_reviews)
+        log(f"  page {i}: {len(page_reviews)} reviews, cursor={'yes' if cursor else 'end'}")
+        if not cursor:
+            break
+    return {
+        "reviews": reviews,
+        "pages": pages,
+        "capped": pages >= max_pages and cursor is not None,
+        "fetchSeconds": round(time.time() - t0, 2),
+    }
+
+
+def aggregate_review_insights(reviews: list, tagged: list, clusters_per_dim: dict) -> dict:
+    """Combine raw reviews + per-review Map tags + per-dimension Reduce clusters
+    into a reviews/analysis-compatible aggregation. No LLM calls."""
+    from collections import defaultdict
+
+    if len(tagged) != len(reviews):
+        raise ValueError(f"tagged length ({len(tagged)}) != reviews length ({len(reviews)})")
+
+    total = len(reviews)
+    ratings = [r.get("rating") or 0 for r in reviews]
+
+    dim_phrase_reviews = {k: defaultdict(set) for k in DIM_TO_LABELTYPE}
+    for i, tags in enumerate(tagged):
+        if not isinstance(tags, dict):
+            continue
+        for dim in DIM_TO_LABELTYPE:
+            for el in (tags.get(dim) or []):
+                if not isinstance(el, str):
+                    continue
+                kl = el.strip().lower()
+                if kl:
+                    dim_phrase_reviews[dim][kl].add(i)
+
+    insights = []
+    for dim, phrases in dim_phrase_reviews.items():
+        if not phrases:
+            continue
+        p2c = {}
+        for cl in (clusters_per_dim.get(dim) or []):
+            canon = (cl.get("canonical") or "").strip()
+            if not canon:
+                continue
+            for m in (cl.get("members") or []):
+                if not isinstance(m, str):
+                    continue
+                ml = m.strip().lower()
+                if ml and ml not in p2c:
+                    p2c[ml] = canon
+        for ph in phrases:
+            p2c.setdefault(ph, ph.title())
+
+        canon_to_reviews = defaultdict(set)
+        for phrase, rs in phrases.items():
+            canon_to_reviews[p2c[phrase]].update(rs)
+
+        lt = DIM_TO_LABELTYPE[dim]
+        for canon, rs in canon_to_reviews.items():
+            c = len(rs)
+            avg = sum(ratings[i] for i in rs) / c if c else 0.0
+            insights.append({
+                "element": canon,
+                "labelType": lt,
+                "count": c,
+                "reviewRate": round(c / total, 4),
+                "avgRating": round(avg, 2),
+            })
+    insights.sort(key=lambda x: (x["labelType"], -x["count"]))
+
+    sentiments = [(t or {}).get("sentiment") for t in tagged]
+    sentiment_dist = {
+        "positive": round(sum(1 for s in sentiments if s == "positive") / total, 4) if total else 0,
+        "neutral": round(sum(1 for s in sentiments if s == "neutral") / total, 4) if total else 0,
+        "negative": round(sum(1 for s in sentiments if s == "negative") / total, 4) if total else 0,
+    }
+    avg_rating = round(sum(ratings) / total, 2) if total else 0.0
+
+    return {
+        "success": True,
+        "data": {
+            "reviewCount": total,
+            "avgRating": avg_rating,
+            "sentimentDistribution": sentiment_dist,
+            "consumerInsights": insights,
+            "topKeywords": [
+                {"element": it["element"], "count": it["count"]}
+                for it in insights if it["labelType"] == "keywords"
+            ][:20],
+        },
+        "_meta": {"source": "prompt-as-data-aggregation", "tagsApplied": total},
+    }
+
+
+def cmd_reviews_raw(args):
+    log_fn = (lambda m: print(m, file=sys.stderr)) if args.verbose else None
+    result = fetch_realtime_reviews_all(args.asin, args.marketplace, args.max_pages, log_fn=log_fn)
+    output({
+        "success": True,
+        "data": result,
+        "_query": {"endpoint": "realtime/reviews",
+                   "params": {"asin": args.asin, "marketplace": args.marketplace,
+                              "maxPages": args.max_pages}},
+    })
+
+
+def _load_json_arg(inline: str, path: str, name: str):
+    """Load JSON from --<name> inline arg or --<name>-file path."""
+    if inline and path:
+        print(f"ERROR: provide either --{name} or --{name}-file, not both", file=sys.stderr)
+        sys.exit(1)
+    if inline:
+        return json.loads(inline)
+    if path:
+        with open(path) as f:
+            return json.load(f)
+    print(f"ERROR: --{name} or --{name}-file is required", file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_review_tag_prompt(args):
+    review = _load_json_arg(args.review, args.review_file, "review")
+    prompt = render_review_map_prompt(
+        review,
+        product_title=args.product_title or "",
+        product_category=args.product_category or "",
+    )
+    print(prompt)
+
+
+def cmd_review_reduce_prompt(args):
+    candidates = _load_json_arg(args.candidates, args.candidates_file, "candidates")
+    if not isinstance(candidates, list):
+        print("ERROR: candidates must be a JSON array of strings", file=sys.stderr)
+        sys.exit(1)
+    prompt = render_review_reduce_prompt(args.label_type, candidates)
+    print(prompt)
+
+
+def cmd_review_aggregate(args):
+    with open(args.reviews) as f:
+        reviews_data = json.load(f)
+    if isinstance(reviews_data, dict):
+        reviews = (reviews_data.get("data") or {}).get("reviews") or reviews_data.get("reviews") or []
+    else:
+        reviews = reviews_data
+
+    with open(args.tagged) as f:
+        tagged = json.load(f)
+    with open(args.clusters) as f:
+        clusters_per_dim = json.load(f)
+
+    result = aggregate_review_insights(reviews, tagged, clusters_per_dim)
+    result["_query"] = {"endpoint": "realtime/reviews+local-aggregate",
+                        "params": {"reviews": args.reviews, "tagged": args.tagged,
+                                    "clusters": args.clusters}}
+    output(result)
 
 
 # ─── Subcommands ─────────────────────────────────────────────────────────────
@@ -2282,6 +2612,38 @@ Examples:
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
     p_rd.add_argument("--category", help="Category path")
     p_rd.set_defaults(func=cmd_review_deepdive)
+
+    # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
+    p_rr = sub.add_parser("reviews-raw", help="Fetch raw reviews from realtime/reviews (cap 100, early-exit on null cursor)", allow_abbrev=False)
+    p_rr.add_argument("--asin", required=True)
+    p_rr.add_argument("--marketplace", default="US", choices=["US", "UK"])
+    p_rr.add_argument("--max-pages", type=int, default=REALTIME_REVIEWS_MAX_PAGES,
+                      help=f"Max pages to fetch (10 reviews each, default {REALTIME_REVIEWS_MAX_PAGES})")
+    p_rr.add_argument("--verbose", action="store_true")
+    p_rr.set_defaults(func=cmd_reviews_raw)
+
+    # ── review-tag-prompt (render Map prompt for one review — caller's LLM runs it) ──
+    p_rtp = sub.add_parser("review-tag-prompt", help="Render the per-review Map prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rtp.add_argument("--review", help="Review object as JSON string")
+    p_rtp.add_argument("--review-file", help="Path to JSON file containing a single review object")
+    p_rtp.add_argument("--product-title", help="Optional product title context")
+    p_rtp.add_argument("--product-category", help="Optional product category context")
+    p_rtp.set_defaults(func=cmd_review_tag_prompt)
+
+    # ── review-reduce-prompt (render Reduce prompt for one dimension — caller's LLM runs it) ──
+    p_rrp = sub.add_parser("review-reduce-prompt", help="Render the per-dimension Reduce prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rrp.add_argument("--label-type", required=True,
+                       help="Dimension to cluster (scenarios, issues, positives, improvements, buyingFactors, painPoints, userProfiles, usageTimes, usageLocations, behaviors, keywords)")
+    p_rrp.add_argument("--candidates", help="Candidate phrases as JSON array string")
+    p_rrp.add_argument("--candidates-file", help="Path to JSON file containing candidate phrases array")
+    p_rrp.set_defaults(func=cmd_review_reduce_prompt)
+
+    # ── review-aggregate (build reviews/analysis-compatible output from tags + clusters) ──
+    p_rag = sub.add_parser("review-aggregate", help="Aggregate per-review tags + per-dim clusters into consumerInsights", allow_abbrev=False)
+    p_rag.add_argument("--reviews", required=True, help="Path to JSON from reviews-raw (or raw reviews array)")
+    p_rag.add_argument("--tagged", required=True, help="Path to JSON array of Map outputs (same order as reviews)")
+    p_rag.add_argument("--clusters", required=True, help="Path to JSON {dim_key: [{canonical, members}]} from Reduce")
+    p_rag.set_defaults(func=cmd_review_aggregate)
 
     # ── analyze (reviews) ──
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)

--- a/amazon-market-trend-scanner/scripts/apiclaw.py
+++ b/amazon-market-trend-scanner/scripts/apiclaw.py
@@ -1,29 +1,8 @@
 #!/usr/bin/env python3
 # ============================================================
-# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
-# Source of truth: apiclaw/scripts/apiclaw.py
-#
-# Sync is enforced at THREE layers — understand all three before editing:
-#
-#   1. Local pre-commit hook (scripts/pre-commit)
-#      When this file is staged, auto-runs sync-scripts.sh and stages the
-#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
-#
-#   2. Sync script (scripts/sync-scripts.sh)
-#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
-#      any copy that differs without an "AUTO-SYNCED" marker (safety against
-#      destroying manual edits). If you hit a CONFLICT, inspect the diff
-#      first, then either (a) merge the manual edit back into canonical, or
-#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
-#
-#   3. CI check (.github/workflows/shared-files-distribution.yml)
-#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
-#      `diff` against canonical. Mismatched copies fail the PR hard with an
-#      "::error::" annotation — no merge until all 9 copies are identical.
-#
-# If you inherit a repo where copies drift without markers, resolve once by:
-#   bash scripts/sync-scripts.sh   # lists CONFLICTs
-#   # then add the AUTO-SYNCED marker to each copy and re-run
+# Canonical source - do not edit copies under amazon-* skill directories directly
+# Source location: apiclaw/scripts/apiclaw.py
+# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API

--- a/amazon-market-trend-scanner/scripts/apiclaw.py
+++ b/amazon-market-trend-scanner/scripts/apiclaw.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python3
 # ============================================================
-# Canonical source - do not edit copies under amazon-* skill directories directly
-# Source location: apiclaw/scripts/apiclaw.py
-# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
+# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
+# Source of truth: apiclaw/scripts/apiclaw.py
+#
+# Sync is enforced at THREE layers — understand all three before editing:
+#
+#   1. Local pre-commit hook (scripts/pre-commit)
+#      When this file is staged, auto-runs sync-scripts.sh and stages the
+#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
+#
+#   2. Sync script (scripts/sync-scripts.sh)
+#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
+#      any copy that differs without an "AUTO-SYNCED" marker (safety against
+#      destroying manual edits). If you hit a CONFLICT, inspect the diff
+#      first, then either (a) merge the manual edit back into canonical, or
+#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
+#
+#   3. CI check (.github/workflows/shared-files-distribution.yml)
+#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
+#      `diff` against canonical. Mismatched copies fail the PR hard with an
+#      "::error::" annotation — no merge until all 9 copies are identical.
+#
+# If you inherit a repo where copies drift without markers, resolve once by:
+#   bash scripts/sync-scripts.sh   # lists CONFLICTs
+#   # then add the AUTO-SYNCED marker to each copy and re-run
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
@@ -376,6 +397,315 @@ def parse_category(cat_str: str) -> list:
     if ">" in cat_str:
         return [c.strip() for c in cat_str.split(">")]
     return [c.strip() for c in cat_str.split(",")]
+
+
+# ─── Review Analysis: Prompt-as-Data Toolkit ───────────────────────────────
+# Used when /reviews/analysis lacks aggregation (ASIN has <50 reviews or no
+# daily snapshot). This module does NOT call any external LLM — it provides
+# raw data, rendered prompts, and a final aggregator. The calling skill's own
+# LLM performs the Map (per-review tagging) and Reduce (semantic clustering)
+# steps, producing JSON that feeds back into `review-aggregate`.
+#
+# Caller flow:
+#   1. apiclaw.py reviews-raw --asin X          → fetch raw reviews
+#   2. For each review, render via:
+#        apiclaw.py review-tag-prompt --review '<json>'
+#      The caller's LLM produces JSON matching REVIEW_MAP_SCHEMA.
+#   3. Collect per-dimension candidate phrases; for each dimension render:
+#        apiclaw.py review-reduce-prompt --label-type <dim> --candidates '[...]'
+#      The caller's LLM produces JSON matching REVIEW_REDUCE_SCHEMA.
+#   4. apiclaw.py review-aggregate --reviews R --tagged T --clusters C
+#      → emits consumerInsights compatible with /reviews/analysis.
+
+REVIEW_MAP_CONCURRENCY = 20           # suggested map parallelism for caller
+REVIEW_REDUCE_KEYWORDS_CHUNK = 150    # suggested chunk size when keywords dim is large
+REALTIME_REVIEWS_MAX_PAGES = 10       # API hard cap = 100 reviews (10 pages × 10)
+
+DIM_TO_LABELTYPE = {
+    "mentioned_scenarios": "scenarios",
+    "mentioned_issues": "issues",
+    "mentioned_positives": "positives",
+    "mentioned_improvements": "improvements",
+    "mentioned_buying_factors": "buyingFactors",
+    "mentioned_pain_points": "painPoints",
+    "user_profiles": "userProfiles",
+    "mentioned_usage_times": "usageTimes",
+    "mentioned_usage_locations": "usageLocations",
+    "mentioned_behaviors": "behaviors",
+    "keywords": "keywords",
+}
+
+_MAP_ARRAY_FIELDS = list(DIM_TO_LABELTYPE.keys())
+
+REVIEW_MAP_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "sentiment": {"type": "STRING", "enum": ["positive", "neutral", "negative"]},
+        **{k: {"type": "ARRAY", "items": {"type": "STRING"}} for k in _MAP_ARRAY_FIELDS},
+    },
+    "required": ["sentiment"] + _MAP_ARRAY_FIELDS,
+}
+
+REVIEW_REDUCE_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "clusters": {
+            "type": "ARRAY",
+            "items": {
+                "type": "OBJECT",
+                "properties": {
+                    "canonical": {"type": "STRING"},
+                    "members": {"type": "ARRAY", "items": {"type": "STRING"}},
+                },
+                "required": ["canonical", "members"],
+            },
+        },
+    },
+    "required": ["clusters"],
+}
+
+
+def render_review_map_prompt(review: dict, product_title: str = "", product_category: str = "") -> str:
+    title = review.get("title") or ""
+    body = review.get("body") or ""
+    full = f"{title}. {body}" if title else body
+    text = full[:500]
+    rating = review.get("rating") or 3
+    verified = bool(review.get("verifiedPurchase"))
+    return f"""IMPORTANT: Respond ONLY with a JSON object matching the schema below. Output must be in English — translate non-English text before extracting.
+
+You are an expert data extraction specialist analyzing product reviews. Extract only what is EXPLICITLY mentioned — do not infer.
+
+JSON schema:
+{{
+  "sentiment": "positive" | "neutral" | "negative",
+  "mentioned_scenarios": [string],      // max 5 noun phrases 1-3 words (Workouts, Gaming)
+  "mentioned_issues": [string],         // max 5 Adjective+Noun for PRODUCT DEFECTS (Poor Sound Quality)
+  "mentioned_positives": [string],      // max 5 Adjective+Noun for praised aspects (Comfortable Fit)
+  "mentioned_improvements": [string],   // max 3 Verb+Noun explicit suggestions (Extend Battery Life)
+  "mentioned_buying_factors": [string], // max 3 noun phrases for purchase reasons (Price Point)
+  "mentioned_pain_points": [string],    // max 3 UX frustrations EXPERIENCED AFTER USE (see rule)
+  "user_profiles": [string],            // max 3 identities stated EXPLICITLY (see rule)
+  "mentioned_usage_times": [string],    // max 3 time/season phrases (Morning, Winter)
+  "mentioned_usage_locations": [string],// max 3 location phrases (Gym, Home)
+  "mentioned_behaviors": [string],      // max 5 Verb+Object (Taking Calls, Running)
+  "keywords": [string]                  // 3-15 salient words from the review
+}}
+
+Rules:
+- sentiment: positive (4-5 stars or praise), neutral (3 stars / mixed), negative (1-2 stars or complaint)
+- pain_points = problems EXPERIENCED AFTER USE. NOT problems the product solves. If the reviewer says the product solved a prior problem (e.g. "cured my foot pain"), that belongs in positives, NOT pain_points.
+- issues vs pain_points: issues = product defects (hardware/software fault); pain_points = UX frustrations
+- user_profiles: include ONLY if the reviewer explicitly states an identity ("I'm a...", "As a..."). NEVER infer.
+- consistent naming across reviews (e.g. always "Workouts", not "At the gym")
+- use empty arrays [] for categories with no mentions, never null
+
+INPUT:
+Product Category: {product_category or '(unknown)'}
+Product Title: {product_title or '(unknown)'}
+Review Rating: {rating}/5 stars
+Verified Purchase: {'Yes' if verified else 'No'}
+Review Text:
+\"\"\"{text}\"\"\"
+
+Return ONLY the JSON object."""
+
+
+def render_review_reduce_prompt(label_type: str, candidates: list) -> str:
+    return f"""Normalize product-review tags. Group semantically equivalent phrases into clusters and pick a concise Title-Case canonical name (1-3 words) for each cluster.
+
+Label type: {label_type}
+
+Rules:
+- A cluster contains phrases describing the SAME underlying concept.
+- Every input phrase MUST appear in exactly one cluster's `members`. No drops, no duplicates across clusters.
+- Phrases with no semantic neighbors go in their own single-member cluster (still Title-Case canonical).
+- Case-insensitive matching. Preserve input phrase strings verbatim in `members`.
+
+Return a JSON object matching:
+{{"clusters": [{{"canonical": "Title Case", "members": ["phrase1", "phrase2"]}}]}}
+
+Input phrases:
+{json.dumps(candidates, ensure_ascii=False)}"""
+
+
+def fetch_realtime_reviews_all(asin: str, marketplace: str = "US",
+                                max_pages: int = REALTIME_REVIEWS_MAX_PAGES,
+                                log_fn=None) -> dict:
+    """Paginate /realtime/reviews with cursor; stop on null cursor or max_pages."""
+    log = log_fn or (lambda m: None)
+    reviews = []
+    cursor = None
+    pages = 0
+    t0 = time.time()
+    for i in range(1, max_pages + 1):
+        params = {"asin": asin, "marketplace": marketplace}
+        if cursor:
+            params["cursor"] = cursor
+        resp = api_call("realtime/reviews", params)
+        if not resp.get("success"):
+            break
+        data = resp.get("data") or {}
+        page_reviews = data.get("reviews") or []
+        cursor = data.get("nextCursor")
+        pages += 1
+        reviews.extend(page_reviews)
+        log(f"  page {i}: {len(page_reviews)} reviews, cursor={'yes' if cursor else 'end'}")
+        if not cursor:
+            break
+    return {
+        "reviews": reviews,
+        "pages": pages,
+        "capped": pages >= max_pages and cursor is not None,
+        "fetchSeconds": round(time.time() - t0, 2),
+    }
+
+
+def aggregate_review_insights(reviews: list, tagged: list, clusters_per_dim: dict) -> dict:
+    """Combine raw reviews + per-review Map tags + per-dimension Reduce clusters
+    into a reviews/analysis-compatible aggregation. No LLM calls."""
+    from collections import defaultdict
+
+    if len(tagged) != len(reviews):
+        raise ValueError(f"tagged length ({len(tagged)}) != reviews length ({len(reviews)})")
+
+    total = len(reviews)
+    ratings = [r.get("rating") or 0 for r in reviews]
+
+    dim_phrase_reviews = {k: defaultdict(set) for k in DIM_TO_LABELTYPE}
+    for i, tags in enumerate(tagged):
+        if not isinstance(tags, dict):
+            continue
+        for dim in DIM_TO_LABELTYPE:
+            for el in (tags.get(dim) or []):
+                if not isinstance(el, str):
+                    continue
+                kl = el.strip().lower()
+                if kl:
+                    dim_phrase_reviews[dim][kl].add(i)
+
+    insights = []
+    for dim, phrases in dim_phrase_reviews.items():
+        if not phrases:
+            continue
+        p2c = {}
+        for cl in (clusters_per_dim.get(dim) or []):
+            canon = (cl.get("canonical") or "").strip()
+            if not canon:
+                continue
+            for m in (cl.get("members") or []):
+                if not isinstance(m, str):
+                    continue
+                ml = m.strip().lower()
+                if ml and ml not in p2c:
+                    p2c[ml] = canon
+        for ph in phrases:
+            p2c.setdefault(ph, ph.title())
+
+        canon_to_reviews = defaultdict(set)
+        for phrase, rs in phrases.items():
+            canon_to_reviews[p2c[phrase]].update(rs)
+
+        lt = DIM_TO_LABELTYPE[dim]
+        for canon, rs in canon_to_reviews.items():
+            c = len(rs)
+            avg = sum(ratings[i] for i in rs) / c if c else 0.0
+            insights.append({
+                "element": canon,
+                "labelType": lt,
+                "count": c,
+                "reviewRate": round(c / total, 4),
+                "avgRating": round(avg, 2),
+            })
+    insights.sort(key=lambda x: (x["labelType"], -x["count"]))
+
+    sentiments = [(t or {}).get("sentiment") for t in tagged]
+    sentiment_dist = {
+        "positive": round(sum(1 for s in sentiments if s == "positive") / total, 4) if total else 0,
+        "neutral": round(sum(1 for s in sentiments if s == "neutral") / total, 4) if total else 0,
+        "negative": round(sum(1 for s in sentiments if s == "negative") / total, 4) if total else 0,
+    }
+    avg_rating = round(sum(ratings) / total, 2) if total else 0.0
+
+    return {
+        "success": True,
+        "data": {
+            "reviewCount": total,
+            "avgRating": avg_rating,
+            "sentimentDistribution": sentiment_dist,
+            "consumerInsights": insights,
+            "topKeywords": [
+                {"element": it["element"], "count": it["count"]}
+                for it in insights if it["labelType"] == "keywords"
+            ][:20],
+        },
+        "_meta": {"source": "prompt-as-data-aggregation", "tagsApplied": total},
+    }
+
+
+def cmd_reviews_raw(args):
+    log_fn = (lambda m: print(m, file=sys.stderr)) if args.verbose else None
+    result = fetch_realtime_reviews_all(args.asin, args.marketplace, args.max_pages, log_fn=log_fn)
+    output({
+        "success": True,
+        "data": result,
+        "_query": {"endpoint": "realtime/reviews",
+                   "params": {"asin": args.asin, "marketplace": args.marketplace,
+                              "maxPages": args.max_pages}},
+    })
+
+
+def _load_json_arg(inline: str, path: str, name: str):
+    """Load JSON from --<name> inline arg or --<name>-file path."""
+    if inline and path:
+        print(f"ERROR: provide either --{name} or --{name}-file, not both", file=sys.stderr)
+        sys.exit(1)
+    if inline:
+        return json.loads(inline)
+    if path:
+        with open(path) as f:
+            return json.load(f)
+    print(f"ERROR: --{name} or --{name}-file is required", file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_review_tag_prompt(args):
+    review = _load_json_arg(args.review, args.review_file, "review")
+    prompt = render_review_map_prompt(
+        review,
+        product_title=args.product_title or "",
+        product_category=args.product_category or "",
+    )
+    print(prompt)
+
+
+def cmd_review_reduce_prompt(args):
+    candidates = _load_json_arg(args.candidates, args.candidates_file, "candidates")
+    if not isinstance(candidates, list):
+        print("ERROR: candidates must be a JSON array of strings", file=sys.stderr)
+        sys.exit(1)
+    prompt = render_review_reduce_prompt(args.label_type, candidates)
+    print(prompt)
+
+
+def cmd_review_aggregate(args):
+    with open(args.reviews) as f:
+        reviews_data = json.load(f)
+    if isinstance(reviews_data, dict):
+        reviews = (reviews_data.get("data") or {}).get("reviews") or reviews_data.get("reviews") or []
+    else:
+        reviews = reviews_data
+
+    with open(args.tagged) as f:
+        tagged = json.load(f)
+    with open(args.clusters) as f:
+        clusters_per_dim = json.load(f)
+
+    result = aggregate_review_insights(reviews, tagged, clusters_per_dim)
+    result["_query"] = {"endpoint": "realtime/reviews+local-aggregate",
+                        "params": {"reviews": args.reviews, "tagged": args.tagged,
+                                    "clusters": args.clusters}}
+    output(result)
 
 
 # ─── Subcommands ─────────────────────────────────────────────────────────────
@@ -2282,6 +2612,38 @@ Examples:
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
     p_rd.add_argument("--category", help="Category path")
     p_rd.set_defaults(func=cmd_review_deepdive)
+
+    # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
+    p_rr = sub.add_parser("reviews-raw", help="Fetch raw reviews from realtime/reviews (cap 100, early-exit on null cursor)", allow_abbrev=False)
+    p_rr.add_argument("--asin", required=True)
+    p_rr.add_argument("--marketplace", default="US", choices=["US", "UK"])
+    p_rr.add_argument("--max-pages", type=int, default=REALTIME_REVIEWS_MAX_PAGES,
+                      help=f"Max pages to fetch (10 reviews each, default {REALTIME_REVIEWS_MAX_PAGES})")
+    p_rr.add_argument("--verbose", action="store_true")
+    p_rr.set_defaults(func=cmd_reviews_raw)
+
+    # ── review-tag-prompt (render Map prompt for one review — caller's LLM runs it) ──
+    p_rtp = sub.add_parser("review-tag-prompt", help="Render the per-review Map prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rtp.add_argument("--review", help="Review object as JSON string")
+    p_rtp.add_argument("--review-file", help="Path to JSON file containing a single review object")
+    p_rtp.add_argument("--product-title", help="Optional product title context")
+    p_rtp.add_argument("--product-category", help="Optional product category context")
+    p_rtp.set_defaults(func=cmd_review_tag_prompt)
+
+    # ── review-reduce-prompt (render Reduce prompt for one dimension — caller's LLM runs it) ──
+    p_rrp = sub.add_parser("review-reduce-prompt", help="Render the per-dimension Reduce prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rrp.add_argument("--label-type", required=True,
+                       help="Dimension to cluster (scenarios, issues, positives, improvements, buyingFactors, painPoints, userProfiles, usageTimes, usageLocations, behaviors, keywords)")
+    p_rrp.add_argument("--candidates", help="Candidate phrases as JSON array string")
+    p_rrp.add_argument("--candidates-file", help="Path to JSON file containing candidate phrases array")
+    p_rrp.set_defaults(func=cmd_review_reduce_prompt)
+
+    # ── review-aggregate (build reviews/analysis-compatible output from tags + clusters) ──
+    p_rag = sub.add_parser("review-aggregate", help="Aggregate per-review tags + per-dim clusters into consumerInsights", allow_abbrev=False)
+    p_rag.add_argument("--reviews", required=True, help="Path to JSON from reviews-raw (or raw reviews array)")
+    p_rag.add_argument("--tagged", required=True, help="Path to JSON array of Map outputs (same order as reviews)")
+    p_rag.add_argument("--clusters", required=True, help="Path to JSON {dim_key: [{canonical, members}]} from Reduce")
+    p_rag.set_defaults(func=cmd_review_aggregate)
 
     # ── analyze (reviews) ──
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Opportunity Discoverer — Niche Scanner & Scoring
-version: 1.0.1
+version: 1.0.2
 description: >
   Automated product opportunity scanner for Amazon sellers.
   Scans categories using 14 preset selection strategies, validates candidates with
@@ -35,7 +35,24 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 - categoryPath is auto-resolved via `categories`, with fallback to top search result. If `category_source` is `inferred_from_search`, confirm with user — keyword-only queries contaminate results
 - All keyword-based endpoints MUST include `--category` when locked
 - Revenue = `sampleAvgMonthlyRevenue` directly. Sales = `monthlySalesFloor` (lower bound)
-- `reviews/analysis` needs 50+ reviews
+- `reviews/analysis` needs 50+ reviews. Fallback chain when sample is insufficient:
+  1. **Lightweight**: `realtime/product` ratingBreakdown — only star distribution, no themes
+  2. **Full 11-dim insights** — bypass `/reviews/analysis` entirely:
+     a. `apiclaw.py reviews-raw --asin X` → fetch up to 100 raw reviews (10 credits, ~60s)
+     b. For each review: render Map prompt via `apiclaw.py review-tag-prompt --review '<json>'`
+        and have your own LLM produce JSON tags (sentiment + 11 dimensions)
+     c. Collect candidate phrases per dimension; for each dimension render
+        Reduce prompt via `apiclaw.py review-reduce-prompt --label-type X --candidates '[...]'`
+        and have your LLM produce semantic clusters
+     d. `apiclaw.py review-aggregate --reviews R --tagged T --clusters C`
+        → consumerInsights output compatible with `/reviews/analysis`
+  3. **Fallback caveats** (apply to the 4-step chain above — lessons from end-to-end validation):
+     - **Working dir**: `WORK=/tmp/review_<ASIN>_$(date +%s) && mkdir -p $WORK`
+     - **Step b CLI behavior**: `review-tag-prompt` RENDERS the prompt only; YOUR LLM produces the JSON. Render once to learn the schema, then produce tags for all N reviews in one in-context pass (don't call the CLI N times).
+     - **Step c candidate extraction** (Python one-liner):
+       `candidates = {d: sorted({el.strip().lower() for t in tagged for el in (t.get(d) or [])}) for d in DIMS}`
+     - **Small-sample rule (reviewCount<50)**: demote single-mention items 📊→🔍; NEVER attach table-level or section-header 📊 when any row inside is 🔍; suppress "🔴 Critical" verdicts on count=1
+     - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (opportunity scoring, mode-based selection, ranked candidate list) remain valid — do not re-run them.
 - Deduplicate ASINs across modes — same product appears in multiple scans
 - Each mode has **built-in filters that STACK** with user filters (e.g. beginner: $15-60, sales≥300)
 
@@ -105,6 +122,22 @@ Output language MUST match the user's input language. If the user asks in Chines
 - 💡 **Directional** — suggestions, predictions, strategy (e.g. "consider entering $10-15 band 💡")
 
 Rules: Strategy recommendations are NEVER 📊. Anomalies (>200% growth) are always 💡. User criteria override AI judgment.
+
+**Aggregate-label rule (applies to ALL report output, not just fallback)**: NEVER attach 📊 to ANY element that aggregates or groups underlying content when ANY piece of that content is 🔍 or 💡. "Aggregate/grouping elements" include:
+- Section headers at EVERY level (`#`, `##`, `###`, `####`) — including top-level summary sections like "Overall Score", "Verdict", "Executive Summary"
+- Summary/score lines anywhere in the report (e.g. `## Overall Score — 27/100 · Grade F 📊` is WRONG if any Basis row inside is 🔍)
+- Table **column** headers in comparison tables (e.g. `**Target ASIN** 📊` as a column label is WRONG if any cell in that column contains 🔍)
+- Table row headers or row-aggregation labels (when the row aggregates multiple cells of mixed confidence)
+- Any other visual grouping label — bullet-list group titles, callout box titles, etc.
+
+A group-level 📊 implies the whole block/column/row is data-backed, which smuggles inferred/directional content into the 📊 tier via visual grouping. Either (a) **omit the group-level label entirely** (preferred when content mixes tiers), or (b) use the LOWEST confidence present inside (🔍 if any underlying content is 🔍; 💡 if any is 💡). This is a universal output-quality rule — it applies regardless of which fallback path (if any) was triggered.
+
+**Emoji reservation rule (closely related)**: The three confidence symbols `📊 🔍 💡` are RESERVED for confidence labeling. NEVER use them as decorative prefixes on section headers, table headers, or any aggregate element — even when you also include a correct confidence suffix on the same line. Example:
+- ❌ WRONG: `## 📊 Overall Score — 27/100 · Grade F 🔍` (the leading 📊 reads as a data-backed claim even though the trailing 🔍 is correct)
+- ✅ RIGHT: `## Overall Score — 27/100 · Grade F 🔍` (no decorative emoji, just the proper confidence suffix)
+- ✅ RIGHT: `## 🎯 Overall Score — 27/100 · Grade F 🔍` (use non-reserved decorative icons like 🎯 🧭 📋 📝 📂 🏁 🚨 🏆 🔔 when a visual prefix is desired)
+
+Decorative emoji ≠ confidence label — but from a reader's perspective, a leading `📊/🔍/💡` is indistinguishable from a confidence claim. Reserve these three symbols EXCLUSIVELY for confidence annotation to avoid ambiguity.
 
 ### Data Provenance (required)
 

--- a/amazon-opportunity-discoverer/scripts/apiclaw.py
+++ b/amazon-opportunity-discoverer/scripts/apiclaw.py
@@ -1,29 +1,8 @@
 #!/usr/bin/env python3
 # ============================================================
-# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
-# Source of truth: apiclaw/scripts/apiclaw.py
-#
-# Sync is enforced at THREE layers — understand all three before editing:
-#
-#   1. Local pre-commit hook (scripts/pre-commit)
-#      When this file is staged, auto-runs sync-scripts.sh and stages the
-#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
-#
-#   2. Sync script (scripts/sync-scripts.sh)
-#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
-#      any copy that differs without an "AUTO-SYNCED" marker (safety against
-#      destroying manual edits). If you hit a CONFLICT, inspect the diff
-#      first, then either (a) merge the manual edit back into canonical, or
-#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
-#
-#   3. CI check (.github/workflows/shared-files-distribution.yml)
-#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
-#      `diff` against canonical. Mismatched copies fail the PR hard with an
-#      "::error::" annotation — no merge until all 9 copies are identical.
-#
-# If you inherit a repo where copies drift without markers, resolve once by:
-#   bash scripts/sync-scripts.sh   # lists CONFLICTs
-#   # then add the AUTO-SYNCED marker to each copy and re-run
+# Canonical source - do not edit copies under amazon-* skill directories directly
+# Source location: apiclaw/scripts/apiclaw.py
+# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API

--- a/amazon-opportunity-discoverer/scripts/apiclaw.py
+++ b/amazon-opportunity-discoverer/scripts/apiclaw.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python3
 # ============================================================
-# Canonical source - do not edit copies under amazon-* skill directories directly
-# Source location: apiclaw/scripts/apiclaw.py
-# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
+# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
+# Source of truth: apiclaw/scripts/apiclaw.py
+#
+# Sync is enforced at THREE layers — understand all three before editing:
+#
+#   1. Local pre-commit hook (scripts/pre-commit)
+#      When this file is staged, auto-runs sync-scripts.sh and stages the
+#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
+#
+#   2. Sync script (scripts/sync-scripts.sh)
+#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
+#      any copy that differs without an "AUTO-SYNCED" marker (safety against
+#      destroying manual edits). If you hit a CONFLICT, inspect the diff
+#      first, then either (a) merge the manual edit back into canonical, or
+#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
+#
+#   3. CI check (.github/workflows/shared-files-distribution.yml)
+#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
+#      `diff` against canonical. Mismatched copies fail the PR hard with an
+#      "::error::" annotation — no merge until all 9 copies are identical.
+#
+# If you inherit a repo where copies drift without markers, resolve once by:
+#   bash scripts/sync-scripts.sh   # lists CONFLICTs
+#   # then add the AUTO-SYNCED marker to each copy and re-run
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
@@ -376,6 +397,315 @@ def parse_category(cat_str: str) -> list:
     if ">" in cat_str:
         return [c.strip() for c in cat_str.split(">")]
     return [c.strip() for c in cat_str.split(",")]
+
+
+# ─── Review Analysis: Prompt-as-Data Toolkit ───────────────────────────────
+# Used when /reviews/analysis lacks aggregation (ASIN has <50 reviews or no
+# daily snapshot). This module does NOT call any external LLM — it provides
+# raw data, rendered prompts, and a final aggregator. The calling skill's own
+# LLM performs the Map (per-review tagging) and Reduce (semantic clustering)
+# steps, producing JSON that feeds back into `review-aggregate`.
+#
+# Caller flow:
+#   1. apiclaw.py reviews-raw --asin X          → fetch raw reviews
+#   2. For each review, render via:
+#        apiclaw.py review-tag-prompt --review '<json>'
+#      The caller's LLM produces JSON matching REVIEW_MAP_SCHEMA.
+#   3. Collect per-dimension candidate phrases; for each dimension render:
+#        apiclaw.py review-reduce-prompt --label-type <dim> --candidates '[...]'
+#      The caller's LLM produces JSON matching REVIEW_REDUCE_SCHEMA.
+#   4. apiclaw.py review-aggregate --reviews R --tagged T --clusters C
+#      → emits consumerInsights compatible with /reviews/analysis.
+
+REVIEW_MAP_CONCURRENCY = 20           # suggested map parallelism for caller
+REVIEW_REDUCE_KEYWORDS_CHUNK = 150    # suggested chunk size when keywords dim is large
+REALTIME_REVIEWS_MAX_PAGES = 10       # API hard cap = 100 reviews (10 pages × 10)
+
+DIM_TO_LABELTYPE = {
+    "mentioned_scenarios": "scenarios",
+    "mentioned_issues": "issues",
+    "mentioned_positives": "positives",
+    "mentioned_improvements": "improvements",
+    "mentioned_buying_factors": "buyingFactors",
+    "mentioned_pain_points": "painPoints",
+    "user_profiles": "userProfiles",
+    "mentioned_usage_times": "usageTimes",
+    "mentioned_usage_locations": "usageLocations",
+    "mentioned_behaviors": "behaviors",
+    "keywords": "keywords",
+}
+
+_MAP_ARRAY_FIELDS = list(DIM_TO_LABELTYPE.keys())
+
+REVIEW_MAP_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "sentiment": {"type": "STRING", "enum": ["positive", "neutral", "negative"]},
+        **{k: {"type": "ARRAY", "items": {"type": "STRING"}} for k in _MAP_ARRAY_FIELDS},
+    },
+    "required": ["sentiment"] + _MAP_ARRAY_FIELDS,
+}
+
+REVIEW_REDUCE_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "clusters": {
+            "type": "ARRAY",
+            "items": {
+                "type": "OBJECT",
+                "properties": {
+                    "canonical": {"type": "STRING"},
+                    "members": {"type": "ARRAY", "items": {"type": "STRING"}},
+                },
+                "required": ["canonical", "members"],
+            },
+        },
+    },
+    "required": ["clusters"],
+}
+
+
+def render_review_map_prompt(review: dict, product_title: str = "", product_category: str = "") -> str:
+    title = review.get("title") or ""
+    body = review.get("body") or ""
+    full = f"{title}. {body}" if title else body
+    text = full[:500]
+    rating = review.get("rating") or 3
+    verified = bool(review.get("verifiedPurchase"))
+    return f"""IMPORTANT: Respond ONLY with a JSON object matching the schema below. Output must be in English — translate non-English text before extracting.
+
+You are an expert data extraction specialist analyzing product reviews. Extract only what is EXPLICITLY mentioned — do not infer.
+
+JSON schema:
+{{
+  "sentiment": "positive" | "neutral" | "negative",
+  "mentioned_scenarios": [string],      // max 5 noun phrases 1-3 words (Workouts, Gaming)
+  "mentioned_issues": [string],         // max 5 Adjective+Noun for PRODUCT DEFECTS (Poor Sound Quality)
+  "mentioned_positives": [string],      // max 5 Adjective+Noun for praised aspects (Comfortable Fit)
+  "mentioned_improvements": [string],   // max 3 Verb+Noun explicit suggestions (Extend Battery Life)
+  "mentioned_buying_factors": [string], // max 3 noun phrases for purchase reasons (Price Point)
+  "mentioned_pain_points": [string],    // max 3 UX frustrations EXPERIENCED AFTER USE (see rule)
+  "user_profiles": [string],            // max 3 identities stated EXPLICITLY (see rule)
+  "mentioned_usage_times": [string],    // max 3 time/season phrases (Morning, Winter)
+  "mentioned_usage_locations": [string],// max 3 location phrases (Gym, Home)
+  "mentioned_behaviors": [string],      // max 5 Verb+Object (Taking Calls, Running)
+  "keywords": [string]                  // 3-15 salient words from the review
+}}
+
+Rules:
+- sentiment: positive (4-5 stars or praise), neutral (3 stars / mixed), negative (1-2 stars or complaint)
+- pain_points = problems EXPERIENCED AFTER USE. NOT problems the product solves. If the reviewer says the product solved a prior problem (e.g. "cured my foot pain"), that belongs in positives, NOT pain_points.
+- issues vs pain_points: issues = product defects (hardware/software fault); pain_points = UX frustrations
+- user_profiles: include ONLY if the reviewer explicitly states an identity ("I'm a...", "As a..."). NEVER infer.
+- consistent naming across reviews (e.g. always "Workouts", not "At the gym")
+- use empty arrays [] for categories with no mentions, never null
+
+INPUT:
+Product Category: {product_category or '(unknown)'}
+Product Title: {product_title or '(unknown)'}
+Review Rating: {rating}/5 stars
+Verified Purchase: {'Yes' if verified else 'No'}
+Review Text:
+\"\"\"{text}\"\"\"
+
+Return ONLY the JSON object."""
+
+
+def render_review_reduce_prompt(label_type: str, candidates: list) -> str:
+    return f"""Normalize product-review tags. Group semantically equivalent phrases into clusters and pick a concise Title-Case canonical name (1-3 words) for each cluster.
+
+Label type: {label_type}
+
+Rules:
+- A cluster contains phrases describing the SAME underlying concept.
+- Every input phrase MUST appear in exactly one cluster's `members`. No drops, no duplicates across clusters.
+- Phrases with no semantic neighbors go in their own single-member cluster (still Title-Case canonical).
+- Case-insensitive matching. Preserve input phrase strings verbatim in `members`.
+
+Return a JSON object matching:
+{{"clusters": [{{"canonical": "Title Case", "members": ["phrase1", "phrase2"]}}]}}
+
+Input phrases:
+{json.dumps(candidates, ensure_ascii=False)}"""
+
+
+def fetch_realtime_reviews_all(asin: str, marketplace: str = "US",
+                                max_pages: int = REALTIME_REVIEWS_MAX_PAGES,
+                                log_fn=None) -> dict:
+    """Paginate /realtime/reviews with cursor; stop on null cursor or max_pages."""
+    log = log_fn or (lambda m: None)
+    reviews = []
+    cursor = None
+    pages = 0
+    t0 = time.time()
+    for i in range(1, max_pages + 1):
+        params = {"asin": asin, "marketplace": marketplace}
+        if cursor:
+            params["cursor"] = cursor
+        resp = api_call("realtime/reviews", params)
+        if not resp.get("success"):
+            break
+        data = resp.get("data") or {}
+        page_reviews = data.get("reviews") or []
+        cursor = data.get("nextCursor")
+        pages += 1
+        reviews.extend(page_reviews)
+        log(f"  page {i}: {len(page_reviews)} reviews, cursor={'yes' if cursor else 'end'}")
+        if not cursor:
+            break
+    return {
+        "reviews": reviews,
+        "pages": pages,
+        "capped": pages >= max_pages and cursor is not None,
+        "fetchSeconds": round(time.time() - t0, 2),
+    }
+
+
+def aggregate_review_insights(reviews: list, tagged: list, clusters_per_dim: dict) -> dict:
+    """Combine raw reviews + per-review Map tags + per-dimension Reduce clusters
+    into a reviews/analysis-compatible aggregation. No LLM calls."""
+    from collections import defaultdict
+
+    if len(tagged) != len(reviews):
+        raise ValueError(f"tagged length ({len(tagged)}) != reviews length ({len(reviews)})")
+
+    total = len(reviews)
+    ratings = [r.get("rating") or 0 for r in reviews]
+
+    dim_phrase_reviews = {k: defaultdict(set) for k in DIM_TO_LABELTYPE}
+    for i, tags in enumerate(tagged):
+        if not isinstance(tags, dict):
+            continue
+        for dim in DIM_TO_LABELTYPE:
+            for el in (tags.get(dim) or []):
+                if not isinstance(el, str):
+                    continue
+                kl = el.strip().lower()
+                if kl:
+                    dim_phrase_reviews[dim][kl].add(i)
+
+    insights = []
+    for dim, phrases in dim_phrase_reviews.items():
+        if not phrases:
+            continue
+        p2c = {}
+        for cl in (clusters_per_dim.get(dim) or []):
+            canon = (cl.get("canonical") or "").strip()
+            if not canon:
+                continue
+            for m in (cl.get("members") or []):
+                if not isinstance(m, str):
+                    continue
+                ml = m.strip().lower()
+                if ml and ml not in p2c:
+                    p2c[ml] = canon
+        for ph in phrases:
+            p2c.setdefault(ph, ph.title())
+
+        canon_to_reviews = defaultdict(set)
+        for phrase, rs in phrases.items():
+            canon_to_reviews[p2c[phrase]].update(rs)
+
+        lt = DIM_TO_LABELTYPE[dim]
+        for canon, rs in canon_to_reviews.items():
+            c = len(rs)
+            avg = sum(ratings[i] for i in rs) / c if c else 0.0
+            insights.append({
+                "element": canon,
+                "labelType": lt,
+                "count": c,
+                "reviewRate": round(c / total, 4),
+                "avgRating": round(avg, 2),
+            })
+    insights.sort(key=lambda x: (x["labelType"], -x["count"]))
+
+    sentiments = [(t or {}).get("sentiment") for t in tagged]
+    sentiment_dist = {
+        "positive": round(sum(1 for s in sentiments if s == "positive") / total, 4) if total else 0,
+        "neutral": round(sum(1 for s in sentiments if s == "neutral") / total, 4) if total else 0,
+        "negative": round(sum(1 for s in sentiments if s == "negative") / total, 4) if total else 0,
+    }
+    avg_rating = round(sum(ratings) / total, 2) if total else 0.0
+
+    return {
+        "success": True,
+        "data": {
+            "reviewCount": total,
+            "avgRating": avg_rating,
+            "sentimentDistribution": sentiment_dist,
+            "consumerInsights": insights,
+            "topKeywords": [
+                {"element": it["element"], "count": it["count"]}
+                for it in insights if it["labelType"] == "keywords"
+            ][:20],
+        },
+        "_meta": {"source": "prompt-as-data-aggregation", "tagsApplied": total},
+    }
+
+
+def cmd_reviews_raw(args):
+    log_fn = (lambda m: print(m, file=sys.stderr)) if args.verbose else None
+    result = fetch_realtime_reviews_all(args.asin, args.marketplace, args.max_pages, log_fn=log_fn)
+    output({
+        "success": True,
+        "data": result,
+        "_query": {"endpoint": "realtime/reviews",
+                   "params": {"asin": args.asin, "marketplace": args.marketplace,
+                              "maxPages": args.max_pages}},
+    })
+
+
+def _load_json_arg(inline: str, path: str, name: str):
+    """Load JSON from --<name> inline arg or --<name>-file path."""
+    if inline and path:
+        print(f"ERROR: provide either --{name} or --{name}-file, not both", file=sys.stderr)
+        sys.exit(1)
+    if inline:
+        return json.loads(inline)
+    if path:
+        with open(path) as f:
+            return json.load(f)
+    print(f"ERROR: --{name} or --{name}-file is required", file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_review_tag_prompt(args):
+    review = _load_json_arg(args.review, args.review_file, "review")
+    prompt = render_review_map_prompt(
+        review,
+        product_title=args.product_title or "",
+        product_category=args.product_category or "",
+    )
+    print(prompt)
+
+
+def cmd_review_reduce_prompt(args):
+    candidates = _load_json_arg(args.candidates, args.candidates_file, "candidates")
+    if not isinstance(candidates, list):
+        print("ERROR: candidates must be a JSON array of strings", file=sys.stderr)
+        sys.exit(1)
+    prompt = render_review_reduce_prompt(args.label_type, candidates)
+    print(prompt)
+
+
+def cmd_review_aggregate(args):
+    with open(args.reviews) as f:
+        reviews_data = json.load(f)
+    if isinstance(reviews_data, dict):
+        reviews = (reviews_data.get("data") or {}).get("reviews") or reviews_data.get("reviews") or []
+    else:
+        reviews = reviews_data
+
+    with open(args.tagged) as f:
+        tagged = json.load(f)
+    with open(args.clusters) as f:
+        clusters_per_dim = json.load(f)
+
+    result = aggregate_review_insights(reviews, tagged, clusters_per_dim)
+    result["_query"] = {"endpoint": "realtime/reviews+local-aggregate",
+                        "params": {"reviews": args.reviews, "tagged": args.tagged,
+                                    "clusters": args.clusters}}
+    output(result)
 
 
 # ─── Subcommands ─────────────────────────────────────────────────────────────
@@ -2282,6 +2612,38 @@ Examples:
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
     p_rd.add_argument("--category", help="Category path")
     p_rd.set_defaults(func=cmd_review_deepdive)
+
+    # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
+    p_rr = sub.add_parser("reviews-raw", help="Fetch raw reviews from realtime/reviews (cap 100, early-exit on null cursor)", allow_abbrev=False)
+    p_rr.add_argument("--asin", required=True)
+    p_rr.add_argument("--marketplace", default="US", choices=["US", "UK"])
+    p_rr.add_argument("--max-pages", type=int, default=REALTIME_REVIEWS_MAX_PAGES,
+                      help=f"Max pages to fetch (10 reviews each, default {REALTIME_REVIEWS_MAX_PAGES})")
+    p_rr.add_argument("--verbose", action="store_true")
+    p_rr.set_defaults(func=cmd_reviews_raw)
+
+    # ── review-tag-prompt (render Map prompt for one review — caller's LLM runs it) ──
+    p_rtp = sub.add_parser("review-tag-prompt", help="Render the per-review Map prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rtp.add_argument("--review", help="Review object as JSON string")
+    p_rtp.add_argument("--review-file", help="Path to JSON file containing a single review object")
+    p_rtp.add_argument("--product-title", help="Optional product title context")
+    p_rtp.add_argument("--product-category", help="Optional product category context")
+    p_rtp.set_defaults(func=cmd_review_tag_prompt)
+
+    # ── review-reduce-prompt (render Reduce prompt for one dimension — caller's LLM runs it) ──
+    p_rrp = sub.add_parser("review-reduce-prompt", help="Render the per-dimension Reduce prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rrp.add_argument("--label-type", required=True,
+                       help="Dimension to cluster (scenarios, issues, positives, improvements, buyingFactors, painPoints, userProfiles, usageTimes, usageLocations, behaviors, keywords)")
+    p_rrp.add_argument("--candidates", help="Candidate phrases as JSON array string")
+    p_rrp.add_argument("--candidates-file", help="Path to JSON file containing candidate phrases array")
+    p_rrp.set_defaults(func=cmd_review_reduce_prompt)
+
+    # ── review-aggregate (build reviews/analysis-compatible output from tags + clusters) ──
+    p_rag = sub.add_parser("review-aggregate", help="Aggregate per-review tags + per-dim clusters into consumerInsights", allow_abbrev=False)
+    p_rag.add_argument("--reviews", required=True, help="Path to JSON from reviews-raw (or raw reviews array)")
+    p_rag.add_argument("--tagged", required=True, help="Path to JSON array of Map outputs (same order as reviews)")
+    p_rag.add_argument("--clusters", required=True, help="Path to JSON {dim_key: [{canonical, members}]} from Reduce")
+    p_rag.set_defaults(func=cmd_review_aggregate)
 
     # ── analyze (reviews) ──
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)

--- a/amazon-pricing-command-center/scripts/apiclaw.py
+++ b/amazon-pricing-command-center/scripts/apiclaw.py
@@ -1,29 +1,8 @@
 #!/usr/bin/env python3
 # ============================================================
-# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
-# Source of truth: apiclaw/scripts/apiclaw.py
-#
-# Sync is enforced at THREE layers — understand all three before editing:
-#
-#   1. Local pre-commit hook (scripts/pre-commit)
-#      When this file is staged, auto-runs sync-scripts.sh and stages the
-#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
-#
-#   2. Sync script (scripts/sync-scripts.sh)
-#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
-#      any copy that differs without an "AUTO-SYNCED" marker (safety against
-#      destroying manual edits). If you hit a CONFLICT, inspect the diff
-#      first, then either (a) merge the manual edit back into canonical, or
-#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
-#
-#   3. CI check (.github/workflows/shared-files-distribution.yml)
-#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
-#      `diff` against canonical. Mismatched copies fail the PR hard with an
-#      "::error::" annotation — no merge until all 9 copies are identical.
-#
-# If you inherit a repo where copies drift without markers, resolve once by:
-#   bash scripts/sync-scripts.sh   # lists CONFLICTs
-#   # then add the AUTO-SYNCED marker to each copy and re-run
+# Canonical source - do not edit copies under amazon-* skill directories directly
+# Source location: apiclaw/scripts/apiclaw.py
+# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API

--- a/amazon-pricing-command-center/scripts/apiclaw.py
+++ b/amazon-pricing-command-center/scripts/apiclaw.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python3
 # ============================================================
-# Canonical source - do not edit copies under amazon-* skill directories directly
-# Source location: apiclaw/scripts/apiclaw.py
-# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
+# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
+# Source of truth: apiclaw/scripts/apiclaw.py
+#
+# Sync is enforced at THREE layers — understand all three before editing:
+#
+#   1. Local pre-commit hook (scripts/pre-commit)
+#      When this file is staged, auto-runs sync-scripts.sh and stages the
+#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
+#
+#   2. Sync script (scripts/sync-scripts.sh)
+#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
+#      any copy that differs without an "AUTO-SYNCED" marker (safety against
+#      destroying manual edits). If you hit a CONFLICT, inspect the diff
+#      first, then either (a) merge the manual edit back into canonical, or
+#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
+#
+#   3. CI check (.github/workflows/shared-files-distribution.yml)
+#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
+#      `diff` against canonical. Mismatched copies fail the PR hard with an
+#      "::error::" annotation — no merge until all 9 copies are identical.
+#
+# If you inherit a repo where copies drift without markers, resolve once by:
+#   bash scripts/sync-scripts.sh   # lists CONFLICTs
+#   # then add the AUTO-SYNCED marker to each copy and re-run
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
@@ -376,6 +397,315 @@ def parse_category(cat_str: str) -> list:
     if ">" in cat_str:
         return [c.strip() for c in cat_str.split(">")]
     return [c.strip() for c in cat_str.split(",")]
+
+
+# ─── Review Analysis: Prompt-as-Data Toolkit ───────────────────────────────
+# Used when /reviews/analysis lacks aggregation (ASIN has <50 reviews or no
+# daily snapshot). This module does NOT call any external LLM — it provides
+# raw data, rendered prompts, and a final aggregator. The calling skill's own
+# LLM performs the Map (per-review tagging) and Reduce (semantic clustering)
+# steps, producing JSON that feeds back into `review-aggregate`.
+#
+# Caller flow:
+#   1. apiclaw.py reviews-raw --asin X          → fetch raw reviews
+#   2. For each review, render via:
+#        apiclaw.py review-tag-prompt --review '<json>'
+#      The caller's LLM produces JSON matching REVIEW_MAP_SCHEMA.
+#   3. Collect per-dimension candidate phrases; for each dimension render:
+#        apiclaw.py review-reduce-prompt --label-type <dim> --candidates '[...]'
+#      The caller's LLM produces JSON matching REVIEW_REDUCE_SCHEMA.
+#   4. apiclaw.py review-aggregate --reviews R --tagged T --clusters C
+#      → emits consumerInsights compatible with /reviews/analysis.
+
+REVIEW_MAP_CONCURRENCY = 20           # suggested map parallelism for caller
+REVIEW_REDUCE_KEYWORDS_CHUNK = 150    # suggested chunk size when keywords dim is large
+REALTIME_REVIEWS_MAX_PAGES = 10       # API hard cap = 100 reviews (10 pages × 10)
+
+DIM_TO_LABELTYPE = {
+    "mentioned_scenarios": "scenarios",
+    "mentioned_issues": "issues",
+    "mentioned_positives": "positives",
+    "mentioned_improvements": "improvements",
+    "mentioned_buying_factors": "buyingFactors",
+    "mentioned_pain_points": "painPoints",
+    "user_profiles": "userProfiles",
+    "mentioned_usage_times": "usageTimes",
+    "mentioned_usage_locations": "usageLocations",
+    "mentioned_behaviors": "behaviors",
+    "keywords": "keywords",
+}
+
+_MAP_ARRAY_FIELDS = list(DIM_TO_LABELTYPE.keys())
+
+REVIEW_MAP_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "sentiment": {"type": "STRING", "enum": ["positive", "neutral", "negative"]},
+        **{k: {"type": "ARRAY", "items": {"type": "STRING"}} for k in _MAP_ARRAY_FIELDS},
+    },
+    "required": ["sentiment"] + _MAP_ARRAY_FIELDS,
+}
+
+REVIEW_REDUCE_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "clusters": {
+            "type": "ARRAY",
+            "items": {
+                "type": "OBJECT",
+                "properties": {
+                    "canonical": {"type": "STRING"},
+                    "members": {"type": "ARRAY", "items": {"type": "STRING"}},
+                },
+                "required": ["canonical", "members"],
+            },
+        },
+    },
+    "required": ["clusters"],
+}
+
+
+def render_review_map_prompt(review: dict, product_title: str = "", product_category: str = "") -> str:
+    title = review.get("title") or ""
+    body = review.get("body") or ""
+    full = f"{title}. {body}" if title else body
+    text = full[:500]
+    rating = review.get("rating") or 3
+    verified = bool(review.get("verifiedPurchase"))
+    return f"""IMPORTANT: Respond ONLY with a JSON object matching the schema below. Output must be in English — translate non-English text before extracting.
+
+You are an expert data extraction specialist analyzing product reviews. Extract only what is EXPLICITLY mentioned — do not infer.
+
+JSON schema:
+{{
+  "sentiment": "positive" | "neutral" | "negative",
+  "mentioned_scenarios": [string],      // max 5 noun phrases 1-3 words (Workouts, Gaming)
+  "mentioned_issues": [string],         // max 5 Adjective+Noun for PRODUCT DEFECTS (Poor Sound Quality)
+  "mentioned_positives": [string],      // max 5 Adjective+Noun for praised aspects (Comfortable Fit)
+  "mentioned_improvements": [string],   // max 3 Verb+Noun explicit suggestions (Extend Battery Life)
+  "mentioned_buying_factors": [string], // max 3 noun phrases for purchase reasons (Price Point)
+  "mentioned_pain_points": [string],    // max 3 UX frustrations EXPERIENCED AFTER USE (see rule)
+  "user_profiles": [string],            // max 3 identities stated EXPLICITLY (see rule)
+  "mentioned_usage_times": [string],    // max 3 time/season phrases (Morning, Winter)
+  "mentioned_usage_locations": [string],// max 3 location phrases (Gym, Home)
+  "mentioned_behaviors": [string],      // max 5 Verb+Object (Taking Calls, Running)
+  "keywords": [string]                  // 3-15 salient words from the review
+}}
+
+Rules:
+- sentiment: positive (4-5 stars or praise), neutral (3 stars / mixed), negative (1-2 stars or complaint)
+- pain_points = problems EXPERIENCED AFTER USE. NOT problems the product solves. If the reviewer says the product solved a prior problem (e.g. "cured my foot pain"), that belongs in positives, NOT pain_points.
+- issues vs pain_points: issues = product defects (hardware/software fault); pain_points = UX frustrations
+- user_profiles: include ONLY if the reviewer explicitly states an identity ("I'm a...", "As a..."). NEVER infer.
+- consistent naming across reviews (e.g. always "Workouts", not "At the gym")
+- use empty arrays [] for categories with no mentions, never null
+
+INPUT:
+Product Category: {product_category or '(unknown)'}
+Product Title: {product_title or '(unknown)'}
+Review Rating: {rating}/5 stars
+Verified Purchase: {'Yes' if verified else 'No'}
+Review Text:
+\"\"\"{text}\"\"\"
+
+Return ONLY the JSON object."""
+
+
+def render_review_reduce_prompt(label_type: str, candidates: list) -> str:
+    return f"""Normalize product-review tags. Group semantically equivalent phrases into clusters and pick a concise Title-Case canonical name (1-3 words) for each cluster.
+
+Label type: {label_type}
+
+Rules:
+- A cluster contains phrases describing the SAME underlying concept.
+- Every input phrase MUST appear in exactly one cluster's `members`. No drops, no duplicates across clusters.
+- Phrases with no semantic neighbors go in their own single-member cluster (still Title-Case canonical).
+- Case-insensitive matching. Preserve input phrase strings verbatim in `members`.
+
+Return a JSON object matching:
+{{"clusters": [{{"canonical": "Title Case", "members": ["phrase1", "phrase2"]}}]}}
+
+Input phrases:
+{json.dumps(candidates, ensure_ascii=False)}"""
+
+
+def fetch_realtime_reviews_all(asin: str, marketplace: str = "US",
+                                max_pages: int = REALTIME_REVIEWS_MAX_PAGES,
+                                log_fn=None) -> dict:
+    """Paginate /realtime/reviews with cursor; stop on null cursor or max_pages."""
+    log = log_fn or (lambda m: None)
+    reviews = []
+    cursor = None
+    pages = 0
+    t0 = time.time()
+    for i in range(1, max_pages + 1):
+        params = {"asin": asin, "marketplace": marketplace}
+        if cursor:
+            params["cursor"] = cursor
+        resp = api_call("realtime/reviews", params)
+        if not resp.get("success"):
+            break
+        data = resp.get("data") or {}
+        page_reviews = data.get("reviews") or []
+        cursor = data.get("nextCursor")
+        pages += 1
+        reviews.extend(page_reviews)
+        log(f"  page {i}: {len(page_reviews)} reviews, cursor={'yes' if cursor else 'end'}")
+        if not cursor:
+            break
+    return {
+        "reviews": reviews,
+        "pages": pages,
+        "capped": pages >= max_pages and cursor is not None,
+        "fetchSeconds": round(time.time() - t0, 2),
+    }
+
+
+def aggregate_review_insights(reviews: list, tagged: list, clusters_per_dim: dict) -> dict:
+    """Combine raw reviews + per-review Map tags + per-dimension Reduce clusters
+    into a reviews/analysis-compatible aggregation. No LLM calls."""
+    from collections import defaultdict
+
+    if len(tagged) != len(reviews):
+        raise ValueError(f"tagged length ({len(tagged)}) != reviews length ({len(reviews)})")
+
+    total = len(reviews)
+    ratings = [r.get("rating") or 0 for r in reviews]
+
+    dim_phrase_reviews = {k: defaultdict(set) for k in DIM_TO_LABELTYPE}
+    for i, tags in enumerate(tagged):
+        if not isinstance(tags, dict):
+            continue
+        for dim in DIM_TO_LABELTYPE:
+            for el in (tags.get(dim) or []):
+                if not isinstance(el, str):
+                    continue
+                kl = el.strip().lower()
+                if kl:
+                    dim_phrase_reviews[dim][kl].add(i)
+
+    insights = []
+    for dim, phrases in dim_phrase_reviews.items():
+        if not phrases:
+            continue
+        p2c = {}
+        for cl in (clusters_per_dim.get(dim) or []):
+            canon = (cl.get("canonical") or "").strip()
+            if not canon:
+                continue
+            for m in (cl.get("members") or []):
+                if not isinstance(m, str):
+                    continue
+                ml = m.strip().lower()
+                if ml and ml not in p2c:
+                    p2c[ml] = canon
+        for ph in phrases:
+            p2c.setdefault(ph, ph.title())
+
+        canon_to_reviews = defaultdict(set)
+        for phrase, rs in phrases.items():
+            canon_to_reviews[p2c[phrase]].update(rs)
+
+        lt = DIM_TO_LABELTYPE[dim]
+        for canon, rs in canon_to_reviews.items():
+            c = len(rs)
+            avg = sum(ratings[i] for i in rs) / c if c else 0.0
+            insights.append({
+                "element": canon,
+                "labelType": lt,
+                "count": c,
+                "reviewRate": round(c / total, 4),
+                "avgRating": round(avg, 2),
+            })
+    insights.sort(key=lambda x: (x["labelType"], -x["count"]))
+
+    sentiments = [(t or {}).get("sentiment") for t in tagged]
+    sentiment_dist = {
+        "positive": round(sum(1 for s in sentiments if s == "positive") / total, 4) if total else 0,
+        "neutral": round(sum(1 for s in sentiments if s == "neutral") / total, 4) if total else 0,
+        "negative": round(sum(1 for s in sentiments if s == "negative") / total, 4) if total else 0,
+    }
+    avg_rating = round(sum(ratings) / total, 2) if total else 0.0
+
+    return {
+        "success": True,
+        "data": {
+            "reviewCount": total,
+            "avgRating": avg_rating,
+            "sentimentDistribution": sentiment_dist,
+            "consumerInsights": insights,
+            "topKeywords": [
+                {"element": it["element"], "count": it["count"]}
+                for it in insights if it["labelType"] == "keywords"
+            ][:20],
+        },
+        "_meta": {"source": "prompt-as-data-aggregation", "tagsApplied": total},
+    }
+
+
+def cmd_reviews_raw(args):
+    log_fn = (lambda m: print(m, file=sys.stderr)) if args.verbose else None
+    result = fetch_realtime_reviews_all(args.asin, args.marketplace, args.max_pages, log_fn=log_fn)
+    output({
+        "success": True,
+        "data": result,
+        "_query": {"endpoint": "realtime/reviews",
+                   "params": {"asin": args.asin, "marketplace": args.marketplace,
+                              "maxPages": args.max_pages}},
+    })
+
+
+def _load_json_arg(inline: str, path: str, name: str):
+    """Load JSON from --<name> inline arg or --<name>-file path."""
+    if inline and path:
+        print(f"ERROR: provide either --{name} or --{name}-file, not both", file=sys.stderr)
+        sys.exit(1)
+    if inline:
+        return json.loads(inline)
+    if path:
+        with open(path) as f:
+            return json.load(f)
+    print(f"ERROR: --{name} or --{name}-file is required", file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_review_tag_prompt(args):
+    review = _load_json_arg(args.review, args.review_file, "review")
+    prompt = render_review_map_prompt(
+        review,
+        product_title=args.product_title or "",
+        product_category=args.product_category or "",
+    )
+    print(prompt)
+
+
+def cmd_review_reduce_prompt(args):
+    candidates = _load_json_arg(args.candidates, args.candidates_file, "candidates")
+    if not isinstance(candidates, list):
+        print("ERROR: candidates must be a JSON array of strings", file=sys.stderr)
+        sys.exit(1)
+    prompt = render_review_reduce_prompt(args.label_type, candidates)
+    print(prompt)
+
+
+def cmd_review_aggregate(args):
+    with open(args.reviews) as f:
+        reviews_data = json.load(f)
+    if isinstance(reviews_data, dict):
+        reviews = (reviews_data.get("data") or {}).get("reviews") or reviews_data.get("reviews") or []
+    else:
+        reviews = reviews_data
+
+    with open(args.tagged) as f:
+        tagged = json.load(f)
+    with open(args.clusters) as f:
+        clusters_per_dim = json.load(f)
+
+    result = aggregate_review_insights(reviews, tagged, clusters_per_dim)
+    result["_query"] = {"endpoint": "realtime/reviews+local-aggregate",
+                        "params": {"reviews": args.reviews, "tagged": args.tagged,
+                                    "clusters": args.clusters}}
+    output(result)
 
 
 # ─── Subcommands ─────────────────────────────────────────────────────────────
@@ -2282,6 +2612,38 @@ Examples:
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
     p_rd.add_argument("--category", help="Category path")
     p_rd.set_defaults(func=cmd_review_deepdive)
+
+    # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
+    p_rr = sub.add_parser("reviews-raw", help="Fetch raw reviews from realtime/reviews (cap 100, early-exit on null cursor)", allow_abbrev=False)
+    p_rr.add_argument("--asin", required=True)
+    p_rr.add_argument("--marketplace", default="US", choices=["US", "UK"])
+    p_rr.add_argument("--max-pages", type=int, default=REALTIME_REVIEWS_MAX_PAGES,
+                      help=f"Max pages to fetch (10 reviews each, default {REALTIME_REVIEWS_MAX_PAGES})")
+    p_rr.add_argument("--verbose", action="store_true")
+    p_rr.set_defaults(func=cmd_reviews_raw)
+
+    # ── review-tag-prompt (render Map prompt for one review — caller's LLM runs it) ──
+    p_rtp = sub.add_parser("review-tag-prompt", help="Render the per-review Map prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rtp.add_argument("--review", help="Review object as JSON string")
+    p_rtp.add_argument("--review-file", help="Path to JSON file containing a single review object")
+    p_rtp.add_argument("--product-title", help="Optional product title context")
+    p_rtp.add_argument("--product-category", help="Optional product category context")
+    p_rtp.set_defaults(func=cmd_review_tag_prompt)
+
+    # ── review-reduce-prompt (render Reduce prompt for one dimension — caller's LLM runs it) ──
+    p_rrp = sub.add_parser("review-reduce-prompt", help="Render the per-dimension Reduce prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rrp.add_argument("--label-type", required=True,
+                       help="Dimension to cluster (scenarios, issues, positives, improvements, buyingFactors, painPoints, userProfiles, usageTimes, usageLocations, behaviors, keywords)")
+    p_rrp.add_argument("--candidates", help="Candidate phrases as JSON array string")
+    p_rrp.add_argument("--candidates-file", help="Path to JSON file containing candidate phrases array")
+    p_rrp.set_defaults(func=cmd_review_reduce_prompt)
+
+    # ── review-aggregate (build reviews/analysis-compatible output from tags + clusters) ──
+    p_rag = sub.add_parser("review-aggregate", help="Aggregate per-review tags + per-dim clusters into consumerInsights", allow_abbrev=False)
+    p_rag.add_argument("--reviews", required=True, help="Path to JSON from reviews-raw (or raw reviews array)")
+    p_rag.add_argument("--tagged", required=True, help="Path to JSON array of Map outputs (same order as reviews)")
+    p_rag.add_argument("--clusters", required=True, help="Path to JSON {dim_key: [{canonical, members}]} from Reduce")
+    p_rag.set_defaults(func=cmd_review_aggregate)
 
     # ── analyze (reviews) ──
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Amazon Review Intelligence Extractor — Consumer Insights from 1B+ Reviews
-version: 1.0.1
+version: 1.0.2
 description: >
   Deep consumer insights from 1B+ pre-analyzed Amazon reviews.
   Extracts pain points, buying factors, user profiles, usage patterns,
@@ -33,10 +33,14 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 - **Category-wide**: keyword/category name → resolve via `categories` first (need ≥3-level deep path)
 
 ## API Pitfalls (see apiclaw skill for full list)
-- `reviews/analysis` needs **50+ reviews** — fallback to `realtime/product` ratingBreakdown
+- `reviews/analysis` needs **50+ reviews**. Fallback chain when sample is insufficient:
+  1. **Lightweight**: `realtime/product` ratingBreakdown — only star distribution, no themes
+  2. **Full 11-dim insights**: see "Insufficient Data Fallback" section below — use the
+     local toolkit (`reviews-raw` + `review-tag-prompt` + `review-reduce-prompt` +
+     `review-aggregate`) to bypass `/reviews/analysis` entirely
 - **labelType** is NOT an API request parameter — the API returns all 11 dimensions in one call. Filter by `labelType` client-side from the `consumerInsights` array.
 - Category mode needs precise path (≥3 levels) — broad categories = diluted insights
-- Field name is `reviewRate` (not `reviewRate`) for mention frequency
+- Field name is `reviewRate` (NOT the legacy `reviewPercentage` from API v1) for mention frequency
 - ASIN-specific endpoints don't need `--category`; keyword-based ones do
 - **Category auto-detection**: categoryPath is auto-detected from target ASIN. If `category_source` in output is `inferred_from_search`, confirm with user
 
@@ -69,6 +73,15 @@ Rank differentiation opportunities by: **frequency × avg rating delta**
 
 **Differentiation Priority** = High frequency + Low avgRating = Biggest opportunity 🔍. If top 3 pain points all have reviewRate >5% and avgRating <3.0, there is a clear product improvement opportunity 💡. If all pain points have reviewRate <2%, the category is well-served — differentiation through reviews is limited 🔍.
 
+⚠️ **Small-sample caveat (N < 50)**: The reviewRate thresholds above assume ≥50 reviews. With smaller samples (e.g. fallback toolkit with 14 reviews), every single mention = 1/N which already crosses 5-10%. Rules to apply when `reviewCount < 50`:
+- Demote single-mention pain points / positives from 📊 to 🔍 (directional, not data-backed)
+- In the report, surface a "Sample-size advisory" banner above all percentage-based tables
+- Prefer reporting `count` alongside `reviewRate` so readers can judge weight themselves
+- Do NOT trigger "🔴 Critical / clear improvement opportunity" 💡 verdicts on counts of 1
+- **Never attach a table-level or section-header 📊 label** when ANY row inside is single-mention (🔍-demoted). A header 📊 implies the entire table is data-backed, which contradicts the per-row demotion rule and smuggles 🔍 data back into the 📊 tier via visual grouping. Either:
+  - (a) Omit the header-level confidence label entirely and let individual rows carry their own labels, OR
+  - (b) If the header must carry a label, use the LOWEST confidence present in any row (🔍 if any row is 🔍; 📊 only if EVERY row qualifies as 📊 on its own — i.e. all counts ≥ 2 when N<50)
+
 ### Consumer Profile Synthesis
 Combine `userProfiles` + `scenarios` + `usageTimes` + `usageLocations` → complete buyer persona.
 
@@ -83,10 +96,196 @@ Align dimensions (pain points vs pain points) across products. If competitor rev
 
 ## Composite Command
 ```bash
-python3 {skill_base_dir}/scripts/apiclaw.py review-deepdive --target-asin "{asin}" [--keyword "{kw}"] [--category "{path}"]
+python3 {skill_base_dir}/scripts/apiclaw.py review-deepdive --target-asin "<ASIN>" [--keyword "<kw>"] [--category "<path>"]
 ```
-Optional: `--comp-asins "{asin1},{asin2}"` for comparison.
+Optional: `--comp-asins "<asin1>,<asin2>"` for comparison.
 Runs: reviews × 11 dimensions + competitors + realtime + market context + price/trend.
+(`<placeholders>` are LITERAL — replace with actual values, no curly braces in commands.)
+
+### Detecting when to fall back
+
+After `review-deepdive` runs, programmatically inspect its JSON output for sparse
+review aggregation. The composite continues past review failures, so success is NOT
+proof of usable insights. Detection rule:
+
+```python
+import json
+deepdive = json.load(open("deepdive.json"))
+reviews_section = deepdive.get("reviews", {})
+# review-deepdive currently makes one /reviews/analysis call per labelType (target_painPoints,
+# target_positives, etc.). All-fail means switch to fallback.
+all_failed = all(
+    sub.get("success") is False
+    or not (sub.get("data") or {}).get("consumerInsights")
+    for sub in reviews_section.values()
+    if isinstance(sub, dict)
+)
+target_review_count = (deepdive.get("target_realtime", {}) or {}).get("data", {}).get("ratingCount", 0)
+# Fallback triggers if ANY of these are true:
+needs_fallback = (
+    all_failed
+    or target_review_count < 50
+    or any((sub.get("error") or {}).get("code") == "INSUFFICIENT_REVIEWS"
+           for sub in reviews_section.values() if isinstance(sub, dict))
+)
+```
+
+If `needs_fallback` is True, run the "Insufficient Data Fallback" workflow below.
+**Important**: the fallback REPLACES ONLY the review-analysis piece. Keep using the
+deepdive's other outputs (`target_realtime`, `competitors`, `market`, `brand_overview`,
+`price_band_overview`, `product_history`) for the corresponding report sections.
+
+## Insufficient Data Fallback
+
+When `/reviews/analysis` cannot produce meaningful aggregation, fetch raw reviews live
+from Amazon and use this skill's own LLM (you) to perform Map/Reduce in-context. No
+external LLM service or API key is required.
+
+**Working directory convention**: create a per-run temp dir to keep intermediate files
+together. Recommended: `/tmp/review_<ASIN>_<TIMESTAMP>/` containing `raw.json`,
+`tagged.json`, `clusters.json`, `insights.json`. Example:
+```bash
+WORK=/tmp/review_B0XXXXXXXX_$(date +%s) && mkdir -p $WORK
+```
+
+### Step 1 — Fetch raw reviews
+
+```bash
+python3 {skill_base_dir}/scripts/apiclaw.py reviews-raw \
+    --asin <ASIN> [--marketplace US] [--max-pages 10] > $WORK/raw.json
+# Cost: 1 credit/page, 10 reviews/page, hard cap 100 (10 pages).
+# Stops automatically when nextCursor=null (small-volume ASINs may exhaust earlier).
+# For cost control: --max-pages 5 = 50 reviews / 5 credits / ~30s.
+```
+
+Then save just the reviews array for downstream tooling:
+```bash
+python3 -c "import json,sys; d=json.load(open('$WORK/raw.json'))['data']['reviews']; json.dump(d,open('$WORK/reviews_array.json','w'),ensure_ascii=False)"
+```
+
+### Step 2 — Map (per-review tagging)
+
+`review-tag-prompt` renders the prompt **but does NOT call any LLM** — YOU (this skill's
+LLM) produce the JSON. The template is uniform per review, so render it ONCE to learn
+the schema, then mass-produce tags for all reviews in a single in-context pass.
+
+```bash
+# Render the prompt for ONE review to learn the schema (do this once per skill run)
+python3 {skill_base_dir}/scripts/apiclaw.py review-tag-prompt \
+    --review "$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1]))[0]))' $WORK/reviews_array.json)" \
+    [--product-title "..."] [--product-category "..."]
+```
+
+The schema you must produce per review (12 fields, all required, empty arrays for empties):
+```json
+{
+  "sentiment": "positive|neutral|negative",
+  "mentioned_scenarios": [], "mentioned_issues": [], "mentioned_positives": [],
+  "mentioned_improvements": [], "mentioned_buying_factors": [],
+  "mentioned_pain_points": [], "user_profiles": [],
+  "mentioned_usage_times": [], "mentioned_usage_locations": [],
+  "mentioned_behaviors": [], "keywords": []
+}
+```
+
+After producing tags for all N reviews, save them as a JSON array preserving review order:
+```bash
+# Save your in-context output as the array (example structure)
+cat > $WORK/tagged.json <<'EOF'
+[ {tag obj for review[0]}, {tag obj for review[1]}, ... ]
+EOF
+```
+
+### Step 3 — Reduce (semantic clustering per dimension)
+
+First extract unique candidate phrases per dimension from `tagged.json`:
+
+```python
+import json
+from collections import defaultdict
+tagged = json.load(open(f"{WORK}/tagged.json"))
+DIMS = ["mentioned_scenarios","mentioned_issues","mentioned_positives",
+        "mentioned_improvements","mentioned_buying_factors","mentioned_pain_points",
+        "user_profiles","mentioned_usage_times","mentioned_usage_locations",
+        "mentioned_behaviors","keywords"]
+candidates = {d: sorted({el.strip().lower() for t in tagged for el in (t.get(d) or [])}) for d in DIMS}
+```
+
+Then for EACH of the 11 dimensions, render the reduce prompt and YOU produce clusters:
+
+```bash
+python3 {skill_base_dir}/scripts/apiclaw.py review-reduce-prompt \
+    --label-type positives \
+    --candidates '["comfortable","comfy","very comfortable",...]'
+# → YOU produce {"clusters": [{"canonical": "Comfortable Fit",
+#                              "members": ["comfortable","comfy","very comfortable"]}]}
+```
+
+Assemble all 11 dimension cluster outputs into one `clusters.json`:
+```json
+{
+  "mentioned_scenarios": [{"canonical": "...", "members": [...]}],
+  "mentioned_issues":    [{"canonical": "...", "members": [...]}],
+  ... (all 11 dims, even if empty: use [])
+}
+```
+
+**Keywords dim chunking**: when `keywords` has >150 unique candidates, split into
+chunks of ~150, render the reduce prompt per chunk, and merge clusters across chunks
+by case-insensitive canonical name match. Other dims rarely exceed 100 candidates.
+
+### Step 4 — Aggregate (no LLM, pure local)
+
+```bash
+python3 {skill_base_dir}/scripts/apiclaw.py review-aggregate \
+    --reviews $WORK/raw.json \
+    --tagged $WORK/tagged.json \
+    --clusters $WORK/clusters.json > $WORK/insights.json
+# Output structure matches /reviews/analysis:
+#   { reviewCount, avgRating, sentimentDistribution, consumerInsights[], topKeywords[] }
+# Each consumerInsight has: {element, labelType, count, reviewRate, avgRating}
+```
+
+Use the same Pain Point Impact Ranking and Differentiation Priority tables above —
+**but apply the small-sample caveat** when `reviewCount < 50`.
+
+### Quality flags to surface in the final report
+
+When generating the report from a fallback run, the Data Provenance section MUST flag:
+
+1. **Sample-size warning** — if `reviewCount < 50`, banner above all rate-based tables.
+2. **Suspicious review patterns** — scan `raw.json` for clusters of:
+   - Same date + ≥3 unverified reviews + similar themes (potential seeded reviews)
+   - Same author across multiple ASINs (review farm signal)
+   Report these as "🔍 Possible seeded reviews" in Data Provenance.
+3. **Spider exhaustion** — if `pages < max_pages` and `capped == false`, note that
+   Spider exhausted the visible review window before reaching the 100-cap.
+
+### Competitor Comparison in fallback mode
+
+The default fallback workflow only fetches reviews for the TARGET ASIN.
+SKILL.md's "Competitor Comparison" rules (your-rate vs competitor-rate) require
+competitor review data, which is NOT available by default in fallback. Two options:
+
+- **Option A (default)**: in the report's Competitor Comparison section, note
+  "Pain-rate comparison unavailable in fallback mode — competitor review aggregations
+  not fetched". Use only structural comparison (rating, ratingCount, price).
+- **Option B (extension)**: for each top-3 competitor ASIN from the deepdive's
+  `competitors` output, run Steps 1-4 again per ASIN. Cost: ~10 credits per
+  competitor + LLM time. Only do this when the user explicitly asks for sentiment
+  comparison.
+
+### Cost / latency benchmark
+
+| Sample size | Fetch | LLM Map+Reduce | Aggregate | Total |
+|-------------|-------|----------------|-----------|-------|
+| 100 reviews | ~60s + 10 credits | model-dependent (suggest ≤20 concurrent) | <1s | ~90-120s |
+| 50 reviews | ~30s + 5 credits | ~half | <1s | ~60s |
+| 14 reviews (validated) | ~20s + 2 credits | inline single pass | <1s | ~30s |
+
+**Quality vs `/reviews/analysis`**: comparable 11-dim coverage; finer sizing-direction
+splits (small vs large vs inaccurate) than server-side aggregation; properly
+distinguishes `painPoints` (problems experienced) from `positives` (problems solved).
 
 ## Output
 Respond in user's language.
@@ -94,7 +293,16 @@ Respond in user's language.
 Sections: Review Snapshot → Top 10 Pain Points (with count & %) → Top 10 Positives → Buying Factors → Improvement Wishlist → Consumer Profile → Usage Patterns → Competitor Comparison → Listing Copy Suggestions → Differentiation Roadmap (impact-ranked) → Data Provenance → API Usage
 
 Do NOT invent insights — only report what the API returns. Omit empty dimensions.
-Cross-validate: star distribution (ratingBreakdown) should match sentiment (reviews/analysis).
+
+**Cross-validation rule** (mandatory): star distribution (`ratingBreakdown`) should match
+sentiment distribution (from `reviews/analysis` OR fallback Map tags). Compute:
+- 4-5★ % vs `positive` %
+- 3★ % vs `neutral` %
+- 1-2★ % vs `negative` %
+
+If any band mismatches by >15 percentage points, **re-examine the Map tags before
+publishing**. Common causes: LLM mis-classifying a 5★ "didn't love it but works" as
+positive; non-English reviews mis-tagged. Document residual mismatch in Data Provenance.
 
 ### Language (required)
 
@@ -111,6 +319,22 @@ Output language MUST match the user's input language. If the user asks in Chines
 - 💡 **Directional** — suggestions, predictions, strategy (e.g. "highlight durability in bullet point #1 💡")
 
 Rules: Strategy recommendations and listing copy suggestions are NEVER 📊. User criteria override AI judgment.
+
+**Aggregate-label rule (applies to ALL report output, not just fallback)**: NEVER attach 📊 to ANY element that aggregates or groups underlying content when ANY piece of that content is 🔍 or 💡. "Aggregate/grouping elements" include:
+- Section headers at EVERY level (`#`, `##`, `###`, `####`) — including top-level summary sections like "Overall Score", "Verdict", "Executive Summary"
+- Summary/score lines anywhere in the report (e.g. `## Overall Score — 27/100 · Grade F 📊` is WRONG if any Basis row inside is 🔍)
+- Table **column** headers in comparison tables (e.g. `**Target ASIN** 📊` as a column label is WRONG if any cell in that column contains 🔍)
+- Table row headers or row-aggregation labels (when the row aggregates multiple cells of mixed confidence)
+- Any other visual grouping label — bullet-list group titles, callout box titles, etc.
+
+A group-level 📊 implies the whole block/column/row is data-backed, which smuggles inferred/directional content into the 📊 tier via visual grouping. Either (a) **omit the group-level label entirely** (preferred when content mixes tiers), or (b) use the LOWEST confidence present inside (🔍 if any underlying content is 🔍; 💡 if any is 💡). This is a universal output-quality rule — it applies regardless of which fallback path (if any) was triggered.
+
+**Emoji reservation rule (closely related)**: The three confidence symbols `📊 🔍 💡` are RESERVED for confidence labeling. NEVER use them as decorative prefixes on section headers, table headers, or any aggregate element — even when you also include a correct confidence suffix on the same line. Example:
+- ❌ WRONG: `## 📊 Overall Score — 27/100 · Grade F 🔍` (the leading 📊 reads as a data-backed claim even though the trailing 🔍 is correct)
+- ✅ RIGHT: `## Overall Score — 27/100 · Grade F 🔍` (no decorative emoji, just the proper confidence suffix)
+- ✅ RIGHT: `## 🎯 Overall Score — 27/100 · Grade F 🔍` (use non-reserved decorative icons like 🎯 🧭 📋 📝 📂 🏁 🚨 🏆 🔔 when a visual prefix is desired)
+
+Decorative emoji ≠ confidence label — but from a reader's perspective, a leading `📊/🔍/💡` is indistinguishable from a confidence claim. Reserve these three symbols EXCLUSIVELY for confidence annotation to avoid ambiguity.
 
 ### Data Provenance (required)
 

--- a/amazon-review-intelligence-extractor/references/reference.md
+++ b/amazon-review-intelligence-extractor/references/reference.md
@@ -160,6 +160,55 @@ Request params: `keyword`, `brand`, `asin`, `categoryPath`, `sortBy`, `pageSize`
 
 ---
 
+## 6b. realtime/reviews + Local Toolkit (fallback for `/reviews/analysis`)
+
+When `/reviews/analysis` lacks aggregation (ASIN <50 reviews, or no daily snapshot),
+use this endpoint + the local Map/Reduce toolkit to produce a compatible
+`consumerInsights` structure.
+
+**Request:**
+- `asin`: String (10 chars, required)
+- `marketplace`: String (US/UK only, default US)
+- `cursor`: String (omit for first page; use previous response's `nextCursor`)
+
+⚠️ Fixed 10 reviews/page; max 10 pages = **100 reviews** hard cap. 1 credit/page.
+
+**Response:**
+- `asin`, `reviews[]` (RealtimeReview), `nextCursor` (null = end)
+
+**RealtimeReview:** `reviewId`, `title`, `body`, `bodyHtml`, `rating`, `author`, `date` (ISO 8601), `verifiedPurchase`, `vineProgram`, `helpfulVoteCount`, `unhelpfulVoteCount`, `reviewCountry`, `images`, `link`, `isGlobalReview`
+
+### Local Toolkit Workflow
+
+```
+apiclaw.py reviews-raw          → fetch raw reviews (one HTTP call per page, auto-paginates)
+apiclaw.py review-tag-prompt    → render Map prompt for one review (caller's LLM tags it)
+apiclaw.py review-reduce-prompt → render Reduce prompt for one dimension (caller's LLM clusters)
+apiclaw.py review-aggregate     → combine raw + tags + clusters → consumerInsights output
+```
+
+The aggregator output matches `/reviews/analysis` structure exactly:
+`{reviewCount, avgRating, sentimentDistribution, consumerInsights[InsightItem], topKeywords[]}`.
+
+See SKILL.md "Insufficient Data Fallback" section for full step-by-step usage.
+
+---
+
+## 6c. reviews/search
+
+**Request:**
+- `asin`: String (required)
+- Optional filters: `ratingMin`/`ratingMax` (1-5), `verifiedOnly`, `vineOnly`, `helpfulVoteCountMin`, `dateStart`/`dateEnd` (YYYY-MM-DD)
+- `sortBy`: `recent` (default) / `rating` / `helpfulVoteCount`
+- `sortOrder`: `desc` (default) / `asc`
+- `page` / `pageSize`: 1-indexed, pageSize 1-20 default 10
+
+**Response:** Array of `TaggedReview` (RealtimeReview fields + `tags[{labelType, element}]` AI tags from offline pipeline).
+
+Differs from `realtime/reviews`: BigQuery snapshot (T+1 delay) but already AI-tagged.
+
+---
+
 ## 7. products/price-band-overview
 
 **Request:** Same params as products/search (keyword, category, filters)

--- a/amazon-review-intelligence-extractor/scripts/apiclaw.py
+++ b/amazon-review-intelligence-extractor/scripts/apiclaw.py
@@ -1,29 +1,8 @@
 #!/usr/bin/env python3
 # ============================================================
-# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
-# Source of truth: apiclaw/scripts/apiclaw.py
-#
-# Sync is enforced at THREE layers — understand all three before editing:
-#
-#   1. Local pre-commit hook (scripts/pre-commit)
-#      When this file is staged, auto-runs sync-scripts.sh and stages the
-#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
-#
-#   2. Sync script (scripts/sync-scripts.sh)
-#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
-#      any copy that differs without an "AUTO-SYNCED" marker (safety against
-#      destroying manual edits). If you hit a CONFLICT, inspect the diff
-#      first, then either (a) merge the manual edit back into canonical, or
-#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
-#
-#   3. CI check (.github/workflows/shared-files-distribution.yml)
-#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
-#      `diff` against canonical. Mismatched copies fail the PR hard with an
-#      "::error::" annotation — no merge until all 9 copies are identical.
-#
-# If you inherit a repo where copies drift without markers, resolve once by:
-#   bash scripts/sync-scripts.sh   # lists CONFLICTs
-#   # then add the AUTO-SYNCED marker to each copy and re-run
+# Canonical source - do not edit copies under amazon-* skill directories directly
+# Source location: apiclaw/scripts/apiclaw.py
+# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API

--- a/amazon-review-intelligence-extractor/scripts/apiclaw.py
+++ b/amazon-review-intelligence-extractor/scripts/apiclaw.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python3
 # ============================================================
-# Canonical source - do not edit copies under amazon-* skill directories directly
-# Source location: apiclaw/scripts/apiclaw.py
-# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
+# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
+# Source of truth: apiclaw/scripts/apiclaw.py
+#
+# Sync is enforced at THREE layers — understand all three before editing:
+#
+#   1. Local pre-commit hook (scripts/pre-commit)
+#      When this file is staged, auto-runs sync-scripts.sh and stages the
+#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
+#
+#   2. Sync script (scripts/sync-scripts.sh)
+#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
+#      any copy that differs without an "AUTO-SYNCED" marker (safety against
+#      destroying manual edits). If you hit a CONFLICT, inspect the diff
+#      first, then either (a) merge the manual edit back into canonical, or
+#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
+#
+#   3. CI check (.github/workflows/shared-files-distribution.yml)
+#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
+#      `diff` against canonical. Mismatched copies fail the PR hard with an
+#      "::error::" annotation — no merge until all 9 copies are identical.
+#
+# If you inherit a repo where copies drift without markers, resolve once by:
+#   bash scripts/sync-scripts.sh   # lists CONFLICTs
+#   # then add the AUTO-SYNCED marker to each copy and re-run
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
@@ -376,6 +397,315 @@ def parse_category(cat_str: str) -> list:
     if ">" in cat_str:
         return [c.strip() for c in cat_str.split(">")]
     return [c.strip() for c in cat_str.split(",")]
+
+
+# ─── Review Analysis: Prompt-as-Data Toolkit ───────────────────────────────
+# Used when /reviews/analysis lacks aggregation (ASIN has <50 reviews or no
+# daily snapshot). This module does NOT call any external LLM — it provides
+# raw data, rendered prompts, and a final aggregator. The calling skill's own
+# LLM performs the Map (per-review tagging) and Reduce (semantic clustering)
+# steps, producing JSON that feeds back into `review-aggregate`.
+#
+# Caller flow:
+#   1. apiclaw.py reviews-raw --asin X          → fetch raw reviews
+#   2. For each review, render via:
+#        apiclaw.py review-tag-prompt --review '<json>'
+#      The caller's LLM produces JSON matching REVIEW_MAP_SCHEMA.
+#   3. Collect per-dimension candidate phrases; for each dimension render:
+#        apiclaw.py review-reduce-prompt --label-type <dim> --candidates '[...]'
+#      The caller's LLM produces JSON matching REVIEW_REDUCE_SCHEMA.
+#   4. apiclaw.py review-aggregate --reviews R --tagged T --clusters C
+#      → emits consumerInsights compatible with /reviews/analysis.
+
+REVIEW_MAP_CONCURRENCY = 20           # suggested map parallelism for caller
+REVIEW_REDUCE_KEYWORDS_CHUNK = 150    # suggested chunk size when keywords dim is large
+REALTIME_REVIEWS_MAX_PAGES = 10       # API hard cap = 100 reviews (10 pages × 10)
+
+DIM_TO_LABELTYPE = {
+    "mentioned_scenarios": "scenarios",
+    "mentioned_issues": "issues",
+    "mentioned_positives": "positives",
+    "mentioned_improvements": "improvements",
+    "mentioned_buying_factors": "buyingFactors",
+    "mentioned_pain_points": "painPoints",
+    "user_profiles": "userProfiles",
+    "mentioned_usage_times": "usageTimes",
+    "mentioned_usage_locations": "usageLocations",
+    "mentioned_behaviors": "behaviors",
+    "keywords": "keywords",
+}
+
+_MAP_ARRAY_FIELDS = list(DIM_TO_LABELTYPE.keys())
+
+REVIEW_MAP_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "sentiment": {"type": "STRING", "enum": ["positive", "neutral", "negative"]},
+        **{k: {"type": "ARRAY", "items": {"type": "STRING"}} for k in _MAP_ARRAY_FIELDS},
+    },
+    "required": ["sentiment"] + _MAP_ARRAY_FIELDS,
+}
+
+REVIEW_REDUCE_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "clusters": {
+            "type": "ARRAY",
+            "items": {
+                "type": "OBJECT",
+                "properties": {
+                    "canonical": {"type": "STRING"},
+                    "members": {"type": "ARRAY", "items": {"type": "STRING"}},
+                },
+                "required": ["canonical", "members"],
+            },
+        },
+    },
+    "required": ["clusters"],
+}
+
+
+def render_review_map_prompt(review: dict, product_title: str = "", product_category: str = "") -> str:
+    title = review.get("title") or ""
+    body = review.get("body") or ""
+    full = f"{title}. {body}" if title else body
+    text = full[:500]
+    rating = review.get("rating") or 3
+    verified = bool(review.get("verifiedPurchase"))
+    return f"""IMPORTANT: Respond ONLY with a JSON object matching the schema below. Output must be in English — translate non-English text before extracting.
+
+You are an expert data extraction specialist analyzing product reviews. Extract only what is EXPLICITLY mentioned — do not infer.
+
+JSON schema:
+{{
+  "sentiment": "positive" | "neutral" | "negative",
+  "mentioned_scenarios": [string],      // max 5 noun phrases 1-3 words (Workouts, Gaming)
+  "mentioned_issues": [string],         // max 5 Adjective+Noun for PRODUCT DEFECTS (Poor Sound Quality)
+  "mentioned_positives": [string],      // max 5 Adjective+Noun for praised aspects (Comfortable Fit)
+  "mentioned_improvements": [string],   // max 3 Verb+Noun explicit suggestions (Extend Battery Life)
+  "mentioned_buying_factors": [string], // max 3 noun phrases for purchase reasons (Price Point)
+  "mentioned_pain_points": [string],    // max 3 UX frustrations EXPERIENCED AFTER USE (see rule)
+  "user_profiles": [string],            // max 3 identities stated EXPLICITLY (see rule)
+  "mentioned_usage_times": [string],    // max 3 time/season phrases (Morning, Winter)
+  "mentioned_usage_locations": [string],// max 3 location phrases (Gym, Home)
+  "mentioned_behaviors": [string],      // max 5 Verb+Object (Taking Calls, Running)
+  "keywords": [string]                  // 3-15 salient words from the review
+}}
+
+Rules:
+- sentiment: positive (4-5 stars or praise), neutral (3 stars / mixed), negative (1-2 stars or complaint)
+- pain_points = problems EXPERIENCED AFTER USE. NOT problems the product solves. If the reviewer says the product solved a prior problem (e.g. "cured my foot pain"), that belongs in positives, NOT pain_points.
+- issues vs pain_points: issues = product defects (hardware/software fault); pain_points = UX frustrations
+- user_profiles: include ONLY if the reviewer explicitly states an identity ("I'm a...", "As a..."). NEVER infer.
+- consistent naming across reviews (e.g. always "Workouts", not "At the gym")
+- use empty arrays [] for categories with no mentions, never null
+
+INPUT:
+Product Category: {product_category or '(unknown)'}
+Product Title: {product_title or '(unknown)'}
+Review Rating: {rating}/5 stars
+Verified Purchase: {'Yes' if verified else 'No'}
+Review Text:
+\"\"\"{text}\"\"\"
+
+Return ONLY the JSON object."""
+
+
+def render_review_reduce_prompt(label_type: str, candidates: list) -> str:
+    return f"""Normalize product-review tags. Group semantically equivalent phrases into clusters and pick a concise Title-Case canonical name (1-3 words) for each cluster.
+
+Label type: {label_type}
+
+Rules:
+- A cluster contains phrases describing the SAME underlying concept.
+- Every input phrase MUST appear in exactly one cluster's `members`. No drops, no duplicates across clusters.
+- Phrases with no semantic neighbors go in their own single-member cluster (still Title-Case canonical).
+- Case-insensitive matching. Preserve input phrase strings verbatim in `members`.
+
+Return a JSON object matching:
+{{"clusters": [{{"canonical": "Title Case", "members": ["phrase1", "phrase2"]}}]}}
+
+Input phrases:
+{json.dumps(candidates, ensure_ascii=False)}"""
+
+
+def fetch_realtime_reviews_all(asin: str, marketplace: str = "US",
+                                max_pages: int = REALTIME_REVIEWS_MAX_PAGES,
+                                log_fn=None) -> dict:
+    """Paginate /realtime/reviews with cursor; stop on null cursor or max_pages."""
+    log = log_fn or (lambda m: None)
+    reviews = []
+    cursor = None
+    pages = 0
+    t0 = time.time()
+    for i in range(1, max_pages + 1):
+        params = {"asin": asin, "marketplace": marketplace}
+        if cursor:
+            params["cursor"] = cursor
+        resp = api_call("realtime/reviews", params)
+        if not resp.get("success"):
+            break
+        data = resp.get("data") or {}
+        page_reviews = data.get("reviews") or []
+        cursor = data.get("nextCursor")
+        pages += 1
+        reviews.extend(page_reviews)
+        log(f"  page {i}: {len(page_reviews)} reviews, cursor={'yes' if cursor else 'end'}")
+        if not cursor:
+            break
+    return {
+        "reviews": reviews,
+        "pages": pages,
+        "capped": pages >= max_pages and cursor is not None,
+        "fetchSeconds": round(time.time() - t0, 2),
+    }
+
+
+def aggregate_review_insights(reviews: list, tagged: list, clusters_per_dim: dict) -> dict:
+    """Combine raw reviews + per-review Map tags + per-dimension Reduce clusters
+    into a reviews/analysis-compatible aggregation. No LLM calls."""
+    from collections import defaultdict
+
+    if len(tagged) != len(reviews):
+        raise ValueError(f"tagged length ({len(tagged)}) != reviews length ({len(reviews)})")
+
+    total = len(reviews)
+    ratings = [r.get("rating") or 0 for r in reviews]
+
+    dim_phrase_reviews = {k: defaultdict(set) for k in DIM_TO_LABELTYPE}
+    for i, tags in enumerate(tagged):
+        if not isinstance(tags, dict):
+            continue
+        for dim in DIM_TO_LABELTYPE:
+            for el in (tags.get(dim) or []):
+                if not isinstance(el, str):
+                    continue
+                kl = el.strip().lower()
+                if kl:
+                    dim_phrase_reviews[dim][kl].add(i)
+
+    insights = []
+    for dim, phrases in dim_phrase_reviews.items():
+        if not phrases:
+            continue
+        p2c = {}
+        for cl in (clusters_per_dim.get(dim) or []):
+            canon = (cl.get("canonical") or "").strip()
+            if not canon:
+                continue
+            for m in (cl.get("members") or []):
+                if not isinstance(m, str):
+                    continue
+                ml = m.strip().lower()
+                if ml and ml not in p2c:
+                    p2c[ml] = canon
+        for ph in phrases:
+            p2c.setdefault(ph, ph.title())
+
+        canon_to_reviews = defaultdict(set)
+        for phrase, rs in phrases.items():
+            canon_to_reviews[p2c[phrase]].update(rs)
+
+        lt = DIM_TO_LABELTYPE[dim]
+        for canon, rs in canon_to_reviews.items():
+            c = len(rs)
+            avg = sum(ratings[i] for i in rs) / c if c else 0.0
+            insights.append({
+                "element": canon,
+                "labelType": lt,
+                "count": c,
+                "reviewRate": round(c / total, 4),
+                "avgRating": round(avg, 2),
+            })
+    insights.sort(key=lambda x: (x["labelType"], -x["count"]))
+
+    sentiments = [(t or {}).get("sentiment") for t in tagged]
+    sentiment_dist = {
+        "positive": round(sum(1 for s in sentiments if s == "positive") / total, 4) if total else 0,
+        "neutral": round(sum(1 for s in sentiments if s == "neutral") / total, 4) if total else 0,
+        "negative": round(sum(1 for s in sentiments if s == "negative") / total, 4) if total else 0,
+    }
+    avg_rating = round(sum(ratings) / total, 2) if total else 0.0
+
+    return {
+        "success": True,
+        "data": {
+            "reviewCount": total,
+            "avgRating": avg_rating,
+            "sentimentDistribution": sentiment_dist,
+            "consumerInsights": insights,
+            "topKeywords": [
+                {"element": it["element"], "count": it["count"]}
+                for it in insights if it["labelType"] == "keywords"
+            ][:20],
+        },
+        "_meta": {"source": "prompt-as-data-aggregation", "tagsApplied": total},
+    }
+
+
+def cmd_reviews_raw(args):
+    log_fn = (lambda m: print(m, file=sys.stderr)) if args.verbose else None
+    result = fetch_realtime_reviews_all(args.asin, args.marketplace, args.max_pages, log_fn=log_fn)
+    output({
+        "success": True,
+        "data": result,
+        "_query": {"endpoint": "realtime/reviews",
+                   "params": {"asin": args.asin, "marketplace": args.marketplace,
+                              "maxPages": args.max_pages}},
+    })
+
+
+def _load_json_arg(inline: str, path: str, name: str):
+    """Load JSON from --<name> inline arg or --<name>-file path."""
+    if inline and path:
+        print(f"ERROR: provide either --{name} or --{name}-file, not both", file=sys.stderr)
+        sys.exit(1)
+    if inline:
+        return json.loads(inline)
+    if path:
+        with open(path) as f:
+            return json.load(f)
+    print(f"ERROR: --{name} or --{name}-file is required", file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_review_tag_prompt(args):
+    review = _load_json_arg(args.review, args.review_file, "review")
+    prompt = render_review_map_prompt(
+        review,
+        product_title=args.product_title or "",
+        product_category=args.product_category or "",
+    )
+    print(prompt)
+
+
+def cmd_review_reduce_prompt(args):
+    candidates = _load_json_arg(args.candidates, args.candidates_file, "candidates")
+    if not isinstance(candidates, list):
+        print("ERROR: candidates must be a JSON array of strings", file=sys.stderr)
+        sys.exit(1)
+    prompt = render_review_reduce_prompt(args.label_type, candidates)
+    print(prompt)
+
+
+def cmd_review_aggregate(args):
+    with open(args.reviews) as f:
+        reviews_data = json.load(f)
+    if isinstance(reviews_data, dict):
+        reviews = (reviews_data.get("data") or {}).get("reviews") or reviews_data.get("reviews") or []
+    else:
+        reviews = reviews_data
+
+    with open(args.tagged) as f:
+        tagged = json.load(f)
+    with open(args.clusters) as f:
+        clusters_per_dim = json.load(f)
+
+    result = aggregate_review_insights(reviews, tagged, clusters_per_dim)
+    result["_query"] = {"endpoint": "realtime/reviews+local-aggregate",
+                        "params": {"reviews": args.reviews, "tagged": args.tagged,
+                                    "clusters": args.clusters}}
+    output(result)
 
 
 # ─── Subcommands ─────────────────────────────────────────────────────────────
@@ -2282,6 +2612,38 @@ Examples:
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
     p_rd.add_argument("--category", help="Category path")
     p_rd.set_defaults(func=cmd_review_deepdive)
+
+    # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
+    p_rr = sub.add_parser("reviews-raw", help="Fetch raw reviews from realtime/reviews (cap 100, early-exit on null cursor)", allow_abbrev=False)
+    p_rr.add_argument("--asin", required=True)
+    p_rr.add_argument("--marketplace", default="US", choices=["US", "UK"])
+    p_rr.add_argument("--max-pages", type=int, default=REALTIME_REVIEWS_MAX_PAGES,
+                      help=f"Max pages to fetch (10 reviews each, default {REALTIME_REVIEWS_MAX_PAGES})")
+    p_rr.add_argument("--verbose", action="store_true")
+    p_rr.set_defaults(func=cmd_reviews_raw)
+
+    # ── review-tag-prompt (render Map prompt for one review — caller's LLM runs it) ──
+    p_rtp = sub.add_parser("review-tag-prompt", help="Render the per-review Map prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rtp.add_argument("--review", help="Review object as JSON string")
+    p_rtp.add_argument("--review-file", help="Path to JSON file containing a single review object")
+    p_rtp.add_argument("--product-title", help="Optional product title context")
+    p_rtp.add_argument("--product-category", help="Optional product category context")
+    p_rtp.set_defaults(func=cmd_review_tag_prompt)
+
+    # ── review-reduce-prompt (render Reduce prompt for one dimension — caller's LLM runs it) ──
+    p_rrp = sub.add_parser("review-reduce-prompt", help="Render the per-dimension Reduce prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rrp.add_argument("--label-type", required=True,
+                       help="Dimension to cluster (scenarios, issues, positives, improvements, buyingFactors, painPoints, userProfiles, usageTimes, usageLocations, behaviors, keywords)")
+    p_rrp.add_argument("--candidates", help="Candidate phrases as JSON array string")
+    p_rrp.add_argument("--candidates-file", help="Path to JSON file containing candidate phrases array")
+    p_rrp.set_defaults(func=cmd_review_reduce_prompt)
+
+    # ── review-aggregate (build reviews/analysis-compatible output from tags + clusters) ──
+    p_rag = sub.add_parser("review-aggregate", help="Aggregate per-review tags + per-dim clusters into consumerInsights", allow_abbrev=False)
+    p_rag.add_argument("--reviews", required=True, help="Path to JSON from reviews-raw (or raw reviews array)")
+    p_rag.add_argument("--tagged", required=True, help="Path to JSON array of Map outputs (same order as reviews)")
+    p_rag.add_argument("--clusters", required=True, help="Path to JSON {dim_key: [{canonical, members}]} from Reduce")
+    p_rag.set_defaults(func=cmd_review_aggregate)
 
     # ── analyze (reviews) ──
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: APIClaw — Amazon Commerce Data, 12 Endpoints
+name: APIClaw — Amazon Commerce Data, 11 Endpoints
 version: 1.1.2
 description: >
   General overview, 12 API endpoints.

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -1,11 +1,12 @@
 ---
-name: APIClaw — Amazon Commerce Data, 11 Endpoints
-version: 1.1.1
+name: APIClaw — Amazon Commerce Data, 12 Endpoints
+version: 1.1.2
 description: >
-  General overview, 11 API endpoints.
+  General overview, 12 API endpoints.
   AI-powered commerce data infrastructure with 200M+ Amazon products.
   Endpoints: category browsing, market metrics, product search,
   competitor lookup, realtime ASIN detail, AI review analysis,
+  live raw reviews (with local Map/Reduce toolkit fallback),
   price band overview/detail, brand overview/detail, and product history.
   Use when user asks: what APIClaw can do, available API endpoints,
   how to get started, API capabilities overview, credit usage, or
@@ -22,7 +23,7 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 
 # APIClaw — Commerce Data Infrastructure for AI Agents
 
-200M+ Amazon products. 11 endpoints. One API key.
+200M+ Amazon products. 12 endpoints. One API key.
 
 ## Quick Start
 1. Get key: [apiclaw.io/api-keys](https://apiclaw.io/en/api-keys) (1,000 free credits)
@@ -37,11 +38,14 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 3. **Revenue** = `sampleAvgMonthlyRevenue` directly. **NEVER** calculate avgPrice × totalSales (overestimates 30-70%)
 4. **Sales** = `monthlySalesFloor` (lower bound). Fallback: 300,000 / BSR^0.65, tag as 🔍
 5. **Use API fields directly**: `sampleOpportunityIndex`, `sampleTop10BrandSalesRate` — never reinvent
-6. **reviews/analysis** needs 50+ reviews; fallback to realtime ratingBreakdown
+6. **reviews/analysis** needs 50+ reviews. Fallback chain when sample is insufficient:
+   1. Lightweight: `realtime/product` → `ratingBreakdown` (star distribution only, no themes)
+   2. Full 11-dim insights: `realtime/reviews` (raw text, up to 100) + local Map/Reduce via the
+      Local Review Toolkit below — see "Local Review Toolkit" section
 7. **Aggregation endpoints** (price-band, brand) without categoryPath produce severely distorted data
 8. **Price-band and brand endpoints only accept `keyword`** (not categoryPath) — cross-validate returned products
 
-## 11 Endpoints
+## 12 Endpoints
 
 | # | Endpoint | Purpose | Key Output |
 |---|----------|---------|------------|
@@ -51,11 +55,12 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 | 4 | `products/competitors` | Competitor discovery | same fields as products/search |
 | 5 | `realtime/product` | Live ASIN detail | rating, features, bestsellersRank[], buyboxWinner.price, variants |
 | 6 | `reviews/analysis` | AI review insights (11 dims) | sentimentDistribution, consumerInsights, topKeywords |
-| 7 | `products/price-band-overview` | Price band summary | hottestBand, bestOpportunityBand, sampleOpportunityIndex |
-| 8 | `products/price-band-detail` | Full 5-band distribution | priceBands[] with sales, brands, ratings per band |
-| 9 | `products/brand-overview` | Brand concentration | sampleTop10BrandSalesRate (CR10), sampleBrandCount |
-| 10 | `products/brand-detail` | Per-brand breakdown | brands[] with sales, revenue, sampleProducts |
-| 11 | `products/history` | Time series (single ASIN per call) | timestamps[], price[], bsr[], monthlySalesFloor[], rating[], ratingCount[], sellerCount[], title/imageUrl/bestSeller/newRelease/aPlus/inventoryStatus changelogs |
+| 7 | `realtime/reviews` | Live raw review text (cursor paginated, max 100) | reviews[], nextCursor — feeds Local Review Toolkit |
+| 8 | `products/price-band-overview` | Price band summary | hottestBand, bestOpportunityBand, sampleOpportunityIndex |
+| 9 | `products/price-band-detail` | Full 5-band distribution | priceBands[] with sales, brands, ratings per band |
+| 10 | `products/brand-overview` | Brand concentration | sampleTop10BrandSalesRate (CR10), sampleBrandCount |
+| 11 | `products/brand-detail` | Per-brand breakdown | brands[] with sales, revenue, sampleProducts |
+| 12 | `products/history` | Time series (single ASIN per call) | timestamps[], price[], bsr[], monthlySalesFloor[], rating[], ratingCount[], sellerCount[], title/imageUrl/bestSeller/newRelease/aPlus/inventoryStatus changelogs |
 
 ## Known Quirks
 - `topN`, `listingAge`, `newProductPeriod` are **strings** (`"10"` not `10`)
@@ -69,19 +74,59 @@ metadata: {"openclaw": {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": 
 - Rate limit: 100 req/min, 10 req/sec burst
 - `categories` uses `categoryKeyword` (not `keyword`) and `parentCategoryPath` (not `parentCategoryName`)
 - `reviews/analysis`: `mode` required ("asin"/"category"), use `asins` (plural array) not `asin`
+- `realtime/reviews`: returns 10 reviews/page fixed (no `pageSize` param); 1 credit/page; cursor-paginated; hard cap = 100 reviews (10 pages); supports `marketplace` US/UK only
+
+## Local Review Toolkit
+
+When `/reviews/analysis` lacks aggregation (ASIN has <50 reviews or no daily snapshot),
+fall back to live raw reviews + your own LLM. The toolkit does NOT call any external
+LLM — you (the calling skill's LLM) perform the Map/Reduce steps.
+
+**Workflow:**
+
+```bash
+# 1. Fetch raw reviews (up to 100, cursor-paginated, ~60s, 10 credits at full)
+apiclaw.py reviews-raw --asin B0XXXXXXXX [--marketplace US] [--max-pages 10]
+
+# 2. For EACH review, render the per-review Map prompt
+apiclaw.py review-tag-prompt --review '<single review JSON>' \
+    [--product-title "..."] [--product-category "..."]
+# → Your LLM produces a JSON object with sentiment + 11 dimension arrays
+#   (mentioned_scenarios, mentioned_issues, mentioned_positives, mentioned_improvements,
+#    mentioned_buying_factors, mentioned_pain_points, user_profiles, mentioned_usage_times,
+#    mentioned_usage_locations, mentioned_behaviors, keywords)
+# Suggested map parallelism: ~20 concurrent if your LLM supports it
+
+# 3. Collect candidate phrases per dimension. For EACH dimension render the Reduce prompt
+apiclaw.py review-reduce-prompt --label-type positives \
+    --candidates '["comfortable","comfy","very comfortable",...]'
+# → Your LLM produces {clusters: [{canonical, members}, ...]}
+# Suggested chunk size for `keywords` dim when >150 candidates: 150 per call
+
+# 4. Aggregate into reviews/analysis-compatible consumerInsights
+apiclaw.py review-aggregate --reviews raw.json --tagged tags.json --clusters clusters.json
+# → Output shape matches /reviews/analysis: reviewCount, avgRating,
+#   sentimentDistribution, consumerInsights[], topKeywords[]
+```
+
+**When to use the toolkit instead of `reviews/analysis`:**
+- ASIN has fewer than 50 reviews
+- `reviews/analysis` returns sparse `consumerInsights` (missing dimensions)
+- Need the freshest possible data (Spider scrape vs. T+1 BigQuery snapshot)
+- Need to analyze a brand-new product that has no daily snapshot yet
 
 ## Field Differences Across Endpoints
 
-| Data | markets | products/competitors | realtime | reviews | price-band | brand | history |
-|------|---------|---------------------|----------|---------|------------|-------|---------|
-| Sales | sampleAvgMonthlySales | monthlySalesFloor | ❌ | ❌ | sampleSalesRate | sampleGroupMonthlySales | monthlySalesFloor[] |
-| Price | sampleAvgPrice | price | buyboxWinner.price | ❌ | bandMin/MaxPrice | sampleAvgPrice | price[] |
-| BSR | sampleAvgBsr | bsr (int) | bestsellersRank[] | ❌ | ❌ | ❌ | bsr[] |
-| Rating | sampleAvgRating | rating | rating | avgRating | sampleAvgRating | sampleAvgRating | rating[] |
-| Reviews | sampleAvgReviewCount | ratingCount | ratingCount | reviewCount | ❌ | sampleAvgRatingCount | ratingCount[] |
-| Insights | ❌ | ❌ | ❌ | ✅ consumerInsights | ❌ | ❌ | ❌ |
-| Concentration | topSalesRate | ❌ | ❌ | ❌ | sampleTop3BrandSalesRate | CR10 | ❌ |
-| Opportunity | ❌ | ❌ | ❌ | ❌ | sampleOpportunityIndex | ❌ | ❌ |
+| Data | markets | products/competitors | realtime/product | reviews/analysis | realtime/reviews | price-band | brand | history |
+|------|---------|---------------------|----------|---------|---------|------------|-------|---------|
+| Sales | sampleAvgMonthlySales | monthlySalesFloor | ❌ | ❌ | ❌ | sampleSalesRate | sampleGroupMonthlySales | monthlySalesFloor[] |
+| Price | sampleAvgPrice | price | buyboxWinner.price | ❌ | ❌ | bandMin/MaxPrice | sampleAvgPrice | price[] |
+| BSR | sampleAvgBsr | bsr (int) | bestsellersRank[] | ❌ | ❌ | ❌ | ❌ | bsr[] |
+| Rating | sampleAvgRating | rating | rating | avgRating | rating (per review) | sampleAvgRating | sampleAvgRating | rating[] |
+| Reviews | sampleAvgReviewCount | ratingCount | ratingCount | reviewCount | reviews[] (raw text, max 100) | ❌ | sampleAvgRatingCount | ratingCount[] |
+| Insights | ❌ | ❌ | ❌ | ✅ consumerInsights | ❌ (raw only — feeds Local Review Toolkit) | ❌ | ❌ | ❌ |
+| Concentration | topSalesRate | ❌ | ❌ | ❌ | ❌ | sampleTop3BrandSalesRate | CR10 | ❌ |
+| Opportunity | ❌ | ❌ | ❌ | ❌ | ❌ | sampleOpportunityIndex | ❌ | ❌ |
 
 ## Confidence Labels (all skills)
 - 📊 **Data-backed** — direct API data

--- a/apiclaw/references/openapi-reference.md
+++ b/apiclaw/references/openapi-reference.md
@@ -104,6 +104,50 @@ labelType values (in response): `scenarios`, `issues`, `positives`, `improvement
 
 ---
 
+## 6b. realtime/reviews
+
+| Parameter | Type | Required | Note |
+|-----------|------|----------|------|
+| asin | String | **Yes** | Product ASIN (10 chars) |
+| marketplace | String | No | `US`/`UK` only (default: US) |
+| cursor | String | No | Pagination token from previous response's `nextCursor`. Omit for first page. |
+
+⚠️ No `pageSize` parameter — server returns 10 reviews/page fixed. Hard cap = **100 reviews / 10 pages**. Cost = **1 credit/page**.
+
+Response: `asin`, `reviews` (array of RealtimeReview), `nextCursor` (null = no more pages).
+
+RealtimeReview: `reviewId`, `title`, `body`, `bodyHtml`, `rating`, `author`, `date` (ISO 8601), `verifiedPurchase`, `vineProgram`, `helpfulVoteCount`, `unhelpfulVoteCount`, `reviewCountry`, `images`, `link`, `isGlobalReview`
+
+Use cases:
+- ASIN has <50 reviews so `/reviews/analysis` aggregation is empty
+- Brand-new product with no daily snapshot
+- Need fresh raw text for local LLM analysis (Map/Reduce → consumerInsights)
+
+See `apiclaw.py reviews-raw / review-tag-prompt / review-reduce-prompt / review-aggregate` for the local toolkit that consumes this endpoint.
+
+---
+
+## 6c. reviews/search
+
+| Parameter | Type | Required | Note |
+|-----------|------|----------|------|
+| asin | String | **Yes** | Product ASIN |
+| ratingMin / ratingMax | Number | No | 1-5 inclusive |
+| verifiedOnly | Boolean | No | Default false |
+| vineOnly | Boolean | No | Default false |
+| helpfulVoteCountMin | Integer | No | Filter low-engagement reviews |
+| dateStart / dateEnd | Date (YYYY-MM-DD) | No | Inclusive range |
+| sortBy | String | No | `recent` (default) / `rating` / `helpfulVoteCount` |
+| sortOrder | String | No | `desc` (default) / `asc` |
+| page | Integer | No | 1-indexed, default 1 |
+| pageSize | Integer | No | 1-20, default 10 |
+
+Response: array of TaggedReview with AI-generated `tags[{labelType, element}]` derived from the offline analysis pipeline (BigQuery daily snapshot).
+
+TaggedReview vs RealtimeReview: `reviews/search` uses snapshot data with AI tags (T+1 delay); `realtime/reviews` is live raw text (no tags). Use `reviews/search` when daily snapshot exists and you want pre-tagged data; use `realtime/reviews` for fresh data or new products.
+
+---
+
 ## 7. products/price-band-overview
 
 | Parameter | Type | Required | Note |

--- a/apiclaw/references/reference.md
+++ b/apiclaw/references/reference.md
@@ -161,6 +161,44 @@ Request params: `keyword`, `brand`, `asin`, `categoryPath`, `sortBy`, `pageSize`
 
 ---
 
+## 6b. realtime/reviews
+
+**Request:**
+- `asin`: String (10 chars, required)
+- `marketplace`: String (US/UK only, default US)
+- `cursor`: String (pagination token; omit for first page)
+
+⚠️ Fixed 10 reviews/page; max 10 pages = **100 reviews** hard cap. 1 credit/page. Cursor-based pagination.
+
+**Response:**
+| Field | Type | Used For |
+|-------|------|----------|
+| `asin` | string | Product ID |
+| `reviews` | list | Array of RealtimeReview |
+| `nextCursor` | string\|null | Next page token (null = end) |
+
+**RealtimeReview:** `reviewId`, `title`, `body`, `bodyHtml`, `rating`, `author`, `date` (ISO 8601 UTC), `verifiedPurchase`, `vineProgram`, `helpfulVoteCount`, `unhelpfulVoteCount`, `reviewCountry`, `images`, `link`, `isGlobalReview`
+
+**Use cases:** ASIN <50 reviews (fallback for `/reviews/analysis`), brand-new product without snapshot, freshest possible raw text. Feeds the local Map/Reduce toolkit (`apiclaw.py reviews-raw / review-tag-prompt / review-reduce-prompt / review-aggregate`).
+
+---
+
+## 6c. reviews/search
+
+**Request:**
+- `asin`: String (required)
+- Optional filters: `ratingMin`/`ratingMax` (1-5), `verifiedOnly`, `vineOnly`, `helpfulVoteCountMin`, `dateStart`/`dateEnd` (YYYY-MM-DD)
+- `sortBy`: `recent` (default) / `rating` / `helpfulVoteCount`
+- `sortOrder`: `desc` (default) / `asc`
+- `page`: 1-indexed (default 1)
+- `pageSize`: 1-20 (default 10)
+
+**Response:** Array of `TaggedReview` — same fields as `RealtimeReview` + `tags[{labelType, element}]` (AI tags from offline pipeline).
+
+**Differs from realtime/reviews:** uses BigQuery daily snapshot (T+1 delay) but already has AI tags applied. Prefer `reviews/search` when snapshot exists; prefer `realtime/reviews` for live data or new products.
+
+---
+
 ## 7. products/price-band-overview
 
 **Request:** Same params as products/search (keyword, category, filters)

--- a/apiclaw/scripts/apiclaw.py
+++ b/apiclaw/scripts/apiclaw.py
@@ -1,29 +1,8 @@
 #!/usr/bin/env python3
 # ============================================================
-# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
-# Source of truth: apiclaw/scripts/apiclaw.py
-#
-# Sync is enforced at THREE layers — understand all three before editing:
-#
-#   1. Local pre-commit hook (scripts/pre-commit)
-#      When this file is staged, auto-runs sync-scripts.sh and stages the
-#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
-#
-#   2. Sync script (scripts/sync-scripts.sh)
-#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
-#      any copy that differs without an "AUTO-SYNCED" marker (safety against
-#      destroying manual edits). If you hit a CONFLICT, inspect the diff
-#      first, then either (a) merge the manual edit back into canonical, or
-#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
-#
-#   3. CI check (.github/workflows/shared-files-distribution.yml)
-#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
-#      `diff` against canonical. Mismatched copies fail the PR hard with an
-#      "::error::" annotation — no merge until all 9 copies are identical.
-#
-# If you inherit a repo where copies drift without markers, resolve once by:
-#   bash scripts/sync-scripts.sh   # lists CONFLICTs
-#   # then add the AUTO-SYNCED marker to each copy and re-run
+# Canonical source - do not edit copies under amazon-* skill directories directly
+# Source location: apiclaw/scripts/apiclaw.py
+# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API

--- a/apiclaw/scripts/apiclaw.py
+++ b/apiclaw/scripts/apiclaw.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python3
 # ============================================================
-# Canonical source - do not edit copies under amazon-* skill directories directly
-# Source location: apiclaw/scripts/apiclaw.py
-# Sync method: pre-commit hook auto-copy or bash scripts/sync-scripts.sh
+# CANONICAL SOURCE — do not edit copies under amazon-*/scripts/apiclaw.py directly.
+# Source of truth: apiclaw/scripts/apiclaw.py
+#
+# Sync is enforced at THREE layers — understand all three before editing:
+#
+#   1. Local pre-commit hook (scripts/pre-commit)
+#      When this file is staged, auto-runs sync-scripts.sh and stages the
+#      updated copies. Install once per clone:  bash scripts/install-hooks.sh
+#
+#   2. Sync script (scripts/sync-scripts.sh)
+#      Mirrors canonical → amazon-*/scripts/apiclaw.py. Refuses to overwrite
+#      any copy that differs without an "AUTO-SYNCED" marker (safety against
+#      destroying manual edits). If you hit a CONFLICT, inspect the diff
+#      first, then either (a) merge the manual edit back into canonical, or
+#      (b) add the AUTO-SYNCED marker to the copy and re-run sync.
+#
+#   3. CI check (.github/workflows/shared-files-distribution.yml)
+#      Every PR touching scripts/** or *scripts/apiclaw.py runs a strict
+#      `diff` against canonical. Mismatched copies fail the PR hard with an
+#      "::error::" annotation — no merge until all 9 copies are identical.
+#
+# If you inherit a repo where copies drift without markers, resolve once by:
+#   bash scripts/sync-scripts.sh   # lists CONFLICTs
+#   # then add the AUTO-SYNCED marker to each copy and re-run
 # ============================================================
 """
 APIClaw CLI — Amazon Product Research via APIClaw API
@@ -376,6 +397,315 @@ def parse_category(cat_str: str) -> list:
     if ">" in cat_str:
         return [c.strip() for c in cat_str.split(">")]
     return [c.strip() for c in cat_str.split(",")]
+
+
+# ─── Review Analysis: Prompt-as-Data Toolkit ───────────────────────────────
+# Used when /reviews/analysis lacks aggregation (ASIN has <50 reviews or no
+# daily snapshot). This module does NOT call any external LLM — it provides
+# raw data, rendered prompts, and a final aggregator. The calling skill's own
+# LLM performs the Map (per-review tagging) and Reduce (semantic clustering)
+# steps, producing JSON that feeds back into `review-aggregate`.
+#
+# Caller flow:
+#   1. apiclaw.py reviews-raw --asin X          → fetch raw reviews
+#   2. For each review, render via:
+#        apiclaw.py review-tag-prompt --review '<json>'
+#      The caller's LLM produces JSON matching REVIEW_MAP_SCHEMA.
+#   3. Collect per-dimension candidate phrases; for each dimension render:
+#        apiclaw.py review-reduce-prompt --label-type <dim> --candidates '[...]'
+#      The caller's LLM produces JSON matching REVIEW_REDUCE_SCHEMA.
+#   4. apiclaw.py review-aggregate --reviews R --tagged T --clusters C
+#      → emits consumerInsights compatible with /reviews/analysis.
+
+REVIEW_MAP_CONCURRENCY = 20           # suggested map parallelism for caller
+REVIEW_REDUCE_KEYWORDS_CHUNK = 150    # suggested chunk size when keywords dim is large
+REALTIME_REVIEWS_MAX_PAGES = 10       # API hard cap = 100 reviews (10 pages × 10)
+
+DIM_TO_LABELTYPE = {
+    "mentioned_scenarios": "scenarios",
+    "mentioned_issues": "issues",
+    "mentioned_positives": "positives",
+    "mentioned_improvements": "improvements",
+    "mentioned_buying_factors": "buyingFactors",
+    "mentioned_pain_points": "painPoints",
+    "user_profiles": "userProfiles",
+    "mentioned_usage_times": "usageTimes",
+    "mentioned_usage_locations": "usageLocations",
+    "mentioned_behaviors": "behaviors",
+    "keywords": "keywords",
+}
+
+_MAP_ARRAY_FIELDS = list(DIM_TO_LABELTYPE.keys())
+
+REVIEW_MAP_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "sentiment": {"type": "STRING", "enum": ["positive", "neutral", "negative"]},
+        **{k: {"type": "ARRAY", "items": {"type": "STRING"}} for k in _MAP_ARRAY_FIELDS},
+    },
+    "required": ["sentiment"] + _MAP_ARRAY_FIELDS,
+}
+
+REVIEW_REDUCE_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "clusters": {
+            "type": "ARRAY",
+            "items": {
+                "type": "OBJECT",
+                "properties": {
+                    "canonical": {"type": "STRING"},
+                    "members": {"type": "ARRAY", "items": {"type": "STRING"}},
+                },
+                "required": ["canonical", "members"],
+            },
+        },
+    },
+    "required": ["clusters"],
+}
+
+
+def render_review_map_prompt(review: dict, product_title: str = "", product_category: str = "") -> str:
+    title = review.get("title") or ""
+    body = review.get("body") or ""
+    full = f"{title}. {body}" if title else body
+    text = full[:500]
+    rating = review.get("rating") or 3
+    verified = bool(review.get("verifiedPurchase"))
+    return f"""IMPORTANT: Respond ONLY with a JSON object matching the schema below. Output must be in English — translate non-English text before extracting.
+
+You are an expert data extraction specialist analyzing product reviews. Extract only what is EXPLICITLY mentioned — do not infer.
+
+JSON schema:
+{{
+  "sentiment": "positive" | "neutral" | "negative",
+  "mentioned_scenarios": [string],      // max 5 noun phrases 1-3 words (Workouts, Gaming)
+  "mentioned_issues": [string],         // max 5 Adjective+Noun for PRODUCT DEFECTS (Poor Sound Quality)
+  "mentioned_positives": [string],      // max 5 Adjective+Noun for praised aspects (Comfortable Fit)
+  "mentioned_improvements": [string],   // max 3 Verb+Noun explicit suggestions (Extend Battery Life)
+  "mentioned_buying_factors": [string], // max 3 noun phrases for purchase reasons (Price Point)
+  "mentioned_pain_points": [string],    // max 3 UX frustrations EXPERIENCED AFTER USE (see rule)
+  "user_profiles": [string],            // max 3 identities stated EXPLICITLY (see rule)
+  "mentioned_usage_times": [string],    // max 3 time/season phrases (Morning, Winter)
+  "mentioned_usage_locations": [string],// max 3 location phrases (Gym, Home)
+  "mentioned_behaviors": [string],      // max 5 Verb+Object (Taking Calls, Running)
+  "keywords": [string]                  // 3-15 salient words from the review
+}}
+
+Rules:
+- sentiment: positive (4-5 stars or praise), neutral (3 stars / mixed), negative (1-2 stars or complaint)
+- pain_points = problems EXPERIENCED AFTER USE. NOT problems the product solves. If the reviewer says the product solved a prior problem (e.g. "cured my foot pain"), that belongs in positives, NOT pain_points.
+- issues vs pain_points: issues = product defects (hardware/software fault); pain_points = UX frustrations
+- user_profiles: include ONLY if the reviewer explicitly states an identity ("I'm a...", "As a..."). NEVER infer.
+- consistent naming across reviews (e.g. always "Workouts", not "At the gym")
+- use empty arrays [] for categories with no mentions, never null
+
+INPUT:
+Product Category: {product_category or '(unknown)'}
+Product Title: {product_title or '(unknown)'}
+Review Rating: {rating}/5 stars
+Verified Purchase: {'Yes' if verified else 'No'}
+Review Text:
+\"\"\"{text}\"\"\"
+
+Return ONLY the JSON object."""
+
+
+def render_review_reduce_prompt(label_type: str, candidates: list) -> str:
+    return f"""Normalize product-review tags. Group semantically equivalent phrases into clusters and pick a concise Title-Case canonical name (1-3 words) for each cluster.
+
+Label type: {label_type}
+
+Rules:
+- A cluster contains phrases describing the SAME underlying concept.
+- Every input phrase MUST appear in exactly one cluster's `members`. No drops, no duplicates across clusters.
+- Phrases with no semantic neighbors go in their own single-member cluster (still Title-Case canonical).
+- Case-insensitive matching. Preserve input phrase strings verbatim in `members`.
+
+Return a JSON object matching:
+{{"clusters": [{{"canonical": "Title Case", "members": ["phrase1", "phrase2"]}}]}}
+
+Input phrases:
+{json.dumps(candidates, ensure_ascii=False)}"""
+
+
+def fetch_realtime_reviews_all(asin: str, marketplace: str = "US",
+                                max_pages: int = REALTIME_REVIEWS_MAX_PAGES,
+                                log_fn=None) -> dict:
+    """Paginate /realtime/reviews with cursor; stop on null cursor or max_pages."""
+    log = log_fn or (lambda m: None)
+    reviews = []
+    cursor = None
+    pages = 0
+    t0 = time.time()
+    for i in range(1, max_pages + 1):
+        params = {"asin": asin, "marketplace": marketplace}
+        if cursor:
+            params["cursor"] = cursor
+        resp = api_call("realtime/reviews", params)
+        if not resp.get("success"):
+            break
+        data = resp.get("data") or {}
+        page_reviews = data.get("reviews") or []
+        cursor = data.get("nextCursor")
+        pages += 1
+        reviews.extend(page_reviews)
+        log(f"  page {i}: {len(page_reviews)} reviews, cursor={'yes' if cursor else 'end'}")
+        if not cursor:
+            break
+    return {
+        "reviews": reviews,
+        "pages": pages,
+        "capped": pages >= max_pages and cursor is not None,
+        "fetchSeconds": round(time.time() - t0, 2),
+    }
+
+
+def aggregate_review_insights(reviews: list, tagged: list, clusters_per_dim: dict) -> dict:
+    """Combine raw reviews + per-review Map tags + per-dimension Reduce clusters
+    into a reviews/analysis-compatible aggregation. No LLM calls."""
+    from collections import defaultdict
+
+    if len(tagged) != len(reviews):
+        raise ValueError(f"tagged length ({len(tagged)}) != reviews length ({len(reviews)})")
+
+    total = len(reviews)
+    ratings = [r.get("rating") or 0 for r in reviews]
+
+    dim_phrase_reviews = {k: defaultdict(set) for k in DIM_TO_LABELTYPE}
+    for i, tags in enumerate(tagged):
+        if not isinstance(tags, dict):
+            continue
+        for dim in DIM_TO_LABELTYPE:
+            for el in (tags.get(dim) or []):
+                if not isinstance(el, str):
+                    continue
+                kl = el.strip().lower()
+                if kl:
+                    dim_phrase_reviews[dim][kl].add(i)
+
+    insights = []
+    for dim, phrases in dim_phrase_reviews.items():
+        if not phrases:
+            continue
+        p2c = {}
+        for cl in (clusters_per_dim.get(dim) or []):
+            canon = (cl.get("canonical") or "").strip()
+            if not canon:
+                continue
+            for m in (cl.get("members") or []):
+                if not isinstance(m, str):
+                    continue
+                ml = m.strip().lower()
+                if ml and ml not in p2c:
+                    p2c[ml] = canon
+        for ph in phrases:
+            p2c.setdefault(ph, ph.title())
+
+        canon_to_reviews = defaultdict(set)
+        for phrase, rs in phrases.items():
+            canon_to_reviews[p2c[phrase]].update(rs)
+
+        lt = DIM_TO_LABELTYPE[dim]
+        for canon, rs in canon_to_reviews.items():
+            c = len(rs)
+            avg = sum(ratings[i] for i in rs) / c if c else 0.0
+            insights.append({
+                "element": canon,
+                "labelType": lt,
+                "count": c,
+                "reviewRate": round(c / total, 4),
+                "avgRating": round(avg, 2),
+            })
+    insights.sort(key=lambda x: (x["labelType"], -x["count"]))
+
+    sentiments = [(t or {}).get("sentiment") for t in tagged]
+    sentiment_dist = {
+        "positive": round(sum(1 for s in sentiments if s == "positive") / total, 4) if total else 0,
+        "neutral": round(sum(1 for s in sentiments if s == "neutral") / total, 4) if total else 0,
+        "negative": round(sum(1 for s in sentiments if s == "negative") / total, 4) if total else 0,
+    }
+    avg_rating = round(sum(ratings) / total, 2) if total else 0.0
+
+    return {
+        "success": True,
+        "data": {
+            "reviewCount": total,
+            "avgRating": avg_rating,
+            "sentimentDistribution": sentiment_dist,
+            "consumerInsights": insights,
+            "topKeywords": [
+                {"element": it["element"], "count": it["count"]}
+                for it in insights if it["labelType"] == "keywords"
+            ][:20],
+        },
+        "_meta": {"source": "prompt-as-data-aggregation", "tagsApplied": total},
+    }
+
+
+def cmd_reviews_raw(args):
+    log_fn = (lambda m: print(m, file=sys.stderr)) if args.verbose else None
+    result = fetch_realtime_reviews_all(args.asin, args.marketplace, args.max_pages, log_fn=log_fn)
+    output({
+        "success": True,
+        "data": result,
+        "_query": {"endpoint": "realtime/reviews",
+                   "params": {"asin": args.asin, "marketplace": args.marketplace,
+                              "maxPages": args.max_pages}},
+    })
+
+
+def _load_json_arg(inline: str, path: str, name: str):
+    """Load JSON from --<name> inline arg or --<name>-file path."""
+    if inline and path:
+        print(f"ERROR: provide either --{name} or --{name}-file, not both", file=sys.stderr)
+        sys.exit(1)
+    if inline:
+        return json.loads(inline)
+    if path:
+        with open(path) as f:
+            return json.load(f)
+    print(f"ERROR: --{name} or --{name}-file is required", file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd_review_tag_prompt(args):
+    review = _load_json_arg(args.review, args.review_file, "review")
+    prompt = render_review_map_prompt(
+        review,
+        product_title=args.product_title or "",
+        product_category=args.product_category or "",
+    )
+    print(prompt)
+
+
+def cmd_review_reduce_prompt(args):
+    candidates = _load_json_arg(args.candidates, args.candidates_file, "candidates")
+    if not isinstance(candidates, list):
+        print("ERROR: candidates must be a JSON array of strings", file=sys.stderr)
+        sys.exit(1)
+    prompt = render_review_reduce_prompt(args.label_type, candidates)
+    print(prompt)
+
+
+def cmd_review_aggregate(args):
+    with open(args.reviews) as f:
+        reviews_data = json.load(f)
+    if isinstance(reviews_data, dict):
+        reviews = (reviews_data.get("data") or {}).get("reviews") or reviews_data.get("reviews") or []
+    else:
+        reviews = reviews_data
+
+    with open(args.tagged) as f:
+        tagged = json.load(f)
+    with open(args.clusters) as f:
+        clusters_per_dim = json.load(f)
+
+    result = aggregate_review_insights(reviews, tagged, clusters_per_dim)
+    result["_query"] = {"endpoint": "realtime/reviews+local-aggregate",
+                        "params": {"reviews": args.reviews, "tagged": args.tagged,
+                                    "clusters": args.clusters}}
+    output(result)
 
 
 # ─── Subcommands ─────────────────────────────────────────────────────────────
@@ -2282,6 +2612,38 @@ Examples:
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
     p_rd.add_argument("--category", help="Category path")
     p_rd.set_defaults(func=cmd_review_deepdive)
+
+    # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
+    p_rr = sub.add_parser("reviews-raw", help="Fetch raw reviews from realtime/reviews (cap 100, early-exit on null cursor)", allow_abbrev=False)
+    p_rr.add_argument("--asin", required=True)
+    p_rr.add_argument("--marketplace", default="US", choices=["US", "UK"])
+    p_rr.add_argument("--max-pages", type=int, default=REALTIME_REVIEWS_MAX_PAGES,
+                      help=f"Max pages to fetch (10 reviews each, default {REALTIME_REVIEWS_MAX_PAGES})")
+    p_rr.add_argument("--verbose", action="store_true")
+    p_rr.set_defaults(func=cmd_reviews_raw)
+
+    # ── review-tag-prompt (render Map prompt for one review — caller's LLM runs it) ──
+    p_rtp = sub.add_parser("review-tag-prompt", help="Render the per-review Map prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rtp.add_argument("--review", help="Review object as JSON string")
+    p_rtp.add_argument("--review-file", help="Path to JSON file containing a single review object")
+    p_rtp.add_argument("--product-title", help="Optional product title context")
+    p_rtp.add_argument("--product-category", help="Optional product category context")
+    p_rtp.set_defaults(func=cmd_review_tag_prompt)
+
+    # ── review-reduce-prompt (render Reduce prompt for one dimension — caller's LLM runs it) ──
+    p_rrp = sub.add_parser("review-reduce-prompt", help="Render the per-dimension Reduce prompt (caller's own LLM runs it)", allow_abbrev=False)
+    p_rrp.add_argument("--label-type", required=True,
+                       help="Dimension to cluster (scenarios, issues, positives, improvements, buyingFactors, painPoints, userProfiles, usageTimes, usageLocations, behaviors, keywords)")
+    p_rrp.add_argument("--candidates", help="Candidate phrases as JSON array string")
+    p_rrp.add_argument("--candidates-file", help="Path to JSON file containing candidate phrases array")
+    p_rrp.set_defaults(func=cmd_review_reduce_prompt)
+
+    # ── review-aggregate (build reviews/analysis-compatible output from tags + clusters) ──
+    p_rag = sub.add_parser("review-aggregate", help="Aggregate per-review tags + per-dim clusters into consumerInsights", allow_abbrev=False)
+    p_rag.add_argument("--reviews", required=True, help="Path to JSON from reviews-raw (or raw reviews array)")
+    p_rag.add_argument("--tagged", required=True, help="Path to JSON array of Map outputs (same order as reviews)")
+    p_rag.add_argument("--clusters", required=True, help="Path to JSON {dim_key: [{canonical, members}]} from Reduce")
+    p_rag.set_defaults(func=cmd_review_aggregate)
 
     # ── analyze (reviews) ──
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)


### PR DESCRIPTION
## Summary

- **New `/openapi/v2/realtime/reviews` integration** — cursor-paginated raw review fetch (max 100 reviews / 10 pages / 1 credit/page, US+UK). Spider-live text, no AI tags.
- **Local Map/Reduce toolkit in `apiclaw.py`** — prompt-as-data fallback when `/reviews/analysis` lacks aggregation (ASIN <50 reviews or no daily snapshot). **No external LLM dependency** — the calling skill's own LLM performs Map (per-review tagging) and Reduce (semantic clustering); `apiclaw.py` only fetches data, renders prompts, and aggregates.
- **8 SKILL.md fallback chain documentation** — each skill self-contained (no cross-skill references since skills are invoked independently). Includes working-dir convention, CLI/LLM boundary notes, small-sample rule, and fallback scope.
- **Universal output-quality rules** added to 7 skill Confidence Labels specs:
  - **Aggregate-label rule** — no group-level 📊 when any row/cell is 🔍/💡 (covers section headers, summary/score lines, table column headers)
  - **Emoji reservation rule** — 📊/🔍/💡 reserved exclusively for confidence labels, never decorative
- **Three-layer sync enforcement documented** in `apiclaw/scripts/apiclaw.py` file header.
- **9 skill copies of `apiclaw.py` force-resynced** to canonical (one-time cleanup of pre-existing drift; CI diff check now passes).
- **CONTRIBUTING.md** adds local branch hygiene + shared CLI sync mechanism notes.

## 4 New CLI Commands

```bash
apiclaw.py reviews-raw --asin X [--max-pages 10]        # fetch raw reviews
apiclaw.py review-tag-prompt --review '<json>'           # render per-review Map prompt
apiclaw.py review-reduce-prompt --label-type X --candidates '[...]'  # Reduce prompt
apiclaw.py review-aggregate --reviews R --tagged T --clusters C      # no-LLM aggregation
```

Output structure matches `/reviews/analysis` exactly: `{reviewCount, avgRating, sentimentDistribution, consumerInsights[], topKeywords[]}`.

## Validation

End-to-end fresh-session tests with ASIN **B0GD7BSDN2** (new Bluetooth earbuds, 20 ratings on Amazon, Spider pulled 14 reviews):

| Skill | Test type | Result |
|-------|-----------|--------|
| amazon-review-intelligence-extractor | fresh session full workflow | ✅ 29/29 |
| amazon-listing-audit-pro | fresh session 3-iteration regression | ✅ converged clean |
| amazon-competitor-intelligence-monitor | CLI + structural smoke | ✅ |
| amazon-daily-market-radar | CLI + structural smoke | ✅ |
| amazon-market-entry-analyzer | CLI + structural smoke | ✅ |
| amazon-opportunity-discoverer | CLI + structural smoke | ✅ |
| apiclaw (reference skill) | read-test | ✅ |
| amazon-analysis | **CLI + structural smoke only** (not fresh-session tested) | ⚠️ inherits rules from siblings |
| amazon-market-trend-scanner (Tier C) | not modified | — |
| amazon-pricing-command-center (Tier C) | not modified | — |

## Version Bumps (8 SKILL.md, patch +1 from main)

- apiclaw: 1.1.1 → 1.1.2
- amazon-analysis: 1.1.5 → 1.1.6
- amazon-review-intelligence-extractor / amazon-listing-audit-pro / amazon-daily-market-radar / amazon-market-entry-analyzer / amazon-opportunity-discoverer: 1.0.1 → 1.0.2
- amazon-competitor-intelligence-monitor: 1.1.1 → 1.1.2

## Test plan

- [ ] CI's `shared-files-distribution.yml` passes (all 9 amazon-* copies diff-clean vs canonical)
- [ ] CI's `skill-md-checks.yml` passes (SKILL.md lints / name stability / apiclaw.py path prefix)
- [ ] CI's `markdown-link-check.yml` passes (no broken links from new docs)
- [ ] Manual: `APICLAW_API_KEY=xxx python3 apiclaw/scripts/apiclaw.py reviews-raw --asin B0GD7BSDN2 --max-pages 2` returns ≥10 reviews
- [ ] Manual: `apiclaw.py review-tag-prompt` / `review-reduce-prompt` render valid prompt text
- [ ] Manual: `apiclaw.py review-aggregate` produces `/reviews/analysis`-shaped output

## Known non-blockers (left for future PRs)

- `cmd_review_deepdive` still makes 11 separate `/reviews/analysis` calls (one per labelType) — pre-existing behavior, contradicts SKILL.md "API returns all 11 dimensions in one call". Wastes time on failure but doesn't bill credits.
- `apiclaw` SKILL.md's Confidence Labels section retains the basic 3-tier definition; Aggregate-label / Emoji reservation rules are in the 7 output-producing skills only (since apiclaw is a pure reference skill with no report output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)