### PR TITLE
fix(market-entry): downgrade to keyword-only when deep categoryPath has no aggregation data

### DIFF
--- a/amazon-analysis/scripts/apiclaw.py
+++ b/amazon-analysis/scripts/apiclaw.py
@@ -1020,6 +1020,26 @@ def cmd_market_entry(args):
         market_params["categoryKeyword"] = keyword
     results["market"] = safe_call("markets/search", market_params, "market")
 
+    # 1a-fallback: deep-leaf categoryPath has no aggregation data on the
+    # backend → downgrade to keyword-only mode so all subsequent steps use
+    # categoryKeyword instead of categoryPath. Only applies when both keyword
+    # and categoryPath were provided (otherwise we have nothing to fall back to).
+    if category_path and keyword:
+        m = results["market"] or {}
+        m_data = m.get("data") or []
+        m_total = (m.get("meta") or {}).get("total", 0)
+        if m.get("success") is False or not m_data or m_total == 0:
+            log(f"  → categoryPath {' > '.join(category_path)} returned empty; "
+                f"downgrading to keyword-only mode for subsequent steps")
+            results["meta"]["category_downgrade"] = {
+                "from": category_path,
+                "reason": "empty_aggregation",
+            }
+            category_path = None
+            market_params = {"topN": "10", "pageSize": 20, "categoryKeyword": keyword}
+            results["market"] = safe_call("markets/search", market_params,
+                                          "market (keyword fallback)")
+
     # 1b. Brand overview (keyword + category, fallback to category-only)
     brand_ov_params = {"pageSize": 20}
     if category_path:

--- a/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
+++ b/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
@@ -1020,6 +1020,26 @@ def cmd_market_entry(args):
         market_params["categoryKeyword"] = keyword
     results["market"] = safe_call("markets/search", market_params, "market")
 
+    # 1a-fallback: deep-leaf categoryPath has no aggregation data on the
+    # backend → downgrade to keyword-only mode so all subsequent steps use
+    # categoryKeyword instead of categoryPath. Only applies when both keyword
+    # and categoryPath were provided (otherwise we have nothing to fall back to).
+    if category_path and keyword:
+        m = results["market"] or {}
+        m_data = m.get("data") or []
+        m_total = (m.get("meta") or {}).get("total", 0)
+        if m.get("success") is False or not m_data or m_total == 0:
+            log(f"  → categoryPath {' > '.join(category_path)} returned empty; "
+                f"downgrading to keyword-only mode for subsequent steps")
+            results["meta"]["category_downgrade"] = {
+                "from": category_path,
+                "reason": "empty_aggregation",
+            }
+            category_path = None
+            market_params = {"topN": "10", "pageSize": 20, "categoryKeyword": keyword}
+            results["market"] = safe_call("markets/search", market_params,
+                                          "market (keyword fallback)")
+
     # 1b. Brand overview (keyword + category, fallback to category-only)
     brand_ov_params = {"pageSize": 20}
     if category_path:

--- a/amazon-daily-market-radar/scripts/apiclaw.py
+++ b/amazon-daily-market-radar/scripts/apiclaw.py
@@ -1020,6 +1020,26 @@ def cmd_market_entry(args):
         market_params["categoryKeyword"] = keyword
     results["market"] = safe_call("markets/search", market_params, "market")
 
+    # 1a-fallback: deep-leaf categoryPath has no aggregation data on the
+    # backend → downgrade to keyword-only mode so all subsequent steps use
+    # categoryKeyword instead of categoryPath. Only applies when both keyword
+    # and categoryPath were provided (otherwise we have nothing to fall back to).
+    if category_path and keyword:
+        m = results["market"] or {}
+        m_data = m.get("data") or []
+        m_total = (m.get("meta") or {}).get("total", 0)
+        if m.get("success") is False or not m_data or m_total == 0:
+            log(f"  → categoryPath {' > '.join(category_path)} returned empty; "
+                f"downgrading to keyword-only mode for subsequent steps")
+            results["meta"]["category_downgrade"] = {
+                "from": category_path,
+                "reason": "empty_aggregation",
+            }
+            category_path = None
+            market_params = {"topN": "10", "pageSize": 20, "categoryKeyword": keyword}
+            results["market"] = safe_call("markets/search", market_params,
+                                          "market (keyword fallback)")
+
     # 1b. Brand overview (keyword + category, fallback to category-only)
     brand_ov_params = {"pageSize": 20}
     if category_path:

--- a/amazon-listing-audit-pro/scripts/apiclaw.py
+++ b/amazon-listing-audit-pro/scripts/apiclaw.py
@@ -1020,6 +1020,26 @@ def cmd_market_entry(args):
         market_params["categoryKeyword"] = keyword
     results["market"] = safe_call("markets/search", market_params, "market")
 
+    # 1a-fallback: deep-leaf categoryPath has no aggregation data on the
+    # backend → downgrade to keyword-only mode so all subsequent steps use
+    # categoryKeyword instead of categoryPath. Only applies when both keyword
+    # and categoryPath were provided (otherwise we have nothing to fall back to).
+    if category_path and keyword:
+        m = results["market"] or {}
+        m_data = m.get("data") or []
+        m_total = (m.get("meta") or {}).get("total", 0)
+        if m.get("success") is False or not m_data or m_total == 0:
+            log(f"  → categoryPath {' > '.join(category_path)} returned empty; "
+                f"downgrading to keyword-only mode for subsequent steps")
+            results["meta"]["category_downgrade"] = {
+                "from": category_path,
+                "reason": "empty_aggregation",
+            }
+            category_path = None
+            market_params = {"topN": "10", "pageSize": 20, "categoryKeyword": keyword}
+            results["market"] = safe_call("markets/search", market_params,
+                                          "market (keyword fallback)")
+
     # 1b. Brand overview (keyword + category, fallback to category-only)
     brand_ov_params = {"pageSize": 20}
     if category_path:

--- a/amazon-market-entry-analyzer/scripts/apiclaw.py
+++ b/amazon-market-entry-analyzer/scripts/apiclaw.py
@@ -1020,6 +1020,26 @@ def cmd_market_entry(args):
         market_params["categoryKeyword"] = keyword
     results["market"] = safe_call("markets/search", market_params, "market")
 
+    # 1a-fallback: deep-leaf categoryPath has no aggregation data on the
+    # backend → downgrade to keyword-only mode so all subsequent steps use
+    # categoryKeyword instead of categoryPath. Only applies when both keyword
+    # and categoryPath were provided (otherwise we have nothing to fall back to).
+    if category_path and keyword:
+        m = results["market"] or {}
+        m_data = m.get("data") or []
+        m_total = (m.get("meta") or {}).get("total", 0)
+        if m.get("success") is False or not m_data or m_total == 0:
+            log(f"  → categoryPath {' > '.join(category_path)} returned empty; "
+                f"downgrading to keyword-only mode for subsequent steps")
+            results["meta"]["category_downgrade"] = {
+                "from": category_path,
+                "reason": "empty_aggregation",
+            }
+            category_path = None
+            market_params = {"topN": "10", "pageSize": 20, "categoryKeyword": keyword}
+            results["market"] = safe_call("markets/search", market_params,
+                                          "market (keyword fallback)")
+
     # 1b. Brand overview (keyword + category, fallback to category-only)
     brand_ov_params = {"pageSize": 20}
     if category_path:

--- a/amazon-market-trend-scanner/scripts/apiclaw.py
+++ b/amazon-market-trend-scanner/scripts/apiclaw.py
@@ -1020,6 +1020,26 @@ def cmd_market_entry(args):
         market_params["categoryKeyword"] = keyword
     results["market"] = safe_call("markets/search", market_params, "market")
 
+    # 1a-fallback: deep-leaf categoryPath has no aggregation data on the
+    # backend → downgrade to keyword-only mode so all subsequent steps use
+    # categoryKeyword instead of categoryPath. Only applies when both keyword
+    # and categoryPath were provided (otherwise we have nothing to fall back to).
+    if category_path and keyword:
+        m = results["market"] or {}
+        m_data = m.get("data") or []
+        m_total = (m.get("meta") or {}).get("total", 0)
+        if m.get("success") is False or not m_data or m_total == 0:
+            log(f"  → categoryPath {' > '.join(category_path)} returned empty; "
+                f"downgrading to keyword-only mode for subsequent steps")
+            results["meta"]["category_downgrade"] = {
+                "from": category_path,
+                "reason": "empty_aggregation",
+            }
+            category_path = None
+            market_params = {"topN": "10", "pageSize": 20, "categoryKeyword": keyword}
+            results["market"] = safe_call("markets/search", market_params,
+                                          "market (keyword fallback)")
+
     # 1b. Brand overview (keyword + category, fallback to category-only)
     brand_ov_params = {"pageSize": 20}
     if category_path:

--- a/amazon-opportunity-discoverer/scripts/apiclaw.py
+++ b/amazon-opportunity-discoverer/scripts/apiclaw.py
@@ -1020,6 +1020,26 @@ def cmd_market_entry(args):
         market_params["categoryKeyword"] = keyword
     results["market"] = safe_call("markets/search", market_params, "market")
 
+    # 1a-fallback: deep-leaf categoryPath has no aggregation data on the
+    # backend → downgrade to keyword-only mode so all subsequent steps use
+    # categoryKeyword instead of categoryPath. Only applies when both keyword
+    # and categoryPath were provided (otherwise we have nothing to fall back to).
+    if category_path and keyword:
+        m = results["market"] or {}
+        m_data = m.get("data") or []
+        m_total = (m.get("meta") or {}).get("total", 0)
+        if m.get("success") is False or not m_data or m_total == 0:
+            log(f"  → categoryPath {' > '.join(category_path)} returned empty; "
+                f"downgrading to keyword-only mode for subsequent steps")
+            results["meta"]["category_downgrade"] = {
+                "from": category_path,
+                "reason": "empty_aggregation",
+            }
+            category_path = None
+            market_params = {"topN": "10", "pageSize": 20, "categoryKeyword": keyword}
+            results["market"] = safe_call("markets/search", market_params,
+                                          "market (keyword fallback)")
+
     # 1b. Brand overview (keyword + category, fallback to category-only)
     brand_ov_params = {"pageSize": 20}
     if category_path:

--- a/amazon-pricing-command-center/scripts/apiclaw.py
+++ b/amazon-pricing-command-center/scripts/apiclaw.py
@@ -1020,6 +1020,26 @@ def cmd_market_entry(args):
         market_params["categoryKeyword"] = keyword
     results["market"] = safe_call("markets/search", market_params, "market")
 
+    # 1a-fallback: deep-leaf categoryPath has no aggregation data on the
+    # backend → downgrade to keyword-only mode so all subsequent steps use
+    # categoryKeyword instead of categoryPath. Only applies when both keyword
+    # and categoryPath were provided (otherwise we have nothing to fall back to).
+    if category_path and keyword:
+        m = results["market"] or {}
+        m_data = m.get("data") or []
+        m_total = (m.get("meta") or {}).get("total", 0)
+        if m.get("success") is False or not m_data or m_total == 0:
+            log(f"  → categoryPath {' > '.join(category_path)} returned empty; "
+                f"downgrading to keyword-only mode for subsequent steps")
+            results["meta"]["category_downgrade"] = {
+                "from": category_path,
+                "reason": "empty_aggregation",
+            }
+            category_path = None
+            market_params = {"topN": "10", "pageSize": 20, "categoryKeyword": keyword}
+            results["market"] = safe_call("markets/search", market_params,
+                                          "market (keyword fallback)")
+
     # 1b. Brand overview (keyword + category, fallback to category-only)
     brand_ov_params = {"pageSize": 20}
     if category_path:

--- a/amazon-review-intelligence-extractor/scripts/apiclaw.py
+++ b/amazon-review-intelligence-extractor/scripts/apiclaw.py
@@ -1020,6 +1020,26 @@ def cmd_market_entry(args):
         market_params["categoryKeyword"] = keyword
     results["market"] = safe_call("markets/search", market_params, "market")
 
+    # 1a-fallback: deep-leaf categoryPath has no aggregation data on the
+    # backend → downgrade to keyword-only mode so all subsequent steps use
+    # categoryKeyword instead of categoryPath. Only applies when both keyword
+    # and categoryPath were provided (otherwise we have nothing to fall back to).
+    if category_path and keyword:
+        m = results["market"] or {}
+        m_data = m.get("data") or []
+        m_total = (m.get("meta") or {}).get("total", 0)
+        if m.get("success") is False or not m_data or m_total == 0:
+            log(f"  → categoryPath {' > '.join(category_path)} returned empty; "
+                f"downgrading to keyword-only mode for subsequent steps")
+            results["meta"]["category_downgrade"] = {
+                "from": category_path,
+                "reason": "empty_aggregation",
+            }
+            category_path = None
+            market_params = {"topN": "10", "pageSize": 20, "categoryKeyword": keyword}
+            results["market"] = safe_call("markets/search", market_params,
+                                          "market (keyword fallback)")
+
     # 1b. Brand overview (keyword + category, fallback to category-only)
     brand_ov_params = {"pageSize": 20}
     if category_path:

--- a/apiclaw/scripts/apiclaw.py
+++ b/apiclaw/scripts/apiclaw.py
@@ -1020,6 +1020,26 @@ def cmd_market_entry(args):
         market_params["categoryKeyword"] = keyword
     results["market"] = safe_call("markets/search", market_params, "market")
 
+    # 1a-fallback: deep-leaf categoryPath has no aggregation data on the
+    # backend → downgrade to keyword-only mode so all subsequent steps use
+    # categoryKeyword instead of categoryPath. Only applies when both keyword
+    # and categoryPath were provided (otherwise we have nothing to fall back to).
+    if category_path and keyword:
+        m = results["market"] or {}
+        m_data = m.get("data") or []
+        m_total = (m.get("meta") or {}).get("total", 0)
+        if m.get("success") is False or not m_data or m_total == 0:
+            log(f"  → categoryPath {' > '.join(category_path)} returned empty; "
+                f"downgrading to keyword-only mode for subsequent steps")
+            results["meta"]["category_downgrade"] = {
+                "from": category_path,
+                "reason": "empty_aggregation",
+            }
+            category_path = None
+            market_params = {"topN": "10", "pageSize": 20, "categoryKeyword": keyword}
+            results["market"] = safe_call("markets/search", market_params,
+                                          "market (keyword fallback)")
+
     # 1b. Brand overview (keyword + category, fallback to category-only)
     brand_ov_params = {"pageSize": 20}
     if category_path:

--- a/scripts/sync-scripts.sh
+++ b/scripts/sync-scripts.sh
@@ -30,14 +30,15 @@ for skill_dir in "$REPO_ROOT"/amazon-*/; do
   elif diff -q "$SOURCE" "$target" &>/dev/null; then
     echo "  OK   $skill_name"
   else
-    # If the target differs, only overwrite files that are marked as managed copies
-    if grep -q "AUTO-SYNCED" "$target"; then
+    # If the target differs, only overwrite files that are marked as managed copies.
+    # The canonical-source banner (added in #47) is the marker we look for.
+    if grep -q "Canonical source - do not edit copies" "$target"; then
       # The marker indicates a managed copy, so it is safe to overwrite
       cp "$SOURCE" "$target"
       echo "  SYNC $skill_name"
       ((changed++))
     else
-      echo "  CONFLICT $skill_name - scripts/apiclaw.py differs from the canonical source and has no AUTO-SYNCED marker"
+      echo "  CONFLICT $skill_name - scripts/apiclaw.py differs from the canonical source and has no managed-copy marker"
       echo "           Do not edit copies directly; submit changes to apiclaw/scripts/apiclaw.py"
       ((conflict++))
     fi

--- a/tests/test_apiclaw.py
+++ b/tests/test_apiclaw.py
@@ -322,6 +322,98 @@ class TestCategoryParamPassing(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# 9. cmd_market_entry: categoryPath → keyword fallback (regression for #XX)
+# ---------------------------------------------------------------------------
+class TestMarketEntryCategoryFallback(unittest.TestCase):
+    """cmd_market_entry must downgrade to keyword-only mode when a deep-leaf
+    categoryPath returns no aggregation data from markets/search.
+
+    Without this fallback, all 11 downstream endpoints inherit the dead
+    categoryPath and return empty/HTTP 500 — the symptom Kimi 2.5 reported when
+    asked to analyze a 5-level leaf like
+    'Electronics > … > Over-Ear Headphones'.
+    """
+
+    DEEP_LEAF = "Electronics,Headphones,Earbuds & Accessories,Headphones & Earbuds,Over-Ear Headphones"
+
+    def _run(self, market_when_categoryPath, market_when_categoryKeyword):
+        """Run market-entry, returning the ordered list of (endpoint, params) calls."""
+        calls = []
+        # Endpoints whose response.data is a dict (others use list)
+        dict_data_endpoints = {
+            "products/brand-overview", "products/brand-detail",
+            "products/price-band-overview", "products/price-band-detail",
+            "reviews/analysis", "realtime/product", "realtime/reviews",
+            "products/history",
+        }
+
+        def fake_api_call(endpoint, params):
+            calls.append((endpoint, dict(params)))
+            if endpoint == "markets/search":
+                if "categoryPath" in params:
+                    return market_when_categoryPath
+                return market_when_categoryKeyword
+            empty_data = {} if endpoint in dict_data_endpoints else []
+            return {"success": True, "data": empty_data, "meta": {"total": 0},
+                    "_query": {"endpoint": endpoint, "params": params}}
+
+        argv = ["apiclaw.py", "market-entry",
+                "--keyword", "Over-Ear Headphones",
+                "--category", self.DEEP_LEAF]
+        with patch.object(apiclaw, "api_call", side_effect=fake_api_call), \
+             patch.object(apiclaw, "output"), \
+             patch.object(sys, "argv", argv):
+            apiclaw.main()
+        return calls
+
+    @staticmethod
+    def _market_resp(empty=False):
+        if empty:
+            return {"success": True, "data": [], "meta": {"total": 0},
+                    "_query": {"endpoint": "markets/search", "params": {}}}
+        return {"success": True, "data": [{"asin": "B0EXAMPLE"}],
+                "meta": {"total": 1234},
+                "_query": {"endpoint": "markets/search", "params": {}}}
+
+    def test_empty_categoryPath_triggers_keyword_retry(self):
+        calls = self._run(self._market_resp(empty=True), self._market_resp())
+        market_calls = [p for ep, p in calls if ep == "markets/search"]
+        self.assertGreaterEqual(len(market_calls), 2,
+            "Expected an initial categoryPath call followed by a keyword fallback retry")
+        self.assertIn("categoryPath", market_calls[0])
+        self.assertIn("categoryKeyword", market_calls[1])
+        self.assertNotIn("categoryPath", market_calls[1])
+
+    def test_subsequent_endpoints_drop_categoryPath_after_downgrade(self):
+        calls = self._run(self._market_resp(empty=True), self._market_resp())
+        # Skip the very first markets/search (which legitimately uses
+        # categoryPath); every call after the downgrade must not carry it.
+        seen_first_market = False
+        for ep, p in calls:
+            if ep == "markets/search" and not seen_first_market:
+                seen_first_market = True
+                continue
+            self.assertNotIn("categoryPath", p,
+                f"{ep} should not carry categoryPath after downgrade, got {p}")
+
+    def test_nonempty_categoryPath_does_not_retry(self):
+        calls = self._run(self._market_resp(), self._market_resp())
+        market_calls = [p for ep, p in calls if ep == "markets/search"]
+        self.assertEqual(len(market_calls), 1,
+            "No fallback retry should fire when categoryPath returns data")
+        self.assertIn("categoryPath", market_calls[0])
+
+    def test_failed_categoryPath_call_also_triggers_retry(self):
+        # success=False (HTTP 500-equivalent) should also trigger downgrade
+        failed = {"success": False, "error": {"status": 500, "message": "boom"},
+                  "_query": {"endpoint": "markets/search", "params": {}}}
+        calls = self._run(failed, self._market_resp())
+        market_calls = [p for ep, p in calls if ep == "markets/search"]
+        self.assertGreaterEqual(len(market_calls), 2)
+        self.assertIn("categoryKeyword", market_calls[1])
+
+
+# ---------------------------------------------------------------------------
 # Standalone runner
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `cmd_market_entry` now detects when a deep-leaf `categoryPath` returns no aggregation data from `markets/search` and downgrades the run to keyword-only mode for steps 1b–6, instead of letting a dead `categoryPath` poison every downstream call.
- Bumps `scripts/sync-scripts.sh` to look for the canonical-source banner added in #47 instead of the old `AUTO-SYNCED` marker so future syncs don't false-conflict.
- Adds 4 regression tests in `TestMarketEntryCategoryFallback`. Full suite: 45/45 ✅.

## Why

A user reported via Kimi 2.5 that asking the `amazon-analyst` agent to analyze the leaf category `Electronics > Headphones > Earbuds & Accessories > Headphones & Earbuds > Over-Ear Headphones` produced a completely empty report. Reproduced symptoms:

- `markets/search` → `total: 0`
- `products/brand-overview` / `products/competitors` / `products/price-band-overview` → `HTTP 500`
- `reviews/analysis` → `INSUFFICIENT_REVIEWS (0 reviews)`

Root cause: when the deep-leaf has no aggregation data on the backend, every downstream step in `cmd_market_entry` keeps using the same dead `categoryPath`, so the entire 11-endpoint report comes back empty. The keyword on its own (`Over-Ear Headphones`) has 28k+ SKUs of supply — we just never tried it.

## Fix shape

Right after Step 1a, if `markets/search` came back failed/empty AND we have a keyword to fall back to:

1. Drop `categoryPath` (set local `category_path = None`)
2. Retry `markets/search` with `categoryKeyword` instead
3. Let Steps 1b–6 run keyword-only naturally

The downgrade is recorded in `results.meta.category_downgrade` so callers can tell what happened.

## Related (not in this PR)

There is a separate APIClaw backend bug — `/products/*` endpoints crash with HTTP 500 when `keyword` contains `-` / `'` / `&` / `/` (Lucene reserved chars, likely missing escaping on the backend). That bug **also** contributes to the empty report in the screenshot above, since the keyword `Over-Ear Headphones` contains a hyphen. The skill cannot safely strip those chars without changing search semantics, so that fix has to land server-side. Tracking doc on @christine-srp's desktop: `APIClaw-后端Bug-products端点keyword特殊字符崩溃.md`.

## Test plan

- [x] `python3 -m unittest tests.test_apiclaw` → 45/45 pass
- [x] New cases cover: empty data triggers retry, HTTP 500 triggers retry, non-empty path does NOT retry, no downstream call carries `categoryPath` after downgrade
- [ ] Smoke-run live: `apiclaw.py market-entry --keyword "Over-Ear Headphones" --category "Electronics,Headphones,Earbuds & Accessories,Headphones & Earbuds,Over-Ear Headphones"` should now return a non-empty market section

🤖 Generated with [Claude Code](https://claude.com/claude-code)