### PR TITLE
chore(monitoring): add French Press daily snapshot for 2026-05-09

### DIFF
--- a/monitoring/french-press-snapshot-2026-05-09.json
+++ b/monitoring/french-press-snapshot-2026-05-09.json
@@ -1,0 +1,11 @@
+{
+  "date": "2026-05-09",
+  "note": "Seller Sprite MCP not connected — data not retrieved. Reconnect at https://claude.ai/customize/connectors and re-run.",
+  "asins": [
+    {"asin": "B0FDQJFRYS", "brand": "Veken",     "price": null, "ratings": null, "reviews": null, "bsr_coffee_presses": null},
+    {"asin": "B00JE36GLQ", "brand": "Secura",    "price": null, "ratings": null, "reviews": null, "bsr_coffee_presses": null},
+    {"asin": "B0047BIWSK", "brand": "AeroPress", "price": null, "ratings": null, "reviews": null, "bsr_coffee_presses": null},
+    {"asin": "B00008XEWG", "brand": "Bodum",      "price": null, "ratings": null, "reviews": null, "bsr_coffee_presses": null},
+    {"asin": "B07JGBK6XV", "brand": "Mueller",   "price": null, "ratings": null, "reviews": null, "bsr_coffee_presses": null}
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `monitoring/french-press-snapshot-2026-05-09.json` — the daily French Press competitor snapshot file for 2026-05-09
- Seller Sprite MCP was not connected during this run; all metric fields are `null` (placeholder) so the `monitoring/` directory and file structure are established for future runs

## Test plan
- [ ] Confirm `monitoring/french-press-snapshot-2026-05-09.json` is valid JSON
- [ ] Once Seller Sprite MCP is connected, re-run the monitor and verify the file is populated with live data

https://claude.ai/code/session_01A1KwhZ1wCnTFkL5h7Ze77M

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1KwhZ1wCnTFkL5h7Ze77M)_