### PR TITLE
fix(readme): point broken CI badge at test-apiclaw.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/SerendipityOneInc/APIClaw-Skills/actions/workflows/ci.yml"><img src="https://github.com/SerendipityOneInc/APIClaw-Skills/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/SerendipityOneInc/APIClaw-Skills/actions/workflows/test-apiclaw.yml"><img src="https://github.com/SerendipityOneInc/APIClaw-Skills/actions/workflows/test-apiclaw.yml/badge.svg" alt="Tests" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License" /></a>
   <a href="https://apiclaw.io"><img src="https://img.shields.io/badge/API-apiclaw.io-orange" alt="API" /></a>
   <a href="https://discord.gg/YfDFU9BDp5"><img src="https://img.shields.io/badge/Discord-Join-7289da?logo=discord&logoColor=white" alt="Discord" /></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/SerendipityOneInc/APIClaw-Skills/actions/workflows/ci.yml"><img src="https://github.com/SerendipityOneInc/APIClaw-Skills/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/SerendipityOneInc/APIClaw-Skills/actions/workflows/test-apiclaw.yml"><img src="https://github.com/SerendipityOneInc/APIClaw-Skills/actions/workflows/test-apiclaw.yml/badge.svg" alt="Tests" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License" /></a>
   <a href="https://apiclaw.io"><img src="https://img.shields.io/badge/API-apiclaw.io-orange" alt="API" /></a>
   <a href="https://discord.gg/YfDFU9BDp5"><img src="https://img.shields.io/badge/Discord-Join-7289da?logo=discord&logoColor=white" alt="Discord" /></a>


### PR DESCRIPTION
## Summary

Both READMEs (`README.md`, `README.zh-CN.md`) had a CI badge pointing at `.github/workflows/ci.yml/badge.svg`. That workflow was removed in #47 ("refactor: centralize apiclaw.py sync and PR checks"), so the badge URL has been returning 404 → broken image. Repoint at `test-apiclaw.yml` (the closest "CI" semantic — the Python test suite that survived the refactor) and relabel from "CI" to "Tests" to match.

## Diff

```diff
- <a href=".../workflows/ci.yml"><img src=".../ci.yml/badge.svg" alt="CI" /></a>
+ <a href=".../workflows/test-apiclaw.yml"><img src=".../test-apiclaw.yml/badge.svg" alt="Tests" /></a>
```

Applied to both `README.md` line 15 and `README.zh-CN.md` line 15.

## Test plan

- [x] No code changes — README only
- [x] `grep ci.yml README*.md` returns nothing
- [ ] After merge: GitHub README pages render the badge correctly (live test-apiclaw.yml status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SerendipityOneInc/codesmith/APIClaw-Skills/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783236442&installation_id=138111599&pr_number=67&repository=SerendipityOneInc%2FAPIClaw-Skills&return_to=https%3A%2F%2Fgithub.com%2FSerendipityOneInc%2FAPIClaw-Skills%2Fpull%2F67&signature=30539be65cdcb05c55bcc24a57627d82903f43a5c9ed11b9f3527c1e425ae047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->