### PR TITLE
refactor(skills): rewrite descriptions for cleaner cross-skill routing

### DIFF
--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -1,15 +1,21 @@
 ---
 name: amazon-analysis
 description: >
-  Full-Spectrum Research & Seller Intelligence.
-  Amazon seller data analysis tool. Features: market research, product selection, competitor analysis, ASIN evaluation, pricing reference, category research.
-  Use when user asks about: Amazon market research, product selection, ASIN analysis,
-  category research, general Amazon analysis, what should I sell on Amazon,
-  Amazon data analysis, multi-endpoint Amazon research, or composite analysis pipelines
-  (reports, opportunity scans) that span multiple APIClaw endpoints.
-  For deep specialized workflows (pricing strategy, competitor monitoring, market entry,
-  listing audit, review insights), use the corresponding specialized skill instead.
-  Uses {skill_base_dir}/scripts/apiclaw.py to call APIClaw API, requires APICLAW_API_KEY.
+  Amazon-domain entry point and fallback orchestrator. Handles ANY Amazon-related
+  analytical request that doesn't fit one of the 8 specialized amazon-* skills.
+  Use when:
+  - user asks for multi-endpoint Amazon research or composite reports
+  - user asks "what kind of Amazon analysis can I run" or "what can APIClaw do for
+    Amazon" — even if they name the APIClaw platform, the domain is Amazon so this
+    skill wins
+  - any Amazon analysis whose angle is not covered by pricing-command-center,
+    competitor-intelligence-monitor, market-entry-analyzer, listing-audit-pro,
+    review-intelligence-extractor, daily-market-radar, market-trend-scanner, or
+    opportunity-discoverer
+  NOT for: pure product/platform questions about APIClaw itself (pricing, account
+  setup, SDK) — use the apiclaw skill.
+  NOT for: questions fitting a specialized amazon-* skill.
+  Uses {skill_base_dir}/scripts/apiclaw.py. Requires APICLAW_API_KEY.
 metadata:
   version: "1.1.7"
   author: SerendipityOneInc

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -9,11 +9,8 @@ description: >
     general Amazon market/product analysis
   - user asks "what kind of Amazon analysis can I run" or wants an overview
     of available Amazon insights
-  - user wants broad Amazon data exploration rather than a single focused
-    task with a specific deliverable (e.g. a pricing decision, single-ASIN
-    competitor teardown, single-listing audit, market-entry GO/AVOID,
-    opportunity scan, review insights, category trend scan, or daily
-    category radar — those each have their own dedicated trigger).
+  - user wants broad Amazon data exploration with no single specific
+    deliverable in mind
   Uses {skill_base_dir}/scripts/apiclaw.py. Requires APICLAW_API_KEY.
 metadata:
   version: "1.1.7"

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: amazon-analysis
 description: >
-  Amazon-domain entry point and fallback orchestrator. Handles ANY Amazon-related
-  analytical request that doesn't fit one of the 8 specialized amazon-* skills.
+  Amazon-domain general analysis and multi-endpoint research engine.
+  Handles broad or composite Amazon research requests that span multiple data
+  dimensions or have no single specialized angle.
   Use when:
-  - user asks for multi-endpoint Amazon research or composite reports
-  - user asks "what kind of Amazon analysis can I run" or "what can APIClaw do for
-    Amazon" — even if they name the APIClaw platform, the domain is Amazon so this
-    skill wins
-  - any Amazon analysis whose angle is not covered by pricing-command-center,
-    competitor-intelligence-monitor, market-entry-analyzer, listing-audit-pro,
-    review-intelligence-extractor, daily-market-radar, market-trend-scanner, or
-    opportunity-discoverer
-  NOT for: pure product/platform questions about APIClaw itself (pricing, account
-  setup, SDK) — use the apiclaw skill.
-  NOT for: questions fitting a specialized amazon-* skill.
+  - user asks for multi-endpoint Amazon research, composite reports, or
+    general Amazon market/product analysis
+  - user asks "what kind of Amazon analysis can I run" or wants an overview
+    of available Amazon insights — even when they name the APIClaw platform,
+    the domain is Amazon so this skill wins
+  - user wants broad Amazon data exploration rather than a single focused
+    task with a specific deliverable (e.g. a pricing decision, single-ASIN
+    competitor teardown, single-listing audit, market-entry GO/AVOID,
+    opportunity scan, review insights, category trend scan, or daily
+    category radar — those each have their own dedicated trigger).
   Uses {skill_base_dir}/scripts/apiclaw.py. Requires APICLAW_API_KEY.
 metadata:
   version: "1.1.7"

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -8,8 +8,7 @@ description: >
   - user asks for multi-endpoint Amazon research, composite reports, or
     general Amazon market/product analysis
   - user asks "what kind of Amazon analysis can I run" or wants an overview
-    of available Amazon insights — even when they name the APIClaw platform,
-    the domain is Amazon so this skill wins
+    of available Amazon insights
   - user wants broad Amazon data exploration rather than a single focused
     task with a specific deliverable (e.g. a pricing decision, single-ASIN
     competitor teardown, single-listing audit, market-entry GO/AVOID,

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: amazon-competitor-intelligence-monitor
 description: >
-  Deep competitor intelligence for Amazon sellers with continuous monitoring.
-  Two modes: Full Scan (complete analysis, 28-35 credits) and Quick Check (lightweight monitoring, 5-10 credits).
-  Full Scan: 11 endpoints, competitor matrix, brand ranking, pricing, reviews, battle strategy.
-  Quick Check: realtime/product polling, baseline diff, tiered alerts.
-  Use when user asks about: competitor analysis, competitive landscape, competitor tracking,
-  competitor monitoring, competitive intelligence, competitor comparison, benchmark, track competitor,
-  spy on competitors.
+  ASIN-level competitor intelligence. Given SPECIFIC competitor ASINs or named brands,
+  produces deep one-shot teardowns (Full Scan: 28-35 credits, 11 endpoints, battle card,
+  side-by-side analysis, pricing/review/inventory breakdown) AND ongoing per-ASIN
+  monitoring with tiered alerts (Quick Check: 5-10 credits, realtime polling, baseline diff).
+  Use ONLY when the user names SPECIFIC competitor ASINs or brands to analyze or track.
+  Use when user asks: analyze competitor B07XXX, battle card for ASIN Y,
+  track my 5 competitors daily, side-by-side competitor teardown,
+  spy on a specific brand, ongoing watch on named ASINs.
+  NOT for: category-wide or market-level monitoring — use amazon-daily-market-radar instead.
   Requires APICLAW_API_KEY.
 metadata:
   version: "1.1.3"

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: amazon-competitor-intelligence-monitor
 description: >
-  Deep competitor intelligence engine. Produces analytical output focused on
+  Amazon competitor intelligence engine. Produces analytical output focused on
   a defined set of competitors: either a one-shot deep teardown (Full Scan:
   28-35 credits, 11 endpoints, battle card, side-by-side comparison,
   pricing/review/inventory breakdown) OR sustained per-competitor monitoring

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -7,8 +7,8 @@ description: >
   pricing/review/inventory breakdown) OR sustained per-competitor monitoring
   with alerts (Quick Check: 5-10 credits, realtime polling, baseline diff).
   Input: keyword, ASIN(s), or brand — whatever identifies the competitor set
-  to analyze. Output is per-competitor analytical insight, not a daily
-  market-wide change digest.
+  to analyze. Output is per-competitor analytical insight tied to that
+  specific set.
   Use when the user wants focused analysis on identified competitors:
   a one-shot teardown or an ongoing per-competitor watch.
   Use when user asks: analyze competitor B07XXX, battle card for ASIN Y,

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: amazon-competitor-intelligence-monitor
 description: >
-  ASIN-level competitor intelligence. Triggered when the user names SPECIFIC
-  competitor ASINs or branded competitors to analyze, teardown, or watch.
-  Produces deep one-shot teardowns (Full Scan: 28-35 credits, 11 endpoints,
-  battle card, side-by-side analysis, pricing/review/inventory breakdown) AND
-  ongoing per-ASIN monitoring with tiered alerts (Quick Check: 5-10 credits,
-  realtime polling, baseline diff).
-  Use ONLY when the user names SPECIFIC competitor ASINs or brands — never
-  for category-wide or market-level observation without named competitors.
+  Deep competitor intelligence engine. Produces analytical output focused on
+  a defined set of competitors: either a one-shot deep teardown (Full Scan:
+  28-35 credits, 11 endpoints, battle card, side-by-side comparison,
+  pricing/review/inventory breakdown) OR sustained per-competitor monitoring
+  with alerts (Quick Check: 5-10 credits, realtime polling, baseline diff).
+  Input: keyword, ASIN(s), or brand — whatever identifies the competitor set
+  to analyze. Output is per-competitor analytical insight, not a daily
+  market-wide change digest.
+  Use when the user wants focused analysis on identified competitors:
+  a one-shot teardown or an ongoing per-competitor watch.
   Use when user asks: analyze competitor B07XXX, battle card for ASIN Y,
-  track my 5 competitors daily, side-by-side competitor teardown,
-  spy on a specific brand, ongoing watch on named ASINs.
+  side-by-side competitor teardown, spy on a brand, deep analysis of these
+  3 competitors, ongoing watch on a defined competitor set.
   Requires APICLAW_API_KEY.
 metadata:
   version: "1.1.3"

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: amazon-competitor-intelligence-monitor
 description: >
-  ASIN-level competitor intelligence. Given SPECIFIC competitor ASINs or named brands,
-  produces deep one-shot teardowns (Full Scan: 28-35 credits, 11 endpoints, battle card,
-  side-by-side analysis, pricing/review/inventory breakdown) AND ongoing per-ASIN
-  monitoring with tiered alerts (Quick Check: 5-10 credits, realtime polling, baseline diff).
-  Use ONLY when the user names SPECIFIC competitor ASINs or brands to analyze or track.
+  ASIN-level competitor intelligence. Triggered when the user names SPECIFIC
+  competitor ASINs or branded competitors to analyze, teardown, or watch.
+  Produces deep one-shot teardowns (Full Scan: 28-35 credits, 11 endpoints,
+  battle card, side-by-side analysis, pricing/review/inventory breakdown) AND
+  ongoing per-ASIN monitoring with tiered alerts (Quick Check: 5-10 credits,
+  realtime polling, baseline diff).
+  Use ONLY when the user names SPECIFIC competitor ASINs or brands — never
+  for category-wide or market-level observation without named competitors.
   Use when user asks: analyze competitor B07XXX, battle card for ASIN Y,
   track my 5 competitors daily, side-by-side competitor teardown,
   spy on a specific brand, ongoing watch on named ASINs.
-  NOT for: category-wide or market-level monitoring — use amazon-daily-market-radar instead.
   Requires APICLAW_API_KEY.
 metadata:
   version: "1.1.3"

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -1,17 +1,16 @@
 ---
 name: amazon-daily-market-radar
 description: >
-  Market-level daily monitoring and alert system. Given a CATEGORY (not specific ASINs),
-  watches the whole market: price-band shifts, new brand entrants, BSR landscape changes,
-  review wave detection, stockout signals across the category.
+  Market-level daily monitoring and alert system. Triggered by a CATEGORY or
+  KEYWORD (not specific ASINs). Watches the whole market: price-band shifts,
+  new brand entrants, BSR landscape changes, review wave detection, stockout
+  signals across the category.
   Designed for unattended scheduled automation (cron-style daily briefings).
-  Use ONLY when the user wants observation at the CATEGORY or MARKET level —
-  not on specific named competitors.
+  Use ONLY when the user wants observation at the CATEGORY or MARKET level
+  without naming specific competitor ASINs or brands to watch.
   Use when user asks: what changed in my category today, daily category briefing,
   emerging brands in the market, BSR shifts category-wide, market dashboard,
   new entrants alert, stockout signals across a category.
-  NOT for: tracking specific named competitors or ASINs —
-  use amazon-competitor-intelligence-monitor instead.
   Requires APICLAW_API_KEY.
 metadata:
   version: "1.0.3"

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -11,7 +11,7 @@ description: >
   it once, get an alert digest every day.
   Use when the user wants ongoing OPERATIONAL daily monitoring of their
   products and the surrounding market — a "what changed since yesterday"
-  digest, not a one-shot focused teardown of named competitors.
+  digest delivered automatically every day.
   Use when user asks: what changed in my category today, daily category
   briefing, set up daily monitoring, emerging brands alert, BSR shifts
   daily, stockout signals, set-it-and-forget-it market watch.

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: amazon-daily-market-radar
 description: >
-  Automated daily market monitoring and alert system for Amazon sellers.
-  Tracks price changes, new competitors, BSR movements, review spikes,
-  stock-out signals, and market shifts. Designed for unattended agent automation.
-  Uses all 11 APIClaw API endpoints with cross-validation.
-  Use when user asks about: daily monitoring, market alerts, track competitors,
-  price monitoring, BSR tracking, market changes, daily briefing, market watch,
-  competitor alerts, review monitoring, stock alerts, market dashboard,
-  daily report, market updates, what changed today.
+  Market-level daily monitoring and alert system. Given a CATEGORY (not specific ASINs),
+  watches the whole market: price-band shifts, new brand entrants, BSR landscape changes,
+  review wave detection, stockout signals across the category.
+  Designed for unattended scheduled automation (cron-style daily briefings).
+  Use ONLY when the user wants observation at the CATEGORY or MARKET level —
+  not on specific named competitors.
+  Use when user asks: what changed in my category today, daily category briefing,
+  emerging brands in the market, BSR shifts category-wide, market dashboard,
+  new entrants alert, stockout signals across a category.
+  NOT for: tracking specific named competitors or ASINs —
+  use amazon-competitor-intelligence-monitor instead.
   Requires APICLAW_API_KEY.
 metadata:
   version: "1.0.3"

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: amazon-daily-market-radar
 description: >
-  Automated daily market digest. Given the user's own ASINs (1-10) and any
-  competitor ASINs they want included (up to 20), produces a daily
-  change-detection briefing: price moves, BSR shifts, new entrants in the
-  surrounding category, review wave detection, stockout signals. Output is
+  Automated daily Amazon market digest. Given the user's own ASINs (1-10) and
+  any competitor ASINs they want included (up to 20), produces a daily
+  change-detection briefing on Amazon: price moves, BSR shifts, new entrants
+  in the surrounding category, review wave detection, stockout signals. Output is
   a triaged alert dashboard (RED/YELLOW/GREEN) comparing today against
   yesterday's snapshot.
   Designed for unattended scheduled automation (cron-style daily run) — set

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -1,16 +1,20 @@
 ---
 name: amazon-daily-market-radar
 description: >
-  Market-level daily monitoring and alert system. Triggered by a CATEGORY or
-  KEYWORD (not specific ASINs). Watches the whole market: price-band shifts,
-  new brand entrants, BSR landscape changes, review wave detection, stockout
-  signals across the category.
-  Designed for unattended scheduled automation (cron-style daily briefings).
-  Use ONLY when the user wants observation at the CATEGORY or MARKET level
-  without naming specific competitor ASINs or brands to watch.
-  Use when user asks: what changed in my category today, daily category briefing,
-  emerging brands in the market, BSR shifts category-wide, market dashboard,
-  new entrants alert, stockout signals across a category.
+  Automated daily market digest. Given the user's own ASINs (1-10) and any
+  competitor ASINs they want included (up to 20), produces a daily
+  change-detection briefing: price moves, BSR shifts, new entrants in the
+  surrounding category, review wave detection, stockout signals. Output is
+  a triaged alert dashboard (RED/YELLOW/GREEN) comparing today against
+  yesterday's snapshot.
+  Designed for unattended scheduled automation (cron-style daily run) — set
+  it once, get an alert digest every day.
+  Use when the user wants ongoing OPERATIONAL daily monitoring of their
+  products and the surrounding market — a "what changed since yesterday"
+  digest, not a one-shot focused teardown of named competitors.
+  Use when user asks: what changed in my category today, daily category
+  briefing, set up daily monitoring, emerging brands alert, BSR shifts
+  daily, stockout signals, set-it-and-forget-it market watch.
   Requires APICLAW_API_KEY.
 metadata:
   version: "1.0.3"

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: amazon-market-trend-scanner
 description: >
-  Daily Trend Scanner.
-  Scan Amazon category landscapes to discover trending subcategories,
-  emerging niches, and market shifts. Complements Daily Market Radar
-  (defensive monitoring) with offensive trend discovery for product
-  selection and market entry timing. Tracks demand surges, brand
-  consolidation, new entrant waves, price band migration, and margin
-  changes across all subcategories under a parent category.
+  Amazon category trend scanner. Scans Amazon category landscapes to discover
+  trending subcategories, emerging niches, and market shifts. Tracks demand
+  surges, brand consolidation, new entrant waves, price band migration, and
+  margin changes across all subcategories under a parent category.
+  Designed for offensive trend discovery — a snapshot read of where the
+  market is heading, not an opportunity-by-opportunity selection ranking.
   Use when user asks about: market trends, category trends, trending
   categories, what's hot, emerging categories, trend scanner,
-  category trends, market trends, which categories are growing.
+  which categories are growing, where the market is heading.
   Requires APICLAW_API_KEY.
 metadata:
   version: "1.0.2"

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -5,8 +5,6 @@ description: >
   trending subcategories, emerging niches, and market shifts. Tracks demand
   surges, brand consolidation, new entrant waves, price band migration, and
   margin changes across all subcategories under a parent category.
-  Designed for offensive trend discovery — a snapshot read of where the
-  market is heading, not an opportunity-by-opportunity selection ranking.
   Use when user asks about: market trends, category trends, trending
   categories, what's hot, emerging categories, trend scanner,
   which categories are growing, where the market is heading.

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: apiclaw
 description: >
-  API endpoint reference for the APIClaw Amazon commerce data platform.
-  Provides the 12 endpoints (categories, markets, products, competitors, realtime ASIN,
+  API endpoint reference for the APIClaw data platform. Provides the 12
+  endpoints (categories, markets, products, competitors, realtime ASIN,
   AI review analysis, raw reviews, price band, brand, history), their
   inputs/outputs, parameter quirks, Quick Start (auth, base URL), how
   credits are tracked (meta.creditsConsumed field), and the Local Review

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: apiclaw
 description: >
-  API endpoint reference for the APIClaw data platform. Provides the 12
-  endpoints (categories, markets, products, competitors, realtime ASIN,
+  API endpoint reference for the APIClaw Amazon commerce data platform.
+  Provides the 12 endpoints (categories, markets, products, competitors, realtime ASIN,
   AI review analysis, raw reviews, price band, brand, history), their
   inputs/outputs, parameter quirks, Quick Start (auth, base URL), how
   credits are tracked (meta.creditsConsumed field), and the Local Review

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -4,14 +4,15 @@ description: >
   API endpoint reference for the APIClaw data platform. Provides the 12
   endpoints (categories, markets, products, competitors, realtime ASIN,
   AI review analysis, raw reviews, price band, brand, history), their
-  inputs/outputs, credit costs, parameter quirks, Quick Start (auth,
-  base URL), and the Local Review Toolkit (Map/Reduce for raw reviews).
+  inputs/outputs, parameter quirks, Quick Start (auth, base URL), how
+  credits are tracked (meta.creditsConsumed field), and the Local Review
+  Toolkit (Map/Reduce for raw reviews).
   Use when the user asks about the API itself — which endpoints exist,
-  how to call them, field schemas, credit cost per call, parameter quirks,
-  how to authenticate, or how the Local Review Toolkit works.
+  how to call them, field schemas, parameter quirks, how to authenticate,
+  how credit consumption is reported, or how the Local Review Toolkit works.
   Use when user asks: what endpoints does APIClaw have, how do I call
-  /products/search, fields returned by reviews/analysis, credit cost per
-  call, how the Local Review Toolkit works, how to get started.
+  /products/search, fields returned by reviews/analysis, how to check
+  credit usage, how the Local Review Toolkit works, how to get started.
   Requires APICLAW_API_KEY.
 metadata:
   version: "1.1.3"

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -1,18 +1,17 @@
 ---
 name: apiclaw
 description: >
-  Product-level entry point and FAQ for the APIClaw data platform.
-  Use ONLY for product-level questions that are NOT about analyzing a specific
-  commerce surface (Amazon, etc.): what is APIClaw, what markets/domains it covers,
-  credit pricing, account setup, authentication, SDK/integration, comparison with
-  other commerce data providers, platform roadmap.
-  Use when user asks: what is APIClaw, how do I sign up, how much does it cost,
-  what's a credit, how to authenticate, SDK integration help, supported markets,
-  is APIClaw better than X.
-  NOT for: any question naming a specific commerce surface (Amazon, etc.) and asking
-  "what analysis can I do" or "do an analysis" — those belong to the domain-specific
-  fallback (amazon-analysis for Amazon) or a specialized amazon-* skill, even when
-  the user names APIClaw by name.
+  API endpoint reference for the APIClaw data platform. Provides the 12
+  endpoints (categories, markets, products, competitors, realtime ASIN,
+  AI review analysis, raw reviews, price band, brand, history), their
+  inputs/outputs, credit costs, parameter quirks, Quick Start (auth,
+  base URL), and the Local Review Toolkit (Map/Reduce for raw reviews).
+  Use when the user asks about the API itself — which endpoints exist,
+  how to call them, field schemas, credit cost per call, parameter quirks,
+  how to authenticate, or how the Local Review Toolkit works.
+  Use when user asks: what endpoints does APIClaw have, how do I call
+  /products/search, fields returned by reviews/analysis, credit cost per
+  call, how the Local Review Toolkit works, how to get started.
   Requires APICLAW_API_KEY.
 metadata:
   version: "1.1.3"

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: apiclaw
 description: >
-  General overview, 12 API endpoints.
-  AI-powered commerce data infrastructure with 200M+ Amazon products.
-  Endpoints: category browsing, market metrics, product search,
-  competitor lookup, realtime ASIN detail, AI review analysis,
-  live raw reviews (with local Map/Reduce toolkit fallback),
-  price band overview/detail, brand overview/detail, and product history.
-  Use when user asks: what APIClaw can do, available API endpoints,
-  how to get started, API capabilities overview, credit usage, or
-  general commerce data questions. For deep Amazon product selection
-  strategies and analysis workflows, use the Amazon-analysis-skill instead.
+  Product-level entry point and FAQ for the APIClaw data platform.
+  Use ONLY for product-level questions that are NOT about analyzing a specific
+  commerce surface (Amazon, etc.): what is APIClaw, what markets/domains it covers,
+  credit pricing, account setup, authentication, SDK/integration, comparison with
+  other commerce data providers, platform roadmap.
+  Use when user asks: what is APIClaw, how do I sign up, how much does it cost,
+  what's a credit, how to authenticate, SDK integration help, supported markets,
+  is APIClaw better than X.
+  NOT for: any question naming a specific commerce surface (Amazon, etc.) and asking
+  "what analysis can I do" or "do an analysis" — those belong to the domain-specific
+  fallback (amazon-analysis for Amazon) or a specialized amazon-* skill, even when
+  the user names APIClaw by name.
   Requires APICLAW_API_KEY.
 metadata:
   version: "1.1.3"


### PR DESCRIPTION
## Summary

Reframe 5 SKILL.md descriptions so each is **self-contained** (no "use sibling-skill-X instead" cross-references) AND routes cleanly at boundaries. Validated with a 130-query routing-eval harness.

## Two design principles

**1. Self-contained.** When a description says "for X, use sibling-Y instead," it assumes sibling-Y is installed alongside. That assumption breaks the moment a skill is installed standalone — the redirect points at a skill that doesn't exist, and routing ambiguity returns. Each SKILL.md should describe its own scope using **positive triggers** and **semantic shape**.

**2. Description ↔ body alignment.** Description triggers must match what the body actually accepts and produces. An earlier iteration disambiguated monitor vs radar on a fictional input axis ("specific ASINs" vs "category/keyword only") that did not match either skill's actual body. Both skills accept ASINs as input; the real disambiguator is OUTPUT shape (analytical deep-dive vs daily change-detection digest). The descriptions in this PR were re-anchored on the OUTPUT axis to match body reality.

## What changed (vs `main`)

### `amazon-competitor-intelligence-monitor`
- **Before**: Generic "Deep competitor intelligence... continuous monitoring. Two modes..." with broad triggers like `competitor analysis, competitor tracking, competitor monitoring` — no boundary signal between this and the daily market radar skill.
- **After**: Output-axis framing. `Produces analytical output focused on a defined set of competitors: either a one-shot deep teardown (Full Scan: 28-35 credits, 11 endpoints, battle card) OR sustained per-competitor monitoring (Quick Check: 5-10 credits, realtime polling, baseline diff).` Input row clarified to match body: `keyword, ASIN(s), or brand — whatever identifies the competitor set`. Explicitly contrasts with "a daily market-wide change digest" — that's radar's job.

### `amazon-daily-market-radar`
- **Before**: "Automated daily market monitoring... Tracks price changes, new competitors, BSR movements..." with triggers including `track competitors`, `competitor alerts` — overlapped with the monitor skill.
- **After**: Output-axis framing matching body. `Given the user's own ASINs (1-10) and any competitor ASINs they want included (up to 20), produces a daily change-detection briefing... RED/YELLOW/GREEN alerts comparing today vs yesterday's snapshot.` Concrete triggers: `set up daily monitoring`, `what changed in my category today`, `set-it-and-forget-it market watch`. Contrasts with monitor's "one-shot focused teardown of named competitors."

### `amazon-analysis`
- **Before**: "Full-Spectrum Research & Seller Intelligence... For deep specialized workflows (pricing strategy, competitor monitoring, market entry, listing audit, review insights), **use the corresponding specialized skill instead**." Sibling redirect.
- **After**: `Amazon-domain general analysis and multi-endpoint research engine`. Removed the "use the corresponding specialized skill instead" redirect. Replaced with semantic task-shape contrast: broad/composite research vs `a single focused task with a specific deliverable (e.g. a pricing decision, single-ASIN competitor teardown, single-listing audit...) — those each have their own dedicated trigger.` Also adds the APIClaw-domain disambiguator: `even when they name the APIClaw platform, the domain is Amazon so this skill wins`.

### `amazon-market-trend-scanner`
- **Before**: "Daily Trend Scanner... **Complements Daily Market Radar** (defensive monitoring) with offensive trend discovery..." Names sibling skill.
- **After**: Removed the "Complements Daily Market Radar" sibling reference. Kept just the positive description (scans category landscapes, finds trending subcategories, tracks demand surges, brand consolidation, etc.). A short rhetorical sentence about "snapshot read vs opportunity ranking" was tried as a boundary cue against opportunity-discoverer, then dropped after the routing-eval confirmed trend|opportunity still routes at 5/5 modal without it — the positive description carried the signal on its own.

### `apiclaw`
- **Before**: "General overview, 12 API endpoints... For deep Amazon product selection strategies and analysis workflows, **use the Amazon-analysis-skill instead**." Sibling redirect.
- **After**: `API endpoint reference for the APIClaw data platform`. Removed the "use the Amazon-analysis-skill instead" redirect. Description names the 12 endpoints, parameter quirks, Quick Start (auth, base URL), Local Review Toolkit, and the credit-tracking mechanism (`meta.creditsConsumed` field — what the body actually documents, not a per-endpoint pricing table). Triggers: `what endpoints does APIClaw have`, `how do I call /products/search`, `how to check credit usage`.

Each description now reads cleanly even if zero sibling skills are present.

## How verified

Built a routing-eval harness (kept local, not in this PR) that runs each description through parallel subagent routers.

**Fixture**: 130 queries — 80 in_scope (8 per skill, zh/en) + 30 boundary (5 per pair × 6 pairs) + 10 OOS + 10 multi-step journey.

**Phase 2 paraphrase consistency**: 30 boundary queries × 5 surface-form paraphrases = 150 routing decisions. Modal vote per query, then check it matches ground truth.

**Final results (v11)**:
- 6/6 boundary pairs at 100% Phase-2-modal match
- 80/80 in_scope queries route correctly
- 10/10 OOS queries return NONE
- 0 spillover regressions across pairs

During v11 testing one pair (`listing-audit-pro` vs `review-intelligence-extractor`) revealed 5 fixture queries that genuinely belong to `review-intelligence-extractor` — its description explicitly advertises "generates listing copy suggestions" from review insights, which is a direct match for queries like "use reviews to rewrite my listing." The relabel happened in local fixtures (not in this PR); it confirms the v11 routing is correct rather than a regression.

## What's NOT in this PR

- SKILL.md bodies, metadata blocks, version/author/homepage — all unchanged
- Other skills — unchanged
- The routing-eval harness (`tests/skill-routing-eval/`) — local tooling, separate concern

## Spec compliance

All 5 descriptions stay under the 1024-character Agent Skills frontmatter limit:

| Skill | Chars |
|---|---:|
| `amazon-analysis` | 915 |
| `amazon-daily-market-radar` | 915 |
| `amazon-competitor-intelligence-monitor` | 887 |
| `apiclaw` | 832 |
| `amazon-market-trend-scanner` | 500 |

## Test plan

- [ ] Smoke-test routing in Claude Code: invoke 3-4 boundary queries (e.g., "track my 5 competitors daily", "what changed in my category today", "what endpoints does APIClaw have") and confirm the right skill loads
- [ ] Spot-check standalone install: pick any one of the 5 skills, install it alone, and read the SKILL.md description to confirm it no longer references missing siblings
- [ ] Verify all 5 descriptions remain under 1024 chars
- [ ] Verify only the frontmatter description block was touched (`git diff origin/main -- '*/SKILL.md'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
