### PR TITLE
fix(skills): add 401/402 fallback protocols + clean URL routing

### DIFF
--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -59,6 +59,10 @@ User provides: keyword, category, ASIN, or brand — depending on intent. Use in
 8. **history empty**: try oldest-listed ASINs first, up to 3 rounds of different ASINs before giving up
 9. **Sales null fallback**: Monthly sales ≈ 300,000 / BSR^0.65
 
+## On 401 Invalid Key
+
+When `apiclaw.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `apiclaw/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.
+
 ## On 402 Credit Exhausted
 
 When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -59,6 +59,10 @@ User provides: keyword, category, ASIN, or brand — depending on intent. Use in
 8. **history empty**: try oldest-listed ASINs first, up to 3 rounds of different ASINs before giving up
 9. **Sales null fallback**: Monthly sales ≈ 300,000 / BSR^0.65
 
+## On 402 Credit Exhausted
+
+When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.
+
 ## 14 Product Selection Modes
 
 | Mode | One-line Description |

--- a/amazon-analysis/scripts/apiclaw.py
+++ b/amazon-analysis/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
+                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-analysis/scripts/apiclaw.py
+++ b/amazon-analysis/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
+                    "Top up credits at https://apiclaw.io/en/pricing",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -63,6 +63,10 @@ Brand queries MUST also include confirmed `--category`.
       - **Small-sample rule (reviewCount<50)**: demote single-mention items 📊→🔍; NEVER attach table-level or section-header 📊 when any row inside is 🔍; suppress "🔴 Critical" verdicts on count=1
       - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (competitor metrics, brand ranking, pricing, etc.) remain valid — do not re-run them.
 
+## On 401 Invalid Key
+
+When `apiclaw.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `apiclaw/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.
+
 ## On 402 Credit Exhausted
 
 When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -63,6 +63,10 @@ Brand queries MUST also include confirmed `--category`.
       - **Small-sample rule (reviewCount<50)**: demote single-mention items 📊→🔍; NEVER attach table-level or section-header 📊 when any row inside is 🔍; suppress "🔴 Critical" verdicts on count=1
       - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (competitor metrics, brand ranking, pricing, etc.) remain valid — do not re-run them.
 
+## On 402 Credit Exhausted
+
+When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.
+
 ## Mode Selection
 
 - **Full Scan** (~28-35 credits): First run, no baseline.json, explicit request, or weekly refresh

--- a/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
+++ b/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
+                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
+++ b/amazon-competitor-intelligence-monitor/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
+                    "Top up credits at https://apiclaw.io/en/pricing",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -62,6 +62,10 @@ Collect in ONE message: ✅ my_asins (1-10) | 💡 competitor_asins (up to 20) |
       - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (price/BSR/sales deltas, alerts, watchlist baseline) remain valid — do not re-run them.
 5. **Aggregation without categoryPath**: severely distorted data
 
+## On 401 Invalid Key
+
+When `apiclaw.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `apiclaw/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.
+
 ## On 402 Credit Exhausted
 
 When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -62,6 +62,10 @@ Collect in ONE message: ✅ my_asins (1-10) | 💡 competitor_asins (up to 20) |
       - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (price/BSR/sales deltas, alerts, watchlist baseline) remain valid — do not re-run them.
 5. **Aggregation without categoryPath**: severely distorted data
 
+## On 402 Credit Exhausted
+
+When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.
+
 ## Execution
 
 1. `daily-radar --asins "asin1,asin2,..." [--keyword X] [--category Y]` (composite, auto-detects category from ASINs)

--- a/amazon-daily-market-radar/scripts/apiclaw.py
+++ b/amazon-daily-market-radar/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
+                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-daily-market-radar/scripts/apiclaw.py
+++ b/amazon-daily-market-radar/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
+                    "Top up credits at https://apiclaw.io/en/pricing",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -62,6 +62,10 @@ Required: my_asin. Optional: keyword, category. Category is auto-detected from A
       - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (8-dimension audit scores, title/bullet/A+ checks, category-leader benchmarks) remain valid — do not re-run them.
 5. **Sales null fallback**: Monthly sales ≈ 300,000 / BSR^0.65, tag 🔍
 
+## On 401 Invalid Key
+
+When `apiclaw.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `apiclaw/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.
+
 ## On 402 Credit Exhausted
 
 When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -62,6 +62,10 @@ Required: my_asin. Optional: keyword, category. Category is auto-detected from A
       - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (8-dimension audit scores, title/bullet/A+ checks, category-leader benchmarks) remain valid — do not re-run them.
 5. **Sales null fallback**: Monthly sales ≈ 300,000 / BSR^0.65, tag 🔍
 
+## On 402 Credit Exhausted
+
+When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.
+
 ## Execution
 
 1. `listing-audit --my-asin X [--keyword Y] [--category Z]` (composite, auto-detects category from ASIN)

--- a/amazon-listing-audit-pro/scripts/apiclaw.py
+++ b/amazon-listing-audit-pro/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
+                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-listing-audit-pro/scripts/apiclaw.py
+++ b/amazon-listing-audit-pro/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
+                    "Top up credits at https://apiclaw.io/en/pricing",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -57,6 +57,10 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
      - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (GO/CAUTION/AVOID verdict, market size, brand/price analysis) remain valid — do not re-run them.
 - Aggregation endpoints without categoryPath produce severely distorted data
 
+## On 401 Invalid Key
+
+When `apiclaw.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `apiclaw/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.
+
 ## On 402 Credit Exhausted
 
 When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -57,6 +57,10 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
      - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (GO/CAUTION/AVOID verdict, market size, brand/price analysis) remain valid — do not re-run them.
 - Aggregation endpoints without categoryPath produce severely distorted data
 
+## On 402 Credit Exhausted
+
+When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.
+
 ## Unique Logic
 
 ### Sub-Market Discovery

--- a/amazon-market-entry-analyzer/scripts/apiclaw.py
+++ b/amazon-market-entry-analyzer/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
+                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-market-entry-analyzer/scripts/apiclaw.py
+++ b/amazon-market-entry-analyzer/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
+                    "Top up credits at https://apiclaw.io/en/pricing",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -48,6 +48,10 @@ Required: 1+ category paths or keywords. Optional: scan depth, metric preference
 3. **Use API fields directly**: revenue=`sampleAvgMonthlyRevenue`, sales=`monthlySalesFloor`
 4. **Key metrics per subcategory**: sampleAvgMonthlySales, sampleNewSkuRate, topBrandSalesRate, sampleAvgPrice, sampleAPlusRate, totalSkuCount, sampleFbaRate
 
+## On 401 Invalid Key
+
+When `apiclaw.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `apiclaw/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.
+
 ## On 402 Credit Exhausted
 
 When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -48,6 +48,10 @@ Required: 1+ category paths or keywords. Optional: scan depth, metric preference
 3. **Use API fields directly**: revenue=`sampleAvgMonthlyRevenue`, sales=`monthlySalesFloor`
 4. **Key metrics per subcategory**: sampleAvgMonthlySales, sampleNewSkuRate, topBrandSalesRate, sampleAvgPrice, sampleAPlusRate, totalSkuCount, sampleFbaRate
 
+## On 402 Credit Exhausted
+
+When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.
+
 ## Mode 1: Full Scan
 
 1. `categories --keyword "{keyword}"` → resolve category path

--- a/amazon-market-trend-scanner/scripts/apiclaw.py
+++ b/amazon-market-trend-scanner/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
+                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-market-trend-scanner/scripts/apiclaw.py
+++ b/amazon-market-trend-scanner/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
+                    "Top up credits at https://apiclaw.io/en/pricing",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -57,6 +57,10 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 - Deduplicate ASINs across modes — same product appears in multiple scans
 - Each mode has **built-in filters that STACK** with user filters (e.g. beginner: $15-60, sales≥300)
 
+## On 402 Credit Exhausted
+
+When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.
+
 ## Unique Logic
 
 ### Profile → Strategy Mapping

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -57,6 +57,10 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 - Deduplicate ASINs across modes — same product appears in multiple scans
 - Each mode has **built-in filters that STACK** with user filters (e.g. beginner: $15-60, sales≥300)
 
+## On 401 Invalid Key
+
+When `apiclaw.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `apiclaw/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.
+
 ## On 402 Credit Exhausted
 
 When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.

--- a/amazon-opportunity-discoverer/scripts/apiclaw.py
+++ b/amazon-opportunity-discoverer/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
+                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-opportunity-discoverer/scripts/apiclaw.py
+++ b/amazon-opportunity-discoverer/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
+                    "Top up credits at https://apiclaw.io/en/pricing",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -51,6 +51,10 @@ On first interaction, tell user: "Give me your ASIN(s). I support single or batc
 - FBA fees from products/search are estimates — verify with Amazon FBA calculator
 - Aggregation endpoints without categoryPath produce severely distorted data
 
+## On 401 Invalid Key
+
+When `apiclaw.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `apiclaw/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.
+
 ## On 402 Credit Exhausted
 
 When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -51,6 +51,10 @@ On first interaction, tell user: "Give me your ASIN(s). I support single or batc
 - FBA fees from products/search are estimates — verify with Amazon FBA calculator
 - Aggregation endpoints without categoryPath produce severely distorted data
 
+## On 402 Credit Exhausted
+
+When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.
+
 ## Pricing Signal Logic
 
 | Signal | Condition |

--- a/amazon-pricing-command-center/scripts/apiclaw.py
+++ b/amazon-pricing-command-center/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
+                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-pricing-command-center/scripts/apiclaw.py
+++ b/amazon-pricing-command-center/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
+                    "Top up credits at https://apiclaw.io/en/pricing",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -45,6 +45,10 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 - ASIN-specific endpoints don't need `--category`; keyword-based ones do
 - **Category auto-detection**: categoryPath is auto-detected from target ASIN. If `category_source` in output is `inferred_from_search`, confirm with user
 
+## On 402 Credit Exhausted
+
+When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.
+
 ## 11 Analysis Dimensions
 `painPoints` · `issues` · `positives` · `improvements` · `buyingFactors` · `keywords` · `userProfiles` · `scenarios` · `usageTimes` · `usageLocations` · `behaviors`
 

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -45,6 +45,10 @@ Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apicl
 - ASIN-specific endpoints don't need `--category`; keyword-based ones do
 - **Category auto-detection**: categoryPath is auto-detected from target ASIN. If `category_source` in output is `inferred_from_search`, confirm with user
 
+## On 401 Invalid Key
+
+When `apiclaw.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `apiclaw/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.
+
 ## On 402 Credit Exhausted
 
 When `apiclaw.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `apiclaw/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.

--- a/amazon-review-intelligence-extractor/scripts/apiclaw.py
+++ b/amazon-review-intelligence-extractor/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
+                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/amazon-review-intelligence-extractor/scripts/apiclaw.py
+++ b/amazon-review-intelligence-extractor/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
+                    "Top up credits at https://apiclaw.io/en/pricing",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -55,7 +55,7 @@ When `apiclaw.py` returns `{"code": 402, "message": "API quota exhausted or subs
    - Which step in the workflow was reached (e.g. "Completed step 3/5: brand analysis")
    - Partial findings already collected (show the actual data, not just a list of completed steps)
    - Rough credits needed to resume (sum remaining-step costs from this skill's API Budget table)
-   - Top-up link: https://apiclaw.io/en/api-keys
+   - Top-up link: https://apiclaw.io/en/pricing
 3. **Do not fabricate or guess** the missing data to "complete" the report. Mark partial findings explicitly as partial.
 
 ## 12 Endpoints

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -46,6 +46,18 @@ metadata:
 7. **Aggregation endpoints** (price-band, brand) without categoryPath produce severely distorted data
 8. **Price-band and brand endpoints only accept `keyword`** (not categoryPath) — cross-validate returned products
 
+## On 402 Credit Exhausted
+
+When `apiclaw.py` returns `{"code": 402, "message": "API quota exhausted or subscription expired"}`:
+
+1. **STOP further endpoint calls immediately.** Do not retry. Do not switch endpoints as a workaround — 402 is account-level (key/subscription), not endpoint-level.
+2. **Report to the user** with all four of:
+   - Which step in the workflow was reached (e.g. "Completed step 3/5: brand analysis")
+   - Partial findings already collected (show the actual data, not just a list of completed steps)
+   - Rough credits needed to resume (sum remaining-step costs from this skill's API Budget table)
+   - Top-up link: https://apiclaw.io/en/api-keys
+3. **Do not fabricate or guess** the missing data to "complete" the report. Mark partial findings explicitly as partial.
+
 ## 12 Endpoints
 
 | # | Endpoint | Purpose | Key Output |

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -46,6 +46,17 @@ metadata:
 7. **Aggregation endpoints** (price-band, brand) without categoryPath produce severely distorted data
 8. **Price-band and brand endpoints only accept `keyword`** (not categoryPath) — cross-validate returned products
 
+## On 401 Invalid Key
+
+When `apiclaw.py` returns `{"code": 401, "message": "API Key invalid or expired"}`:
+
+1. **STOP further endpoint calls immediately.** Do not retry — a rejected key won't be accepted on a second try; every subsequent call will return 401 too.
+2. **Report to the user**:
+   - The `APICLAW_API_KEY` in use was rejected (likely invalid, revoked, or expired)
+   - If any partial findings were collected before the failure, show them and mark as partial
+   - Fix at https://apiclaw.io/en/api-keys (verify the key, regenerate if needed)
+3. **Do not fabricate or guess** the data the failed calls would have returned.
+
 ## On 402 Credit Exhausted
 
 When `apiclaw.py` returns `{"code": 402, "message": "API quota exhausted or subscription expired"}`:

--- a/apiclaw/scripts/apiclaw.py
+++ b/apiclaw/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Check your plan at https://apiclaw.io/en/api-keys or provide a new Key",
+                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits

--- a/apiclaw/scripts/apiclaw.py
+++ b/apiclaw/scripts/apiclaw.py
@@ -177,7 +177,7 @@ def api_call(endpoint: str, params: dict) -> dict:
                     endpoint, actual_params)
             elif status == 402:
                 return _error_result(402, "API quota exhausted or subscription expired",
-                    "Top up credits at https://apiclaw.io/en/pricing (or switch to a different key — manage keys at https://apiclaw.io/en/api-keys)",
+                    "Top up credits at https://apiclaw.io/en/pricing",
                     endpoint, actual_params)
             elif status == 429:
                 # Switch to longer retry strategy for rate limits


### PR DESCRIPTION
## Summary

Adds **two parallel account-level failure protocols** (HTTP 401 + 402) to the SKILL.md bodies, with cleanly separated user-facing URLs. Until now, both failure modes were handled only at the script layer with no SKILL.md-level guidance for the agent — leading to inconsistent agent behavior and a real risk of fabricating missing data to "complete" a report.

## What changed

### Canonical protocols (`apiclaw/SKILL.md`)
Added two parallel sections in the "API Pitfalls" area:

- **`## On 401 Invalid Key`** — when `apiclaw.py` returns `{"code": 401}`: STOP further calls, tell user the key was rejected, point to `https://apiclaw.io/en/api-keys`, do not fabricate.
- **`## On 402 Credit Exhausted`** — when `apiclaw.py` returns `{"code": 402}`: STOP further calls, report step reached + partial findings + credits-to-resume estimate, point to `https://apiclaw.io/en/pricing`, do not fabricate.

### Pointer subsections (9 × `amazon-*/SKILL.md`)
Each consuming skill gets a 1-line pointer to the canonical protocol — Progressive Disclosure pattern from agentskills.io best practices. DRY: future protocol updates touch only the canonical source.

### URL clean-up (`apiclaw/scripts/apiclaw.py` + 9 synced copies)
- **401 hint** stays at `/api-keys` (key management — already correct)
- **402 hint** moved from mixed text to focused `Top up credits at https://apiclaw.io/en/pricing`

Clean separation: 401 ↔ `/api-keys` (key problems), 402 ↔ `/pricing` (credit problems).

## Why

Before: agent saw a structured error object and had to improvise — often resulting in either silent over-retry or fabricated reports. After: explicit STOP + actionable URL + don't-fabricate rule.

## Files (20 changed, +105 / -10)

\`\`\`
apiclaw/SKILL.md                    +23 lines (canonical 401 + 402)
apiclaw/scripts/apiclaw.py           1 line  (402 message URL)
9 × amazon-*/SKILL.md               +8 lines each (2 pointer subsections)
9 × amazon-*/scripts/apiclaw.py      1 line each (synced via sync-scripts.sh)
\`\`\`

## Out of scope (deliberately)
- 429 / 500 / 403: script auto-handles, no fabrication risk
- Proactive credit warnings: reactive protocol is sufficient
- Partial-state persistence across conversations: out of scope for body-level protocols

🤖 Generated with [Claude Code](https://claude.com/claude-code)