### PR TITLE
[codex] add amazon keyword intelligence skill docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ https://github.com/user-attachments/assets/305a161b-7a53-49b8-afdc-4469a4fbf361
 
 ## Skills Overview
 
-This repo contains **10 agent skills** organized in two tiers:
+This repo contains **11 agent skills** organized in two tiers:
 
 **🏗️ Foundation** — data access and full-spectrum analysis:
 
@@ -48,6 +48,7 @@ This repo contains **10 agent skills** organized in two tiers:
 |-------|-------------|-------|--------|---------------|
 | 📦 [`apiclaw/`](apiclaw/) | Direct access to all 11 API endpoints — categories, markets, products, competitors, realtime, reviews, price bands, brands, history | Keyword, category, ASIN, or brand | Raw API data with field mapping and quirk documentation | Complete API reference — every other skill builds on this |
 | 🎯 [`amazon-analysis/`](amazon-analysis/) | 13 built-in selection modes + market research, competitor analysis, ASIN evaluation, pricing, category research | Keyword/category/ASIN + intent | Analysis findings, top products, ASIN deep dives, confidence-tagged insights | Composite commands (`report`, `opportunity`) run multi-endpoint pipelines in one shot |
+| 🔎 [`amazon-keywords/`](amazon-keywords/) | Keyword intelligence workflows built on 6 keyword endpoints | Seed keyword, target keyword, ASIN, or ASIN + keyword | Expansion tiers, single-keyword verdicts, reverse-ASIN traffic terms, anomaly explanations | Dedicated flows for keyword expansion, reverse ASIN, and keyword monitoring |
 
 **⚡ Specialized** — purpose-built for specific workflows:
 
@@ -75,6 +76,7 @@ You'll be prompted to select which skills to install:
 **🏗️ Foundation:**
 - **APIClaw — Amazon Commerce Data, 11 Endpoints**
 - **Amazon Analysis — Full-Spectrum Research & Seller Intelligence**
+- **Amazon Keyword Intelligence — Expansion, Reverse ASIN & Monitoring**
 
 **⚡ Specialized:**
 - **Amazon Competitor Intelligence Monitor** — Dual-mode competitive intelligence with tiered alerts
@@ -172,6 +174,17 @@ The `products/search` endpoint supports 13 preset modes for different research s
 │   │   └── scenarios-listing.md            # Listing writing, optimization
 │   └── scripts/
 │       └── apiclaw.py                      # CLI — 8 subcommands, 13 preset modes
+│
+├── amazon-keywords/                      # Keyword intelligence & traffic analysis
+│   ├── SKILL.md
+│   ├── README.md
+│   └── references/
+│       ├── reference.md                    # Keyword endpoint reference
+│       ├── execution-guide.md              # Execution and monitoring rules
+│       ├── scenarios-expand.md             # Keyword expansion
+│       ├── scenarios-keyword-analysis.md   # Single-keyword evaluation
+│       ├── scenarios-reverse-asin.md       # Reverse ASIN analysis
+│       └── scenarios-keyword-traffic-diagnosis.md # Keyword traffic anomaly diagnosis
 │
 ├── amazon-competitor-intelligence-monitor/  # Competitor intelligence & monitoring
 │   ├── SKILL.md

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,7 +37,7 @@
 
 ## 技能概览
 
-本仓库包含 **10 个 Agent 技能**，分为两个层级：
+本仓库包含 **11 个 Agent 技能**，分为两个层级：
 
 **🏗️ 基础层** — 数据接入与全方位分析：
 
@@ -45,6 +45,7 @@
 |------|------|------|------|----------|
 | 📦 [`apiclaw/`](apiclaw/) | 直接调用全部 11 个 API 端点 | 关键词/品类/ASIN/品牌 | 原始 API 数据 + 字段映射文档 | 所有其他 skill 的底层依赖 |
 | 🎯 [`amazon-analysis/`](amazon-analysis/) | 13 种选品模式 + 市场/竞品/ASIN/定价/品类研究 | 关键词/品类/ASIN + 意图 | 分析发现、Top 产品、深度报告、置信度标签 | report/opportunity 复合命令一键跑完 |
+| 🔎 [`amazon-keywords/`](amazon-keywords/) | 基于 6 个关键词接口的关键词 intelligence 工作流 | 种子词、目标词、ASIN 或 ASIN + 关键词 | 拓词分层、单词判定、反查流量词、异动解释 | 专门覆盖拓词、反查 ASIN、关键词监控 |
 
 **⚡ 专项层** — 面向特定工作流的专用技能：
 
@@ -72,6 +73,7 @@ npx skills add SerendipityOneInc/APIClaw-Skills
 **🏗️ 基础层：**
 - **APIClaw** — 数据层概览，11 个 API 接口，快速集成
 - **Amazon Analysis** — 13 种选品模式，市场验证，竞品情报
+- **Amazon Keyword Intelligence** — 拓词、反查 ASIN、关键词监控
 
 **⚡ 专项层：**
 - **Amazon Competitor Intelligence Monitor** — 双模式竞品情报与三级告警
@@ -169,6 +171,17 @@ python amazon-analysis/scripts/apiclaw.py products --keyword "wireless earbuds" 
 │   │   └── scenarios-listing.md            # Listing 撰写与优化
 │   └── scripts/
 │       └── apiclaw.py                      # CLI 工具 — 8 个子命令，13 种预设模式
+│
+├── amazon-keywords/                      # 关键词 intelligence 与流量分析
+│   ├── SKILL.md
+│   ├── README.md
+│   └── references/
+│       ├── reference.md                    # 关键词接口与字段参考
+│       ├── execution-guide.md              # 执行与监控规则
+│       ├── scenarios-expand.md             # 关键词拓词
+│       ├── scenarios-keyword-analysis.md   # 单关键词分析
+│       ├── scenarios-reverse-asin.md       # 关键词反查
+│       └── scenarios-keyword-traffic-diagnosis.md # 关键词流量异动诊断
 │
 ├── amazon-competitor-intelligence-monitor/  # 竞品情报监控
 │   ├── SKILL.md

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -56,7 +56,7 @@ User provides: keyword, category, ASIN, or brand — depending on intent. Use in
       d. `apiclaw.py review-aggregate --reviews R --tagged T --clusters C`
          → consumerInsights output compatible with `/reviews/analysis`
 5. **Aggregation without categoryPath**: produces severely distorted data
-6. **`.data` is array**: use `.data[0]`, not `.data.field`
+6. **Check the `data` shape before indexing**: many search/list endpoints return `.data` as an array, so use `.data[0]` for the first record in those cases; some commands return non-array payloads inside `data`
 7. **labelType**: NOT an API request parameter — it is a field in the response `consumerInsights` array, used for client-side filtering
 8. **history empty**: try oldest-listed ASINs first, up to 3 rounds of different ASINs before giving up
 9. **Sales null fallback**: Monthly sales ≈ 300,000 / BSR^0.65

--- a/amazon-analysis/references/execution-guide.md
+++ b/amazon-analysis/references/execution-guide.md
@@ -127,9 +127,12 @@ When `monthlySalesFloor` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
 
 ### Data Provenance Block (Full Mode Only)
 
-```markdown
+Use this rendered template at the end of every Full-mode report:
+
 ---
+
 📋 **Data Provenance**
+
 | Item | Value |
 |------|-------|
 | Query Keyword | [keyword used] |
@@ -142,7 +145,6 @@ When `monthlySalesFloor` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
 | Endpoints Used | [list with call count] |
 | Credits Consumed | [total] |
 | Known Limitations | [list any gaps] |
-```
 
 **Rules**:
 1. Every Full-mode analysis MUST end with this block
@@ -153,8 +155,10 @@ When `monthlySalesFloor` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
 
 ### API Usage Summary (All Modes — MANDATORY)
 
-```markdown
+Use this rendered template at the end of every report:
+
 📊 **API Usage**
+
 | Interface | Calls |
 |-----------|-------|
 | categories | 1 |
@@ -165,7 +169,6 @@ When `monthlySalesFloor` is null: **Monthly sales ≈ 300,000 / BSR^0.65**
 | **Total** | **8** |
 | **Credits consumed** | **8** |
 | **Credits remaining** | **492** |
-```
 
 **Tracking rules:**
 1. Count each `apiclaw.py` execution as 1 call to the corresponding interface
@@ -215,7 +218,7 @@ The interfaces return **different fields**. Do NOT assume they share the same st
 
 ## Data Structure Reminder
 
-All interfaces return `.data` as an **array**. Use `.data[0]` to get the first record, NOT `.data.fieldName`.
+Many interfaces return `.data` as an **array**. Use `.data[0]` to get the first record for those responses, but inspect the actual payload shape first because some commands return non-array data inside `data`.
 
 ---
 
@@ -226,7 +229,7 @@ Self-check: `python3 scripts/apiclaw.py check`
 
 | Error | Fix |
 |-------|-----|
-| `Cannot index array with string` | Use `.data[0].fieldName` (`.data` is array) |
+| `Cannot index array with string` | If the response `data` is an array, use `.data[0].fieldName`; otherwise inspect the actual payload shape first |
 | Empty `data: []` | Use `categories` to confirm category exists |
 | `monthlySalesFloor: null` | BSR estimate: 300,000 / BSR^0.65 |
 

--- a/amazon-keywords/README.md
+++ b/amazon-keywords/README.md
@@ -1,0 +1,59 @@
+# Amazon Keyword Intelligence — APIClaw Agent Skill
+
+> Four keyword workflows built on APIClaw's six keyword endpoints.
+
+## What This Skill Does
+
+This skill is for search-demand and keyword-traffic work that product/category skills do not cover well.
+
+It supports four common scenarios:
+
+1. **Keyword expansion** — start from a seed term and find candidate ad keywords
+2. **Single keyword analysis** — decide whether one keyword is worth targeting
+3. **Reverse ASIN keyword analysis** — inspect which keywords are driving an ASIN's visibility
+4. **Keyword traffic monitoring** — watch an ASIN on a keyword and explain anomalies
+
+## Endpoints Used
+
+The skill is designed around these six APIClaw endpoints:
+
+- `/openapi/v2/keywords/detail`
+- `/openapi/v2/keywords/trend`
+- `/openapi/v2/keywords/extends`
+- `/openapi/v2/keywords/search-results`
+- `/openapi/v2/keywords/competitor-product-keywords`
+- `/openapi/v2/keywords/product-traffic-terms`
+
+## Draft Tool Names
+
+To reduce agent guessing, document and prefer full callable tool names.
+These are draft names inferred from other APIClaw tool naming patterns and
+should be manually confirmed against the active session:
+
+- `mcp__apiclaw.openapi_v2_keyword_detail`
+- `mcp__apiclaw.openapi_v2_keyword_trend`
+- `mcp__apiclaw.openapi_v2_keyword_extends`
+- `mcp__apiclaw.openapi_v2_keyword_search_results`
+- `mcp__apiclaw.openapi_v2_keyword_competitor_product_keywords`
+- `mcp__apiclaw.openapi_v2_keyword_product_traffic_terms`
+
+## What You Get
+
+- Candidate keyword tiers: `Priority test` / `Selective test` / `Observe only` / `Exclude`
+- Single-keyword viability assessment across demand, competition, ad density, and SERP structure
+- Reverse ASIN keyword source view with traffic-share-based prioritization
+- Keyword anomaly diagnosis with likely cause analysis
+
+## Example Prompts
+
+- "基于 `wireless earbuds` 给我拓一批适合投放的关键词，并粗筛"
+- "帮我分析 `yoga mat` 这个词值不值得投"
+- "反查 ASIN `B0XXXXXXX` 的关键词流量来源"
+- "监控 ASIN `B0XXXXXXX` 在 `collagen peptides` 下的异动，并解释原因"
+
+## Notes
+
+- This skill currently focuses on workflow design and endpoint orchestration.
+- If the active session has not exposed the required keyword tools, report that boundary explicitly instead of guessing or fabricating calls.
+- Use API docs only as a parameter/schema fallback after live tool-surface verification, not as a substitute for unavailable live tools.
+- Scenario docs are split one-per-file for easier routing: expansion, keyword analysis, reverse ASIN, and keyword monitoring.

--- a/amazon-keywords/SKILL.md
+++ b/amazon-keywords/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: amazon-keywords
+description: >
+  Use when user asks for keyword expansion or ad keyword filtering; whether a keyword is worth
+  bidding on; which keywords drive traffic to an ASIN; or why an ASIN changed under a keyword.
+  Requires APICLAW_API_KEY.
+metadata:
+  version: "0.1.0"
+  author: SerendipityOneInc
+  homepage: https://github.com/SerendipityOneInc/APIClaw-Skills
+  openclaw: {"requires": {"env": ["APICLAW_API_KEY"]}, "primaryEnv": "APICLAW_API_KEY"}
+---
+
+# APIClaw — Amazon Keyword Intelligence
+
+> Amazon keyword research and traffic analysis. Respond in user's language.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `{skill_base_dir}/references/reference.md` | Load when you need exact endpoint fields, quirks, or scoring inputs |
+| `{skill_base_dir}/references/execution-guide.md` | Load for full execution protocol and monitoring rules |
+| `{skill_base_dir}/references/scenarios-expand.md` | Load for keyword expansion flow |
+| `{skill_base_dir}/references/scenarios-keyword-analysis.md` | Load for single-keyword evaluation flow |
+| `{skill_base_dir}/references/scenarios-reverse-asin.md` | Load for reverse ASIN keyword analysis flow |
+| `{skill_base_dir}/references/scenarios-keyword-traffic-diagnosis.md` | Load for keyword traffic diagnosis flow |
+
+## Credential
+
+Required: `APICLAW_API_KEY`. Get free key at [apiclaw.io/api-keys](https://apiclaw.io/en/api-keys).
+
+## Input
+
+User typically provides one of:
+- seed keyword
+- target keyword
+- ASIN
+- ASIN + keyword
+- marketplace and date range constraints
+
+If marketplace is omitted, default to `US`. If date is omitted, use the latest available date window supported by the endpoint.
+
+## Data Source
+
+All keyword data comes from **Amazon Brand Analytics (ABA) backend**. Coverage is limited to keywords that appear in ABA — keywords with no ABA record will return `data: null` or empty results, not an API error. Do not treat missing data as a signal of low demand; it means the keyword is outside ABA coverage.
+
+## Supported Endpoints
+
+This skill is built around these six keyword endpoints:
+
+1. `/openapi/v2/keywords/detail`
+2. `/openapi/v2/keywords/trend`
+3. `/openapi/v2/keywords/extends`
+4. `/openapi/v2/keywords/search-results`
+5. `/openapi/v2/keywords/competitor-product-keywords`
+6. `/openapi/v2/keywords/product-traffic-terms`
+
+## Callable Tool Names
+
+Business endpoint paths and MCP callable tool names are not the same thing.
+
+**MANDATORY — do this before any tool call or capability claim:**
+1. Inspect the live tool surface of the current session
+2. Read the live schema / field descriptions of any candidate tool
+3. Only then judge capability — tool name alone is not evidence
+
+| HTTP endpoint path | Draft callable tool name |
+|-------------------|--------------------------|
+| `/openapi/v2/keywords/detail` | `mcp__apiclaw__openapi_v2_keyword_detail` |
+| `/openapi/v2/keywords/trend` | `mcp__apiclaw__openapi_v2_keyword_trend` |
+| `/openapi/v2/keywords/extends` | `mcp__apiclaw__openapi_v2_keyword_extends` |
+| `/openapi/v2/keywords/search-results` | `mcp__apiclaw__openapi_v2_keyword_search_results` |
+| `/openapi/v2/keywords/competitor-product-keywords` | `mcp__apiclaw__openapi_v2_keyword_competitor_product_keywords` |
+| `/openapi/v2/keywords/product-traffic-terms` | `mcp__apiclaw__openapi_v2_keyword_product_traffic_terms` |
+
+The draft names above follow the naming convention seen in other APIClaw skills. If the live session exposes a different name, use that name exactly.
+
+**PROHIBITED — never do any of the following:**
+- Call a keyword tool before inspecting its live schema
+- Declare a keyword endpoint unavailable without first checking both the live tool surface and its schema
+- Say "the keyword-volume interface is not available" because you didn't see a tool named "keyword volume"
+- Use `products/search` as a substitute for keyword endpoints and label its results as keyword traffic evidence
+- Treat `webtools_search` as a keyword-intelligence endpoint
+- "Normalize" a live callable name back to the draft name above
+
+**Capability signals in live schema:** If a tool exposes fields such as `estimateSearchCountWeekly`, `estimateSearchCount`, `keywordEstimateSearchCount`, or `abaRank`, treat it as having keyword-volume capability even if its name is not explicit.
+
+**Tool boundary rules (CRITICAL — do not misclassify):**
+
+| Tool | Role | NEVER use it as |
+|------|------|-----------------|
+| `/openapi/v2/keywords/*` | Keyword intelligence (snapshot, trend, SERP, ASIN traffic) | — |
+| `products/search` | Product-database snapshot — broader catalog winners, price-band structure, variant distribution | Keyword SERP evidence, keyword demand proof, or a front-end search interface |
+| `webtools_search` | Web crawler / retrieval utility | Keyword snapshot, trend, SERP, or keyword volume substitute |
+
+## Core Scenarios
+
+### 1. Keyword Expansion
+Goal: start from a seed term and find candidate ad keywords for coarse filtering.
+
+Primary endpoints:
+- `keywords/extends`
+- `keywords/detail`
+- `keywords/search-results`
+- `keywords/trend`
+
+Tool availability note:
+- This scenario is executable only when at least `keywords/extends` and `keywords/detail` are exposed
+- If `keywords/trend` or `keywords/search-results` are unavailable, reduce confidence and state the missing evidence explicitly
+
+### 2. Single Keyword Analysis
+Goal: deeply assess whether one keyword is worth targeting.
+
+Primary endpoints:
+- `keywords/detail`
+- `keywords/trend`
+- `keywords/search-results`
+
+Tool availability note:
+- This scenario is executable only when `keywords/detail` and `keywords/search-results` are exposed
+- If `keywords/trend` is unavailable, do not make strong claims about demand direction
+
+### 3. Reverse ASIN Keyword Analysis
+Goal: identify which keywords bring visibility/traffic to an ASIN and where to focus spend.
+
+Primary endpoints:
+- `keywords/product-traffic-terms`
+- `keywords/competitor-product-keywords`
+- `keywords/detail`
+- `keywords/search-results`
+
+Tool availability note:
+- This scenario is executable only when both ASIN keyword endpoints are exposed: `keywords/product-traffic-terms` and `keywords/competitor-product-keywords`
+- If either ASIN keyword endpoint is unavailable, report the boundary and do not substitute `keywords/detail` or `keywords/search-results` as a fake reverse-ASIN source map
+
+### 4. Keyword Traffic Diagnosis
+Goal: diagnose why an ASIN changed under a keyword, detect anomalies, and explain likely causes.
+
+Primary endpoints:
+- `keywords/search-results`
+- `keywords/detail`
+- `keywords/trend`
+- `keywords/product-traffic-terms`
+- `keywords/competitor-product-keywords`
+
+Tool availability note:
+- Minimum executable set: `keywords/search-results` + `keywords/detail`
+- `keywords/trend` and the ASIN keyword endpoints are enrichers; if missing, keep the diagnosis SERP-led and mark those evidence gaps explicitly
+
+## API Pitfalls (CRITICAL)
+
+1. `keywords/extends` uses `query`, not `keyword`
+2. `keywords/detail` and `keywords/extends` resolve to the nearest available weekly snapshot at or before the requested date
+3. `keywords/trend` is weekly time series, not daily
+4. `keywords/search-results` and both ASIN keyword endpoints are daily observations over a sliding ~7-day window, not long-retention history
+5. `keywords/detail` may return `success: true` with `data: null`; treat this as "no snapshot available", not an API failure
+6. `keywords/extends` may legitimately return `data: []`; try both `queryType=phrase` and `queryType=fuzzy` before concluding low expandability
+7. `trafficShare` is an observed share within the endpoint's sampled window; do not present it as exact Amazon share of voice
+8. SERP analysis must separate `exploreType`: `ORG` vs `SP` vs `SB` vs `SBV` vs `SPR`
+9. Monitoring conclusions require comparison across at least 2 timestamps; single-day movement is directional only
+10. `/openapi/v2/keywords/search-results` already returns listing-level product fields and should be the default source for answering "首页都是什么产品"
+11. Do not append `products/search` by default when the user's question is only about the observed keyword SERP; use it only as an optional broader-market supplement
+12. `products/search` is our own product-database query result, not Amazon live search results, so never present it as evidence of current SERP ordering
+13. `webtools_search` is a crawler / web retrieval utility, not a keyword-intelligence endpoint; do not treat it as a substitute for keyword snapshot, trend, or SERP evidence unless the task is explicitly web collection rather than APIClaw keyword analysis
+
+## On 401 Invalid Key
+
+When the API returns code 401: stop further calls, tell the user the key was rejected, and direct them to https://apiclaw.io/en/api-keys. Do not fabricate missing data.
+
+## On 402 Credit Exhausted
+
+When the API returns code 402: stop further calls, report partial findings already gathered, estimate remaining credits needed, and direct the user to https://apiclaw.io/en/pricing. Do not fabricate missing data.
+
+## Decision Framework
+
+### Keyword Fit Assessment
+
+Judge each candidate keyword on four dimensions:
+
+| Dimension | What to look at | Interpretation |
+|-----------|------------------|----------------|
+| Demand | `estimateSearchCountWeekly`, trend slope, ABA rank | Higher demand is better, but only if stable enough |
+| Competition | `adCount`, `adCampaignCount`, SERP ad density, head ASIN concentration | Higher competition raises bid difficulty |
+| Relevance | seed relation, `relevanceScore`, SERP title/brand fit | High relevance means better listing/ad fit |
+| Accessibility | organic entry room, ad crowding, whether current leaders are entrenched | Indicates whether traffic is realistically capturable |
+
+### Recommendation Labels
+
+- `Priority test` — good balance of demand, relevance, and manageable competition
+- `Selective test` — usable in certain ad groups or exact-match campaigns only
+- `Observe only` — interesting but not ready for budget allocation
+- `Exclude` — weak relevance or poor traffic efficiency
+
+### Reverse-ASIN Labels
+
+- `Defend` — already meaningful for traffic or position and should be protected
+- `Expand` — relevant and promising, but still has room to improve visibility
+- `Observe` — potentially useful but weak, unstable, or incomplete
+- `Avoid` — low fit, weak position, or crowded without a clear path
+
+## Output Spec
+
+Sections: Findings → Recommendation / action tier → Data Provenance → API Usage → Data Notes.
+
+### Language (required)
+
+Output language MUST match the user's input language. Technical field names and endpoint names may remain in English.
+
+### Disclaimer (required, at the top of every report)
+
+> Data is based on APIClaw keyword snapshots as of [date]. Weekly search and traffic metrics are sampled observations, not exact Amazon Ads billing data. This analysis is for reference only and should not be the sole basis for business decisions.
+
+### Confidence Labels (required, tag EVERY conclusion)
+
+- 📊 **Data-backed** — direct API data
+- 🔍 **Inferred** — logical reasoning from multiple observed fields
+- 💡 **Directional** — action suggestions, hypotheses, or monitoring explanations
+
+Rules:
+- Strategy recommendations are NEVER 📊
+- Single-day anomaly explanations are NEVER above 💡
+- Group headers and aggregate labels must not use stronger confidence than their contents
+
+### Data Provenance (required)
+
+Include a table at the end of every report:
+
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+| Keyword snapshot | `keywords/detail` | keyword, date, marketplace | Weekly snapshot at or before requested date |
+| ... | ... | ... | ... |
+
+### API Usage (required)
+
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+| (each endpoint used) | N | N |
+| **Total** | **N** | **N** |
+
+End with `Credits remaining: N`.
+
+## Limitations
+
+This skill does not provide:
+- real CPC / bid recommendation from Amazon Ads billing
+- campaign structure write-back
+- long-retention daily keyword history beyond the endpoint windows
+- exact attribution from Amazon internal ad console
+
+Use the outputs as directional research and combine with ad account data before final budget decisions.

--- a/amazon-keywords/references/execution-guide.md
+++ b/amazon-keywords/references/execution-guide.md
@@ -1,0 +1,129 @@
+# Execution Guide — Amazon Keyword Intelligence
+
+This file defines the execution protocol for the four keyword scenarios.
+
+---
+
+## Execution Mode
+
+| Task Type | Mode | Behavior |
+|-----------|------|----------|
+| Single lookup such as one snapshot field | Quick | Return the key metric with light interpretation |
+| Expansion, full keyword judgment, reverse ASIN, monitoring diagnosis | Full | Run the full endpoint chain, apply scoring, and output provenance + API usage |
+
+## Full-Mode Checklist
+
+Before running any Full-mode keyword task:
+
+- [ ] Inspect the active tool surface and read the live schema / field descriptions for candidate keyword tools before judging capability
+- [ ] Confirm the object: seed keyword / target keyword / ASIN / ASIN + keyword
+- [ ] Confirm marketplace; default to `US` if absent
+- [ ] Confirm the date lens: weekly snapshot, recent 4-8 weeks, or latest sliding window
+- [ ] Separate traffic facts from strategy advice using confidence labels
+- [ ] Include Data Provenance and API Usage at the end
+
+## General Rules
+
+### Tool Naming
+
+- Distinguish HTTP endpoint paths such as `/openapi/v2/keywords/detail` from actual callable tool names such as draft `mcp__apiclaw.openapi_v2_keyword_detail`
+- Never call a keyword tool from an inferred prefix alone
+- Before first use, inspect the active tool surface and confirm the exact full callable name
+- If the live callable name differs from the draft docs, trust the live callable name
+- If no keyword tool is exposed, stop and report that the tool is unavailable instead of guessing
+
+### Tool Discovery Fallback
+
+- If the static tool list does not explicitly show the keyword tools, do not immediately fall back to API docs
+- First confirm whether the current session actually exposes the corresponding callable tool names
+- If the keyword tools are exposed, call them directly and do not use doc lookup as a prerequisite step
+- Only fall back to APIClaw docs for parameter confirmation when the keyword tools are not exposed or a live tool call fails
+- If both direct tool access and doc-backed fallback are unavailable, report the limitation clearly and produce only a boundary-labeled substitute analysis
+
+### Capability Inference Rule
+
+- Do not infer endpoint capability from the tool name alone
+- Determine capability in this order: live tool schema and field descriptions, then APIClaw reference docs, then endpoint naming as a weak hint only
+- If a tool exposes fields such as `estimateSearchCountWeekly`, `keywordEstimateSearchCount`, `estimateSearchCount`, `abaRank`, or related traffic fields, treat it as having keyword-volume or trend-analysis capability even if the tool name is not explicit
+- Do not say "the keyword-volume interface is not available" unless you have checked the exposed schema/docs and confirmed the required fields are unavailable
+- Prohibit reasoning such as "I do not see a tool named keyword volume, so volume cannot be analyzed"
+- Prohibit capability claims such as "`products/search` proves this keyword has demand" unless the report explicitly labels that evidence as a secondary product-database signal rather than a keyword snapshot
+- Prohibit classifying `products/search` as a front-end SERP tool or `webtools_search` as a keyword-intelligence endpoint; both have different evidence roles and must be named accordingly
+
+### Date Handling
+
+- `keywords/detail` and `keywords/extends` are weekly snapshots
+- `keywords/trend` is weekly time series
+- `keywords/search-results` and ASIN keyword endpoints are recent daily observations
+- Never compare weekly and daily snapshots as if they were the same grain without stating the difference
+
+### Ad vs Organic Separation
+
+- Analyze `exploreType` separately
+- At minimum, split `ORG` and sponsored placements
+- Do not call a keyword "organic-friendly" if the visible page is dominated by ads
+
+### Anomaly Standards
+
+| Signal type | Minimum evidence | Max confidence |
+|-------------|------------------|----------------|
+| Weekly trend change | 2+ weekly points in same direction | 🔍 |
+| SERP change | 2 timestamps showing changed rank mix | 🔍 |
+| One-day movement | single snapshot difference | 💡 |
+
+### Monitoring Explanation Rule
+
+When explaining keyword anomalies, check causes in this order:
+
+1. Search demand moved
+2. Ad density changed
+3. The target ASIN's position changed
+4. New head competitors entered
+5. The keyword itself became more or less concentrated
+
+If multiple causes are plausible, rank them rather than presenting one as certain.
+
+## Output Rules
+
+### Candidate Tiering
+
+For keyword expansion outputs, classify into:
+
+- `Priority test`
+- `Selective test`
+- `Observe only`
+- `Exclude`
+
+For reverse-ASIN outputs, classify into:
+
+- `Defend`
+- `Expand`
+- `Observe`
+- `Avoid`
+
+### Coarse Filtering Rule
+
+A keyword can only be `Priority test` if ALL are true:
+
+- demand is at least mid-tier for the batch
+- relevance is strong
+- competition is not the worst tier
+- there is a plausible placement strategy
+
+### High-Risk Flags
+
+Flag as risk when any of these appear:
+
+- very high `adCount`
+- search demand falling across multiple weekly points
+- ASIN appears only in sponsored placements, not organic
+- top results repeat the same few brands or parent ASIN families
+- low `daysCoverageRate` or low `observationCount`
+
+## Monitoring Cadence Suggestion
+
+Recommended default cadence:
+
+- weekly for keyword opportunity watchlists
+- 2-3 times per week for launched core terms
+- daily only for high-spend hero keywords or incident follow-up

--- a/amazon-keywords/references/reference.md
+++ b/amazon-keywords/references/reference.md
@@ -1,0 +1,150 @@
+# Amazon Keyword Intelligence — Reference
+
+> Load this file when you need exact endpoint choices, field priorities, or scenario-to-endpoint mapping.
+
+## Endpoints
+
+| Endpoint | Use in this skill | Key fields |
+|----------|-------------------|------------|
+| `/openapi/v2/keywords/detail` | Weekly keyword snapshot | `estimateSearchCountWeekly`, `abaRank`, `abaTop3ClickShareRate`, `abaTop3ConversionShareRate`, `marketCharacteristics`, `totalSkuCnt`, `brandCount`, `organicSkuCount`, `adCampaignCount`, `adCount` |
+| `/openapi/v2/keywords/trend` | Weekly trend validation | `estimateSearchCount`, `estimateSearchChangeRate`, `abaRank`, `rankChangeCount`, `periodStartDate`, `periodEndDate` |
+| `/openapi/v2/keywords/extends` | Expansion / long-tail discovery | `term`, `seedKeyword`, `relevanceScore`, `estimateSearchCountWeekly`, `abaRank`, `marketCharacteristics`, `brandCount`, `organicSkuCount`, `adCount` |
+| `/openapi/v2/keywords/search-results` | SERP structure, page-1 product mix, and ad density | `exploreType`, `absolutePosition`, `pageIndex`, `pagePosition`, `asin`, `title`, `brand`, `price`, `rating`, `ratingCount`, `recentSales`, `estimateImpressionPoint`, `keywordTotalEstimateImpressionPoint` |
+| `/openapi/v2/keywords/competitor-product-keywords` | Keywords where ASIN appears as competitor | `keyword`, `avgPosition`, `daysCoverageRate`, `observationCount`, `keywordEstimateSearchCount`, `keywordEstimateSearchCountChangeRate`, `keywordAbaRank`, `trafficShare` |
+| `/openapi/v2/keywords/product-traffic-terms` | Traffic-driving keywords for ASIN | `keyword`, `avgPosition`, `daysCoverageRate`, `observationCount`, `keywordEstimateSearchCount`, `keywordEstimateSearchCountChangeRate`, `keywordAbaRank`, `trafficShare` |
+
+## Draft Callable Tool Mapping
+
+Use these as draft full names only. Final authority is the tool surface actually
+exposed in the current session.
+
+| HTTP endpoint path | Draft callable tool name |
+|----------|--------------------------|
+| `/openapi/v2/keywords/detail` | `mcp__apiclaw.openapi_v2_keyword_detail` |
+| `/openapi/v2/keywords/trend` | `mcp__apiclaw.openapi_v2_keyword_trend` |
+| `/openapi/v2/keywords/extends` | `mcp__apiclaw.openapi_v2_keyword_extends` |
+| `/openapi/v2/keywords/search-results` | `mcp__apiclaw.openapi_v2_keyword_search_results` |
+| `/openapi/v2/keywords/competitor-product-keywords` | `mcp__apiclaw.openapi_v2_keyword_competitor_product_keywords` |
+| `/openapi/v2/keywords/product-traffic-terms` | `mcp__apiclaw.openapi_v2_keyword_product_traffic_terms` |
+
+Tool selection rules:
+- Use the full callable tool name, not a shortened alias
+- Do not infer a callable name from another tool such as `openapi_v2_categories`
+- If the live session exposes a different full name, follow the live session
+- If the live session does not expose keyword tools, report that explicitly
+
+## Endpoint Quirks
+
+- `keywords/detail`: top-level `data` is an object or `null`
+- `keywords/trend`: `data` is an array of weekly points
+- `keywords/extends`: input seed is `query`; try `queryType=phrase` first, then `fuzzy`
+- `keywords/search-results`: daily-ish observation in a ~7-day sliding window
+- `keywords/competitor-product-keywords` and `keywords/product-traffic-terms`: same live item shape today, different business meaning
+
+## SERP Product Interpretation Rule
+
+- If the user asks "首页卖的都是什么产品", "这个词搜出来都是什么款", or similar, answer that primarily from `/openapi/v2/keywords/search-results`
+- This endpoint already returns product-level fields such as `asin`, `title`, `brand`, `price`, `rating`, `ratingCount`, and `recentSales`, so it is not just an ad-density endpoint
+- Treat `/openapi/v2/keywords/search-results` as the default source for page-1 product mix, intent shape, brand mix, and ad vs organic composition
+- Do not add `products/search` by default just to explain what appears on the keyword SERP
+- Add `products/search` only as an optional supplement when the user explicitly asks for broader market winners,销量分布, price-band structure, or best-selling variants beyond the observed keyword SERP
+
+## `products/search` Boundary Rule
+
+- `products/search` is a query against our own product database snapshot, not a direct Amazon live search-result page
+- Its result set can help describe broader catalog winners,销量分布, price-band structure, and variant concentration
+- Do not present `products/search` output as "Amazon search results", "Amazon首页结果", or evidence of current keyword SERP ordering
+- Do not classify `products/search` as a front-end keyword SERP interface
+- When both endpoints are used, describe them separately:
+  `keywords/search-results` = observed keyword SERP
+  `products/search` = broader product-database supplement
+
+## `webtools_search` Boundary Rule
+
+- `webtools_search` is a crawler / web retrieval utility, not a keyword-intelligence endpoint
+- Do not use `webtools_search` as a substitute for `/openapi/v2/keywords/detail`, `/trend`, `/extends`, or `/search-results`
+- Use it only when the task is genuinely about web collection or when you need an explicitly labeled supplementary source outside the APIClaw keyword endpoints
+
+## Capability Verification Order
+
+Before judging whether a question can be answered:
+
+1. Read the live tool schema and field descriptions for the exposed callable tool
+2. Map those fields to the business question
+3. Use these docs only as confirmation or fallback
+4. Treat endpoint naming alone as weak evidence, not proof
+
+If step 1 is not possible from the current surface, report that boundary explicitly instead of inventing capability.
+
+## Scenario Mapping
+
+| Scenario | Must-have endpoints | Optional endpoints | Main decision output |
+|----------|---------------------|--------------------|----------------------|
+| Keyword expansion | `keywords/extends`, `keywords/detail` | `keywords/trend`, `keywords/search-results`, `products/search` | Candidate tiers and coarse filtering |
+| Single keyword analysis | `keywords/detail`, `keywords/search-results` | `keywords/trend`, `products/search` | Worth targeting or not |
+| Reverse ASIN keyword analysis | `keywords/product-traffic-terms`, `keywords/competitor-product-keywords` | `keywords/detail`, `keywords/search-results`, `products/search` | Traffic-source map and bid focus |
+| Keyword traffic monitoring | `keywords/search-results`, `keywords/detail` | `keywords/trend`, ASIN keyword endpoints, `products/search` | Cause analysis for changes |
+
+Availability interpretation:
+- `Must-have endpoints` means the scenario should not be presented as fully executable without them
+- `Optional endpoints` may enrich confidence or context, but they must not be silently substituted for missing must-have endpoints
+- For reverse ASIN, `keywords/detail` and `keywords/search-results` are enrichers only; they do not replace the two ASIN keyword endpoints
+- For traffic monitoring, if ASIN keyword endpoints are missing, omit ASIN-side traffic-share conclusions instead of inferring them
+- For single keyword analysis, if `keywords/trend` is missing, keep the conclusion snapshot-led and avoid strong claims about demand direction
+
+## Scoring Inputs
+
+### Demand
+
+- Primary: `estimateSearchCountWeekly`, `keywordEstimateSearchCount`
+- Secondary: `estimateSearchChangeRate`, `keywordEstimateSearchCountChangeRate`, `abaRank`
+
+### Competition
+
+- Primary: `adCount`, `adCampaignCount`, SERP ad-slot share
+- Secondary: top ASIN repetition, `avgPosition`, `trafficShare`
+
+### Relevance
+
+- Primary: `relevanceScore`
+- Secondary: semantic closeness to seed term, alignment between keyword intent and SERP results
+
+### Stability
+
+- Primary: trend consistency across 4-8 weekly points
+- Secondary: `daysCoverageRate`, `observationCount`
+
+## Recommended Reporting Dimensions
+
+### For keyword expansion
+
+- Search demand bucket
+- Competition bucket
+- Relevance bucket
+- Suggested usage scene: auto, broad, phrase, exact, product targeting support, or SEO observation
+
+### For single keyword analysis
+
+- Traffic size
+- Traffic direction
+- Ad crowding
+- Organic room
+- Head-listing strength
+- Bid recommendation tier
+
+### For reverse ASIN
+
+- Top traffic-source keywords
+- Ranking quality by keyword
+- Defensive keywords vs expansion keywords
+- Missing but strategically relevant competitor keywords
+- Bucket labels: `Defend` / `Expand` / `Observe` / `Avoid`
+
+### For monitoring
+
+- Position change
+- Exposure change
+- Search demand change
+- Ad density change
+- Head competitor change
+- Likely cause and urgency

--- a/amazon-keywords/references/scenarios-expand.md
+++ b/amazon-keywords/references/scenarios-expand.md
@@ -1,0 +1,98 @@
+# Keyword Expansion
+
+> Load this file for keyword expansion and coarse filtering.
+
+---
+
+## 1. Keyword Expansion
+
+> Trigger: "keyword expansion" / "find ad keyword ideas" / "expand from this seed keyword" / "coarse-filter keyword candidates"
+
+### Inputs
+
+- required: seed keyword
+- optional: marketplace
+- optional: snapshot date for weekly endpoints
+- optional: candidate count or page-size preference
+
+### Workflow
+
+1. Pull expansion candidates from `keywords/extends`
+2. If result count is low, retry with `queryType=fuzzy`
+3. Enrich shortlisted terms with `keywords/detail`
+4. Validate demand direction with `keywords/trend`
+5. Sample SERP structure for top candidates with `keywords/search-results`
+6. Score and tier candidates
+
+### Endpoint Plan
+
+| Step | Endpoint | Purpose |
+|------|----------|---------|
+| 1 | `keywords/extends` | Get related terms and `relevanceScore` |
+| 2 | `keywords/detail` | Add weekly demand, ABA, ad density, market characteristics |
+| 3 | `keywords/trend` | Confirm whether demand is stable / rising / fading |
+| 4 | `keywords/search-results` | Check ad crowding, who dominates, and what product types/brands/prices actually occupy page 1 |
+
+### Candidate Scoring
+
+Suggested 100-point model:
+
+| Dimension | Weight | Main fields |
+|-----------|--------|-------------|
+| Relevance | 35 | `relevanceScore`, seed-intent fit |
+| Demand | 30 | `estimateSearchCountWeekly`, `abaRank` |
+| Competition | 20 | `adCount`, `adCampaignCount`, SERP ad density |
+| Stability | 15 | 4-8 week trend consistency |
+
+### Coarse-Filter Output
+
+For each keyword, output:
+
+| Field | Meaning |
+|-------|---------|
+| Keyword | candidate term |
+| Demand Tier | High / Mid / Low |
+| Competition Tier | High / Mid / Low |
+| Relevance Tier | Strong / Medium / Weak |
+| Suggested Usage | Auto / Broad / Phrase / Exact / SEO Observe |
+| Recommendation | `Priority test` / `Selective test` / `Observe only` / `Exclude` |
+
+### Suggested Interpretation
+
+- High demand + high relevance + manageable ad crowding → `Priority test`
+- High demand + very high ad crowding → `Selective test`
+- High relevance but low demand → `Observe only` or low-budget exact test
+- Weak relevance regardless of traffic → `Exclude`
+
+### Output Template
+
+```markdown
+# Keyword Expansion Report — [Seed Keyword]
+
+> Data is based on APIClaw keyword snapshots as of [date]. Weekly search and traffic metrics are sampled observations, not exact Amazon Ads billing data. This analysis is for reference only and should not be the sole basis for business decisions.
+
+## Summary
+[🔍 What kind of keyword pool this seed generated]
+
+## Priority Candidates
+| Keyword | Demand | Competition | Relevance | Suggested Usage | Recommendation |
+|---------|--------|-------------|-----------|-----------------|----------------|
+
+## Watchlist
+| Keyword | Key reason to watch | Risk |
+|---------|---------------------|------|
+
+## Excluded Terms
+| Keyword | Why excluded |
+|---------|--------------|
+
+## Data Provenance
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+
+## API Usage
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+
+Credits remaining: N
+```

--- a/amazon-keywords/references/scenarios-keyword-analysis.md
+++ b/amazon-keywords/references/scenarios-keyword-analysis.md
@@ -1,0 +1,83 @@
+# Single Keyword Analysis
+
+> Load this file for single-keyword evaluation.
+
+---
+
+## 2. Single Keyword Analysis
+
+> Trigger: "keyword deep dive" / "is this keyword worth targeting" / "single keyword analysis"
+
+### Inputs
+
+- required: target keyword
+- optional: marketplace
+- optional: weekly snapshot date
+- optional: trend lookback window, default 8-12 weeks when available
+
+### Workflow
+
+1. Pull weekly snapshot from `keywords/detail`
+2. Pull 8-12 weeks from `keywords/trend`
+3. Pull current SERP from `keywords/search-results`
+4. Use `keywords/search-results` itself to summarize what products dominate page 1: product type, brand mix, price band, and ad vs organic composition
+5. Assess demand, ad density, brand concentration, and organic room
+6. Output bid-worthiness and suitable usage scene
+
+### SERP Source Rule
+
+- When the user asks what products are showing on the first page, answer from `keywords/search-results` first
+- Do not treat `keywords/search-results` as "only a SERP structure endpoint"; it already includes listing-level product fields
+- Do not append `products/search` by default for this question
+- Use `products/search` only if the user also asks for market-wide best sellers,销量分布, price-band distribution, or a broader market view that goes beyond the observed keyword SERP
+
+### Analysis Dimensions
+
+| Dimension | Questions |
+|-----------|-----------|
+| Demand | Is the search volume meaningful enough? |
+| Trend | Is volume stable, rising, or weakening? |
+| Competition | Is the keyword ad-heavy and crowded? |
+| SERP intent | Do current results match the user's product intent? |
+| Organic room | Is there room outside the entrenched leaders? |
+| Launch fit | Better for discovery, exact defense, or long-tail harvest? |
+
+### Decision Logic
+
+- Worth targeting now:
+  demand is real, trend is not deteriorating, and the SERP is still contestable
+- Worth selective testing:
+  demand is good but competition is heavy, or intent fit is narrower
+- Not worth prioritizing:
+  demand is weak, trend is poor, or SERP mismatch is strong
+
+### Output Template
+
+```markdown
+# Keyword Analysis — [Keyword]
+
+> Data is based on APIClaw keyword snapshots as of [date]. Weekly search and traffic metrics are sampled observations, not exact Amazon Ads billing data. This analysis is for reference only and should not be the sole basis for business decisions.
+
+## Verdict
+[Priority test / Selective test / Observe only / Exclude]
+
+## Findings
+- Demand: [📊 / 🔍]
+- Trend: [📊 / 🔍]
+- Competition: [📊 / 🔍]
+- SERP structure: [📊 / 🔍]
+- Recommended usage scene: [💡]
+
+## Action
+[💡 Budget or placement suggestion]
+
+## Data Provenance
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+
+## API Usage
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+
+Credits remaining: N
+```

--- a/amazon-keywords/references/scenarios-keyword-traffic-diagnosis.md
+++ b/amazon-keywords/references/scenarios-keyword-traffic-diagnosis.md
@@ -1,0 +1,89 @@
+# Keyword Traffic Diagnosis
+
+> Load this file for keyword traffic anomaly diagnosis.
+
+---
+
+## 4. Keyword Traffic Diagnosis
+
+> Trigger: "diagnose keyword traffic anomalies" / "why did this keyword move" / "analyze this ASIN's keyword traffic drop"
+
+### Inputs
+
+- required: ASIN + keyword
+- recommended: at least 2 observation dates
+
+### Workflow
+
+1. Pull `keywords/search-results` for the target keyword at two or more timestamps
+2. Track target ASIN position, exploreType mix, and estimated impression points
+3. Pull `keywords/detail` and `keywords/trend` to check whether keyword demand changed
+4. Pull `keywords/product-traffic-terms` or `keywords/competitor-product-keywords` to check ASIN-side traffic share changes
+5. Compare head competitors and ad density
+6. Output anomaly level, likely causes, and action priority
+
+### Tool Availability Gate
+
+- `keywords/search-results` and `keywords/detail` are the minimum required tools for a diagnosis pass
+- If either minimum tool is unavailable, stop and report that the diagnosis workflow cannot be executed reliably
+- `keywords/product-traffic-terms` and `keywords/competitor-product-keywords` are optional enrichers only when they are actually exposed
+- If those ASIN keyword endpoints are unavailable, continue with a SERP-led diagnosis and label any ASIN-side traffic-share conclusion as unavailable rather than inferred
+
+### SERP And Product-Library Rule
+
+- Diagnose keyword movement primarily from `keywords/search-results` because this is the observed keyword SERP
+- Do not default to `products/search` to explain rank or page-1 composition changes
+- Use `products/search` only if the user also wants a broader catalog context such as category-wide winners, price-band shifts, or strong-selling variants beyond the observed keyword SERP
+- If `products/search` is used, state clearly that it is our product-database query result and does not equal Amazon live search ranking
+
+### Diagnosis Signals
+
+| Signal | What changed | Possible cause |
+|--------|--------------|----------------|
+| Position drop | `absolutePosition` / `pageIndex` worsened | stronger competitors, lower bid, listing weakness |
+| Exposure drop | `estimateImpressionPoint` fell | lower search demand or worse placement |
+| Ad crowding rose | sponsored share of SERP increased | bidding intensified |
+| Traffic share fell | ASIN keyword share weakened | rank loss or keyword portfolio shift |
+| Demand fell | trend/search count moved down | keyword itself cooled off |
+
+### Alert Levels
+
+- `High`
+  target ASIN lost meaningful position/share and at least one supporting cause is observed
+- `Medium`
+  noticeable movement but evidence is mixed
+- `Low`
+  small movement or single-snapshot fluctuation only
+
+### Output Template
+
+```markdown
+# Keyword Traffic Diagnosis Report — [ASIN] × [Keyword]
+
+> Data is based on APIClaw keyword snapshots as of [date]. Weekly search and traffic metrics are sampled observations, not exact Amazon Ads billing data. This analysis is for reference only and should not be the sole basis for business decisions.
+
+## Alert Level
+[High / Medium / Low]
+
+## What Changed
+| Metric | Previous | Current | Interpretation |
+|--------|----------|---------|----------------|
+
+## Likely Causes
+1. [💡 / 🔍 only]
+2. [💡 / 🔍 only]
+3. [💡 / 🔍 only]
+
+## Recommended Actions
+[Observe / increase defense / inspect bids / inspect listing relevance]
+
+## Data Provenance
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+
+## API Usage
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+
+Credits remaining: N
+```

--- a/amazon-keywords/references/scenarios-reverse-asin.md
+++ b/amazon-keywords/references/scenarios-reverse-asin.md
@@ -1,0 +1,91 @@
+# Reverse ASIN Keyword Analysis
+
+> Load this file for reverse ASIN keyword analysis.
+
+---
+
+## 3. Reverse ASIN Keyword Analysis
+
+> Trigger: "reverse ASIN" / "which keywords drive traffic to this ASIN" / "traffic-source keywords for this ASIN"
+
+### Inputs
+
+- required: ASIN
+- optional: marketplace
+- optional: top-N focus for returned keywords
+- optional: spot-check keywords to inspect with `keywords/search-results`
+
+### Workflow
+
+1. Pull `keywords/product-traffic-terms` to get traffic-driving terms
+2. Pull `keywords/competitor-product-keywords` to see where the ASIN appears as a competitor
+3. Merge and deduplicate by keyword
+4. Enrich top terms with `keywords/detail`
+5. Spot-check SERP with `keywords/search-results`
+6. Split terms into defense / expansion / observation buckets
+
+### Tool Availability Gate
+
+- Before running the workflow, confirm that both `keywords/product-traffic-terms` and `keywords/competitor-product-keywords` are exposed in the live tool surface
+- If one or both are unavailable, stop the full reverse-ASIN chain and state the limitation explicitly
+- In that case, do not fabricate reverse-ASIN traffic-source conclusions from `keywords/detail` or `keywords/search-results` alone
+- If the user still wants help, offer only a boundary-labeled substitute such as single-keyword SERP analysis for manually provided keywords
+
+### SERP And Product-Library Rule
+
+- When explaining what products/brands dominate a keyword tied to this ASIN, use `keywords/search-results` first because it reflects the observed keyword SERP
+- Do not default to `products/search` for that question
+- Use `products/search` only as an optional supplement when the user explicitly wants broader catalog winners, price bands, or market-wide best-selling variants around those keywords
+- If `products/search` is used, explicitly label it as our product-database query result, not Amazon live search results
+
+### Analysis Dimensions
+
+| Dimension | What to inspect |
+|-----------|-----------------|
+| Traffic contribution | `trafficShare`, `estimateImpressionPoint` |
+| Rank quality | `avgPosition`, `daysCoverageRate`, `observationCount` |
+| Keyword size | `keywordEstimateSearchCount`, `keywordAbaRank` |
+| Growth | `keywordEstimateSearchCountChangeRate` |
+| Competition | SERP ad density and head-ASIN overlap |
+
+### Decision Buckets
+
+- `Defend`
+  high traffic share or good position on strategically important terms
+- `Expand`
+  decent relevance and volume, but position is still improvable
+- `Observe`
+  signals are promising but weak or unstable
+- `Avoid`
+  low share, low fit, or crowded with poor position
+
+### Output Template
+
+```markdown
+# Reverse ASIN Keyword Report — [ASIN]
+
+> Data is based on APIClaw keyword snapshots as of [date]. Weekly search and traffic metrics are sampled observations, not exact Amazon Ads billing data. This analysis is for reference only and should not be the sole basis for business decisions.
+
+## Top Traffic Terms
+| Keyword | Traffic Share | Avg Position | Search Count | Bucket |
+|---------|---------------|--------------|--------------|--------|
+
+## Defense Terms
+[Which terms should be protected]
+
+## Expansion Terms
+[Which terms deserve more spend or SEO support]
+
+## Risks
+[Crowding, weak coverage, unstable observations]
+
+## Data Provenance
+| Data | Endpoint | Key Params | Notes |
+|------|----------|------------|-------|
+
+## API Usage
+| Endpoint | Calls | Credits |
+|----------|-------|---------|
+
+Credits remaining: N
+```

--- a/apiclaw/SKILL.md
+++ b/apiclaw/SKILL.md
@@ -2,11 +2,13 @@
 name: apiclaw
 description: >
   API endpoint reference for the APIClaw data platform. Provides the 12
-  endpoints (categories, markets, products, competitors, realtime ASIN,
-  AI review analysis, raw reviews, price band, brand, history), their
-  inputs/outputs, parameter quirks, Quick Start (auth, base URL), how
-  credits are tracked (meta.creditsConsumed field), and the Local Review
-  Toolkit (Map/Reduce for raw reviews).
+  commerce endpoints plus 6 keyword intelligence endpoints (categories,
+  markets, products, competitors, realtime ASIN, AI review analysis, raw
+  reviews, price band, brand, history, keyword detail/trend/extends/search
+  results/product traffic/competitor keywords), their inputs/outputs,
+  parameter quirks, Quick Start (auth, base URL), how credits are tracked
+  (meta.creditsConsumed field), and the Local Review Toolkit (Map/Reduce
+  for raw reviews).
   Use when the user asks about the API itself — which endpoints exist,
   how to call them, field schemas, parameter quirks, how to authenticate,
   how credit consumption is reported, or how the Local Review Toolkit works.
@@ -26,7 +28,7 @@ metadata:
 
 # APIClaw — Commerce Data Infrastructure for AI Agents
 
-200M+ Amazon products. 12 endpoints. One API key.
+200M+ Amazon products. 18 endpoints. One API key.
 
 ## Quick Start
 1. Get key: [apiclaw.io/api-keys](https://apiclaw.io/en/api-keys) (1,000 free credits)
@@ -71,7 +73,7 @@ When `apiclaw.py` returns `{"code": 402, "message": "API quota exhausted or subs
    - Top-up link: https://apiclaw.io/en/pricing
 3. **Do not fabricate or guess** the missing data to "complete" the report. Mark partial findings explicitly as partial.
 
-## 12 Endpoints
+## 18 Endpoints
 
 | # | Endpoint | Purpose | Key Output |
 |---|----------|---------|------------|
@@ -87,10 +89,16 @@ When `apiclaw.py` returns `{"code": 402, "message": "API quota exhausted or subs
 | 10 | `products/brand-overview` | Brand concentration | sampleTop10BrandSalesRate (CR10), sampleBrandCount |
 | 11 | `products/brand-detail` | Per-brand breakdown | brands[] with sales, revenue, sampleProducts |
 | 12 | `products/history` | Time series (single ASIN per call) | timestamps[], price[], bsr[], monthlySalesFloor[], rating[], ratingCount[], sellerCount[], title/imageUrl/bestSeller/newRelease/aPlus/inventoryStatus changelogs |
+| 13 | `/openapi/v2/keywords/detail` | Keyword summary from the nearest available weekly snapshot | `estimateSearchCountWeekly`, `abaRank`, `marketCharacteristics`, `adCount`; may return `data: null` |
+| 14 | `/openapi/v2/keywords/trend` | Weekly keyword time series | `estimateSearchCount`, `abaRank`, `rankChangeCount`, `periodStartDate`, `periodEndDate` |
+| 15 | `/openapi/v2/keywords/extends` | Keyword expansion / long-tail discovery | related keywords ranked by `relevanceScore` / `estimateSearchCount`; may return empty array |
+| 16 | `/openapi/v2/keywords/search-results` | Daily keyword SERP snapshot | `asin`, `exploreType`, `absolutePosition`, `estimateImpressionPoint`, listing fields |
+| 17 | `/openapi/v2/keywords/competitor-product-keywords` | Keyword set where an ASIN appears as a competitor | `keyword`, `avgPosition`, `keywordEstimateSearchCount`, `trafficShare` |
+| 18 | `/openapi/v2/keywords/product-traffic-terms` | Traffic-driving keywords for an ASIN | same live response shape as competitor-product-keywords |
 
 ## Known Quirks
 - `topN`, `listingAge`, `newProductPeriod` are **strings** (`"10"` not `10`)
-- Response `.data` is always an **array** — use `.data[0]`
+- Many search/list endpoints return `.data` as an **array** — use `.data[0]` for the first record. But some commands may return non-array payloads inside `data`, so inspect the actual response shape before indexing.
 - `ratingCount` not `reviewCount` everywhere
 - `bsr` (int) in products vs `bestsellersRank` (array) in realtime
 - `buyboxWinner.price` — NOT top-level `price` in realtime
@@ -101,6 +109,81 @@ When `apiclaw.py` returns `{"code": 402, "message": "API quota exhausted or subs
 - `categories` uses `categoryKeyword` (not `keyword`) and `parentCategoryPath` (not `parentCategoryName`)
 - `reviews/analysis`: `mode` required ("asin"/"category"), use `asins` (plural array) not `asin`
 - `realtime/reviews`: returns 10 reviews/page fixed (no `pageSize` param); 1 credit/page; cursor-paginated; hard cap = 100 reviews (10 pages); supports `marketplace` US/UK only
+- `keywords/detail` resolves the input `date` to the nearest available weekly snapshot at or before that date, and may legitimately return `data: null` even with `success: true`
+- `keywords/extends` also resolves the input `date` to the nearest available weekly snapshot, requires `query` (not `keyword`), supports `queryType` = `phrase` or `fuzzy`, and may legitimately return `data: []`
+- `keywords/search-results`, `keywords/competitor-product-keywords`, and `keywords/product-traffic-terms` use daily observations over a sliding ~7-day window, not a long-retention historical store
+- `keywords/search-results` requires `date` + `keyword`; `exploreTypes` values are `ORG`, `SP`, `SB`, `SBV`, `SPR`
+- `keywords/competitor-product-keywords` and `keywords/product-traffic-terms` require `date` + `asin`; both currently return the same live item shape, including `trafficShare`
+- `keywords/search-results` is the default source for explaining what products currently appear on a keyword SERP because it already returns listing-level product fields
+- `products/search` is a broader APIClaw product-database query and must not be presented as Amazon live keyword SERP ordering
+
+## Keyword Intelligence Endpoints
+
+These six endpoints were verified against the live API surface and fill the gap between raw
+catalog data and search-demand/search-visibility intelligence.
+
+### `/openapi/v2/keywords/detail`
+- Input: `keyword`, `date`, optional `marketplace`
+- Data window: resolves the requested `date` to the nearest available weekly snapshot at or before that date
+- Response shape: top-level `data` is an object or `null` (not an array)
+- Key fields from schema: `estimateSearchCountWeekly`, `abaRank`, `abaTop3ClickShareRate`,
+  `abaTop3ConversionShareRate`, `marketCharacteristics`, `totalSkuCnt`, `brandCount`,
+  `organicSkuCount`, `adCampaignCount`, `adCount`
+- Live validation note: for `keyword="yoga mat"` and several June 2026 dates, the endpoint returned
+  `success: true` with `data: null`
+
+### `/openapi/v2/keywords/trend`
+- Input: `keyword`, `dateFrom`, `dateTo`, optional `marketplace`
+- Data window: weekly-granularity points across the requested date range
+- Response shape: `data` is an array
+- Key fields from live response/schema: `observedAt`, `periodStartDate`, `periodEndDate`,
+  `estimateSearchCount`, `estimateSearchChangeCount`, `estimateSearchChangeRate`, `abaRank`,
+  `prevAbaRank`, `prevEstimateSearchCount`, `rankChangeCount`
+
+### `/openapi/v2/keywords/extends`
+- Input: `query`, `date`, optional `marketplace`, `page`, `pageSize`, `queryType`, `sortBy`, `sortOrder`
+- Important quirk: seed field is `query`, not `keyword`; `queryType` supports `phrase` and `fuzzy`
+- Data window: resolves the requested `date` to the nearest available weekly snapshot at or before that date
+- Response shape: `data` is an array
+- Key fields from schema: `term`, `seedKeyword`, `relevanceScore`, `estimateSearchCountWeekly`,
+  `abaRank`, `marketCharacteristics`, `brandCount`, `organicSkuCount`, `adCount`,
+  `periodStartDate`, `periodEndDate`, `observedAt`
+- Live validation note: empty arrays are normal; `query="yoga mat"` returned `data: []` for both
+  `queryType="phrase"` and `queryType="fuzzy"`
+
+### `/openapi/v2/keywords/search-results`
+- Input: `keyword`, `date`, optional `marketplace`, `page`, `pageSize`, `exploreTypes`, `sortBy`, `sortOrder`
+- Data window: daily observations surfaced through a sliding ~7-day window
+- Response shape: `data` is an array
+- Key fields from live response/schema: `exploreType`, `absolutePosition`, `pageIndex`,
+  `pagePosition`, `asin`, `title`, `brand`, `price`, `currency`, `link`, `imageLink`, `rating`,
+  `ratingCount`, `recentSales`, `hasVideo`, `estimateImpressionPoint`,
+  `keywordTotalEstimateImpressionPoint`
+- Interpretation rule: use this endpoint first for "what is on page 1 / what products dominate this keyword / what does the SERP look like"
+- Do not substitute `products/search` when the question is about observed keyword SERP composition or ordering
+
+### `/openapi/v2/keywords/competitor-product-keywords`
+- Input: `asin`, `date`, optional `marketplace`, `page`, `pageSize`, `exploreTypes`,
+  `keywordContains`, `sortBy`, `sortOrder`
+- Data window: daily observations surfaced through a sliding ~7-day window
+- Response shape: `data` is an array
+- Key fields from live response/schema: `exploreType`, `absolutePosition`, `pageIndex`,
+  `pagePosition`, `asin`, `keyword`, `estimateImpressionPoint`, `asinTotalEstimateImpressionPoint`,
+  `avgPosition`, `daysCoverageRate`, `observationCount`, `keywordEstimateSearchCount`,
+  `keywordEstimateSearchGrowthCount`, `keywordEstimateSearchCountChangeRate`, `keywordAbaRank`,
+  `keywordAbaRankChangeCount`, `trafficShare`
+
+### `/openapi/v2/keywords/product-traffic-terms`
+- Input: same request shape as `keywords/competitor-product-keywords`
+- Data window: daily observations surfaced through a sliding ~7-day window
+- Response shape: `data` is an array
+- Key fields from live response/schema: `exploreType`, `absolutePosition`, `pageIndex`,
+  `pagePosition`, `asin`, `keyword`, `estimateImpressionPoint`, `asinTotalEstimateImpressionPoint`,
+  `avgPosition`, `daysCoverageRate`, `observationCount`, `keywordEstimateSearchCount`,
+  `keywordEstimateSearchGrowthCount`, `keywordEstimateSearchCountChangeRate`, `keywordAbaRank`,
+  `keywordAbaRankChangeCount`, `trafficShare`
+- Live validation note: current live response item shape matches `keywords/competitor-product-keywords`
+  field-for-field; keep the semantic distinction in output wording rather than assuming a unique schema
 
 ## Local Review Toolkit
 

--- a/apiclaw/references/openapi-reference.md
+++ b/apiclaw/references/openapi-reference.md
@@ -1,6 +1,6 @@
 # APIClaw API Quick Reference
 
-> Concise field reference for all 11 endpoints. Load when you need exact parameter/field names.
+> Concise field reference for the currently documented Amazon commerce and keyword-intelligence endpoints. Load when you need exact parameter/field names.
 >
 > **OpenAPI Spec (live)**: https://apiclaw.io/api/v1/openapi-spec
 
@@ -31,7 +31,7 @@ Response: `categoryId`, `categoryName`, `categoryPath`, `hasChildren`, `isRoot`,
 | categoryKeyword | String | Keyword match across levels |
 | topN | **String** | `"3"` / `"5"` / `"10"` / `"20"` ⚠️ must be string |
 | newProductPeriod | **String** | `"1"` / `"3"` / `"6"` / `"12"` ⚠️ must be string |
-| sampleType | String | `by_sale_100` / `by_bsr_100` / `avg` |
+| sampleType | String | `bySale100` / `byBsr100` / `avg` |
 | dateRange | String | default `30d` |
 | pageSize | Integer | default 20 |
 | sortBy | String | default `sampleAvgMonthlySales` |
@@ -292,7 +292,177 @@ TaggedReview vs RealtimeReview: `reviews/search` uses snapshot data with AI tags
 
 ---
 
+## Keyword Intelligence Endpoints
+
+These endpoints were live-validated against the current OpenAPI surface.
+
+Tool-surface note:
+- API documentation and live endpoint availability do not guarantee that the current agent session exposes matching callable tools
+- For skill execution, verify the live tool surface first; use this file for parameter and field confirmation after that
+
+## 12. /openapi/v2/keywords/detail
+
+| Parameter | Type | Required | Note |
+|-----------|------|----------|------|
+| keyword | String | **Yes** | Keyword to inspect |
+| date | String | **Yes** | Lookup date `YYYY-MM-DD`; resolves to the nearest available weekly snapshot at or before that date |
+| marketplace | String | No | Marketplace code, default `US` |
+
+⚠️ Live behavior: `success: true` may still return `data: null` when no matching weekly snapshot record is available for that keyword.
+
+**Response:** Single keyword snapshot object **or `null`**.
+
+Key fields: `estimateSearchCountWeekly`, `abaRank`, `abaTop3ClickShareRate`, `abaTop3ConversionShareRate`,
+`marketCharacteristics`, `totalSkuCnt`, `brandCount`, `organicSkuCount`, `adCampaignCount`, `adCount`,
+`periodStartDate`, `periodEndDate`, `observedAt`
+
+---
+
+## 13. /openapi/v2/keywords/trend
+
+| Parameter | Type | Required | Note |
+|-----------|------|----------|------|
+| keyword | String | **Yes** | Keyword to inspect |
+| dateFrom | String | **Yes** | Start date `YYYY-MM-DD` |
+| dateTo | String | **Yes** | End date `YYYY-MM-DD` |
+| marketplace | String | No | Marketplace code, default `US` |
+
+**Response:** Array of weekly-granularity trend points across the requested date range.
+
+Interpretation note:
+- `keywords/trend` is weekly series data; do not compare it to daily SERP observations as if they were the same grain
+
+Key fields: `observedAt`, `periodStartDate`, `periodEndDate`, `estimateSearchCount`,
+`estimateSearchChangeCount`, `estimateSearchChangeRate`, `abaRank`, `prevAbaRank`,
+`prevEstimateSearchCount`, `rankChangeCount`
+
+---
+
+## 14. /openapi/v2/keywords/extends
+
+| Parameter | Type | Required | Note |
+|-----------|------|----------|------|
+| query | String | **Yes** | Seed keyword |
+| date | String | **Yes** | Lookup date `YYYY-MM-DD`; resolves to the nearest available weekly snapshot at or before that date |
+| marketplace | String | No | Marketplace code, default `US` |
+| page | Integer | No | default 1 |
+| pageSize | Integer | No | default 20, max 100 |
+| queryType | String | No | `phrase` / `fuzzy` (default `phrase`) |
+| sortBy | String | No | `relevanceScore` / `estimateSearchCount` / `abaRank` / `observedAt` / `keyword` |
+| sortOrder | String | No | `asc` / `desc` |
+
+⚠️ Uses `query`, NOT `keyword`.
+⚠️ Live behavior: empty `data: []` is a normal success case.
+
+**Response:** Array of expansion keywords.
+
+Key fields per item: `term` (expanded keyword), `seedKeyword`, `relevanceScore`,
+`estimateSearchCountWeekly`, `abaRank`, `marketCharacteristics`, `brandCount`,
+`organicSkuCount`, `adCount`, `periodStartDate`, `periodEndDate`, `observedAt`
+
+Additional market-structure fields may appear on each item, including `totalSkuCnt`,
+`observedSkuCount`, `titleDensity`, `organicRolloverRate`, `amazonChoiceSkuCount`,
+`sponsoredProductSkuCount`, `sponsoredBrandSkuCount`, `sponsoredBrandVideoSkuCount`,
+`sponsoredRecommendSkuCount`, `adCampaignCount`, `top48OrganicSkuAvgPrice`,
+`top48OrganicSkuAvgRating`, `top48OrganicSkuAvgRatingsTotal`, and
+`top48OrganicSkuAvgRecentSaleCnt`.
+
+---
+
+## 15. /openapi/v2/keywords/search-results
+
+| Parameter | Type | Required | Note |
+|-----------|------|----------|------|
+| keyword | String | **Yes** | Keyword to inspect |
+| date | String | **Yes** | Daily snapshot lookup date `YYYY-MM-DD` |
+| marketplace | String | No | Marketplace code, default `US` |
+| page | Integer | No | default 1 |
+| pageSize | Integer | No | default 20, max 100 |
+| exploreTypes | Array\<String\> | No | `ORG` / `SP` / `SB` / `SBV` / `SPR` |
+| sortBy | String | No | `absolutePosition` / `estimateImpressionPoint` / `observedAt` / `price` / `rating` / `ratingCount` / `recentSales` / `asin` / `title` |
+| sortOrder | String | No | `asc` / `desc` |
+
+⚠️ This endpoint behaves like a daily-observation feed exposed through a recent sliding ~7-day window, not a long-retention historical snapshot archive.
+⚠️ Use this endpoint as the primary source for "what products are currently showing on the keyword SERP/page 1" because it already returns listing-level product fields.
+⚠️ Do not replace it with `products/search` when the question is about observed Amazon keyword SERP composition or ordering.
+⚠️ When analyzing this endpoint, separate `exploreType` at least into `ORG` and sponsored placements instead of collapsing all rows together.
+
+**Response:** Array of SERP products with absolute positions.
+
+Key fields from live response: `exploreType`, `absolutePosition`, `pageIndex`, `pagePosition`, `asin`,
+`title`, `brand`, `price`, `currency`, `link`, `imageLink`, `rating`, `ratingCount`, `recentSales`,
+`hasVideo`, `estimateImpressionPoint`, `keywordTotalEstimateImpressionPoint`
+
+Interpretation rule:
+- `keywords/search-results` = observed keyword SERP snapshot
+- It can answer page-1 product mix, brand mix, ad vs organic composition, and visible price band questions
+- If you also use `products/search`, present it as a broader catalog supplement, not as the same thing
+
+---
+
+## 16. /openapi/v2/keywords/competitor-product-keywords
+
+| Parameter | Type | Required | Note |
+|-----------|------|----------|------|
+| asin | String | **Yes** | Target ASIN |
+| date | String | **Yes** | Daily snapshot lookup date `YYYY-MM-DD` |
+| marketplace | String | No | Marketplace code, default `US` |
+| page | Integer | No | default 1 |
+| pageSize | Integer | No | default 20, max 100 |
+| exploreTypes | Array\<String\> | No | `ORG` / `SP` / `SB` / `SBV` / `SPR` |
+| keywordContains | String | No | Optional substring filter on returned keywords |
+| sortBy | String | No | `estimateImpressionPoint` / `absolutePosition` / `avgPosition` / `keywordEstimateSearchCount` / `keywordAbaRank` / `observedAt` / `keyword` |
+| sortOrder | String | No | `asc` / `desc` |
+
+**Response:** Array of keyword rows for an ASIN.
+
+Key fields from live response: `exploreType`, `absolutePosition`, `pageIndex`, `pagePosition`, `asin`,
+`keyword`, `estimateImpressionPoint`, `asinTotalEstimateImpressionPoint`, `avgPosition`,
+`daysCoverageRate`, `observationCount`, `keywordEstimateSearchCount`,
+`keywordEstimateSearchGrowthCount`, `keywordEstimateSearchCountChangeRate`, `keywordAbaRank`,
+`keywordAbaRankChangeCount`, `trafficShare`
+
+⚠️ Live validation indicates this endpoint also behaves like a daily-observation feed exposed through a recent sliding ~7-day window.
+⚠️ In skill workflows, this endpoint is a reverse-ASIN source endpoint, not a substitute for `keywords/search-results` when the question is about visible page-1 product composition.
+
+---
+
+## 17. /openapi/v2/keywords/product-traffic-terms
+
+| Parameter | Type | Required | Note |
+|-----------|------|----------|------|
+| asin | String | **Yes** | Target ASIN |
+| date | String | **Yes** | Daily snapshot lookup date `YYYY-MM-DD` |
+| marketplace | String | No | Marketplace code, default `US` |
+| page | Integer | No | default 1 |
+| pageSize | Integer | No | default 20, max 100 |
+| exploreTypes | Array\<String\> | No | `ORG` / `SP` / `SB` / `SBV` / `SPR` |
+| keywordContains | String | No | Optional substring filter on returned keywords |
+| sortBy | String | No | `estimateImpressionPoint` / `absolutePosition` / `avgPosition` / `keywordEstimateSearchCount` / `keywordAbaRank` / `observedAt` / `keyword` |
+| sortOrder | String | No | `asc` / `desc` |
+
+⚠️ Live validation showed the same item shape as `keywords/competitor-product-keywords`; do not assume
+the semantic label implies a different wire schema.
+⚠️ Live validation indicates this endpoint also behaves like a daily-observation feed exposed through a recent sliding ~7-day window.
+⚠️ In skill workflows, this endpoint is a reverse-ASIN source endpoint, not a substitute for `keywords/search-results` when the question is about visible page-1 product composition.
+
+**Response:** Array of keyword rows for an ASIN.
+
+Key fields from live response: `exploreType`, `absolutePosition`, `pageIndex`, `pagePosition`, `asin`,
+`keyword`, `estimateImpressionPoint`, `asinTotalEstimateImpressionPoint`, `avgPosition`,
+`daysCoverageRate`, `observationCount`, `keywordEstimateSearchCount`,
+`keywordEstimateSearchGrowthCount`, `keywordEstimateSearchCountChangeRate`, `keywordAbaRank`,
+`keywordAbaRankChangeCount`, `trafficShare`
+
+---
+
 ## Shared Product Object (products/search, competitors & brand-detail sampleProducts)
+
+Boundary note:
+- `products/search` is a query against APIClaw's product-database snapshot
+- It is useful for broader catalog analysis such as market winners, sales distribution, price bands, and variant concentration
+- It does NOT represent Amazon live keyword SERP ordering
+- Do not describe `products/search` output as "Amazon search results" or "Amazon首页结果" unless you are explicitly talking about the APIClaw product database rather than the observed Amazon keyword SERP
 
 | Field | Type | Note |
 |-------|------|------|


### PR DESCRIPTION
## Summary
This PR adds a dedicated `amazon-keywords` skill package to the APIClaw skills repo and updates the surrounding docs so keyword-intelligence workflows are first-class alongside the existing product and market analysis skills.

## Problem
APIClaw already exposes a set of keyword endpoints, but the repo did not yet provide:
- a dedicated skill that routes keyword-specific user requests correctly
- scenario guidance for expansion, single-keyword evaluation, reverse ASIN analysis, and traffic diagnosis
- clear boundary documentation to prevent agents from misusing `products/search` or generic web retrieval as substitutes for keyword evidence

That gap made keyword-analysis requests harder to execute consistently and increased the risk of incorrect tool selection.

## What Changed
- added a new `amazon-keywords` skill package with:
  - `SKILL.md`
  - scenario playbooks for keyword expansion, keyword analysis, reverse ASIN, and keyword traffic diagnosis
  - execution guidance and endpoint reference material
  - a dedicated README
- expanded `apiclaw/SKILL.md` to document keyword endpoint coverage and callable tool naming expectations
- expanded `apiclaw/references/openapi-reference.md` with keyword API reference details
- updated `README.md` and `README.zh-CN.md` so the new skill appears in the top-level skills catalog and quick-start narrative
- refreshed `amazon-analysis` guidance to better point users toward the specialized keyword workflow where appropriate

## User Impact
- Codex users now have a dedicated skill for Amazon keyword intelligence instead of routing those requests through broader product-analysis flows
- keyword workflows are now documented end-to-end, including which endpoints are required, which are optional enrichers, and how to interpret missing ABA coverage
- the repo now more clearly separates keyword evidence from broader catalog-search evidence, which should reduce analysis drift and tool misuse

## Root Cause
The repository evolved around product, market, pricing, and review workflows first, while keyword-intelligence support existed at the API layer without an equivalent skill-layer abstraction and scenario documentation. This PR closes that documentation and workflow gap.

## Validation
- ran `pytest -q`
- result: `63 passed`

## Notes
- this PR is documentation and skill-packaging focused; it does not change the underlying API implementation
- the new skill requires `APICLAW_API_KEY`, consistent with the rest of the APIClaw skill ecosystem
