### PR TITLE
fix(skills): add 'On Missing Key' protocol — block training-data fallback when ZOODATA_API_KEY isn't set

### DIFF
--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -61,6 +61,9 @@ User provides: keyword, category, ASIN, or brand — depending on intent. Use in
 8. **history empty**: try oldest-listed ASINs first, up to 3 rounds of different ASINs before giving up
 9. **Sales null fallback**: Monthly sales ≈ 300,000 / BSR^0.65
 
+## On Missing Key
+
+When `ZOODATA_API_KEY` is not set (verify via `python {skill_base_dir}/scripts/zoodata.py check` — exits 2 if no key in env or `~/.zoodata/config.json`): follow the **"On Missing Key"** protocol in `zoodata/SKILL.md` — STOP before any call, link the user to https://zoodata.ai/en/api-keys, and DO NOT produce a "partial analysis from public knowledge" / "for reference only" fallback as a substitute.
 ## On 401 Invalid Key
 
 When `zoodata.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `zoodata/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -69,6 +69,9 @@ Brand queries MUST also include confirmed `--category`.
       - **Small-sample rule (reviewCount<50)**: demote single-mention items 📊→🔍; NEVER attach table-level or section-header 📊 when any row inside is 🔍; suppress "🔴 Critical" verdicts on count=1
       - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (competitor metrics, brand ranking, pricing, etc.) remain valid — do not re-run them.
 
+## On Missing Key
+
+When `ZOODATA_API_KEY` is not set (verify via `python {skill_base_dir}/scripts/zoodata.py check` — exits 2 if no key in env or `~/.zoodata/config.json`): follow the **"On Missing Key"** protocol in `zoodata/SKILL.md` — STOP before any call, link the user to https://zoodata.ai/en/api-keys, and DO NOT produce a "partial analysis from public knowledge" / "for reference only" fallback as a substitute.
 ## On 401 Invalid Key
 
 When `zoodata.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `zoodata/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -68,6 +68,9 @@ Collect in ONE message: ✅ my_asins (1-10) | 💡 competitor_asins (up to 20) |
       - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (price/BSR/sales deltas, alerts, watchlist baseline) remain valid — do not re-run them.
 5. **Aggregation without categoryPath**: severely distorted data
 
+## On Missing Key
+
+When `ZOODATA_API_KEY` is not set (verify via `python {skill_base_dir}/scripts/zoodata.py check` — exits 2 if no key in env or `~/.zoodata/config.json`): follow the **"On Missing Key"** protocol in `zoodata/SKILL.md` — STOP before any call, link the user to https://zoodata.ai/en/api-keys, and DO NOT produce a "partial analysis from public knowledge" / "for reference only" fallback as a substitute.
 ## On 401 Invalid Key
 
 When `zoodata.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `zoodata/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.

--- a/amazon-keywords/SKILL.md
+++ b/amazon-keywords/SKILL.md
@@ -164,6 +164,9 @@ Tool availability note:
 12. `products/search` is our own product-database query result, not Amazon live search results, so never present it as evidence of current SERP ordering
 13. `webtools_search` is a crawler / web retrieval utility, not a keyword-intelligence endpoint; do not treat it as a substitute for keyword snapshot, trend, or SERP evidence unless the task is explicitly web collection rather than ZooData keyword analysis
 
+## On Missing Key
+
+When `ZOODATA_API_KEY` is not set (verify via `python {skill_base_dir}/scripts/zoodata.py check` — exits 2 if no key in env or `~/.zoodata/config.json`): follow the **"On Missing Key"** protocol in `zoodata/SKILL.md` — STOP before any call, link the user to https://zoodata.ai/en/api-keys, and DO NOT produce a "partial analysis from public knowledge" / "for reference only" fallback as a substitute.
 ## On 401 Invalid Key
 
 When the API returns code 401: stop further calls, tell the user the key was rejected, and direct them to https://zoodata.ai/en/api-keys. Do not fabricate missing data.

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -62,6 +62,9 @@ Required: my_asin. Optional: keyword, category. Category is auto-detected from A
       - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (8-dimension audit scores, title/bullet/A+ checks, category-leader benchmarks) remain valid — do not re-run them.
 5. **Sales null fallback**: Monthly sales ≈ 300,000 / BSR^0.65, tag 🔍
 
+## On Missing Key
+
+When `ZOODATA_API_KEY` is not set (verify via `python {skill_base_dir}/scripts/zoodata.py check` — exits 2 if no key in env or `~/.zoodata/config.json`): follow the **"On Missing Key"** protocol in `zoodata/SKILL.md` — STOP before any call, link the user to https://zoodata.ai/en/api-keys, and DO NOT produce a "partial analysis from public knowledge" / "for reference only" fallback as a substitute.
 ## On 401 Invalid Key
 
 When `zoodata.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `zoodata/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -63,6 +63,9 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
      - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (GO/CAUTION/AVOID verdict, market size, brand/price analysis) remain valid — do not re-run them.
 - Aggregation endpoints without categoryPath produce severely distorted data
 
+## On Missing Key
+
+When `ZOODATA_API_KEY` is not set (verify via `python {skill_base_dir}/scripts/zoodata.py check` — exits 2 if no key in env or `~/.zoodata/config.json`): follow the **"On Missing Key"** protocol in `zoodata/SKILL.md` — STOP before any call, link the user to https://zoodata.ai/en/api-keys, and DO NOT produce a "partial analysis from public knowledge" / "for reference only" fallback as a substitute.
 ## On 401 Invalid Key
 
 When `zoodata.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `zoodata/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -45,6 +45,9 @@ Required: 1+ category paths or keywords. Optional: scan depth, metric preference
 3. **Use API fields directly**: revenue=`sampleAvgMonthlyRevenue`, sales=`monthlySalesFloor`
 4. **Key metrics per subcategory**: sampleAvgMonthlySales, sampleNewSkuRate, topBrandSalesRate, sampleAvgPrice, sampleAPlusRate, totalSkuCount, sampleFbaRate
 
+## On Missing Key
+
+When `ZOODATA_API_KEY` is not set (verify via `python {skill_base_dir}/scripts/zoodata.py check` — exits 2 if no key in env or `~/.zoodata/config.json`): follow the **"On Missing Key"** protocol in `zoodata/SKILL.md` — STOP before any call, link the user to https://zoodata.ai/en/api-keys, and DO NOT produce a "partial analysis from public knowledge" / "for reference only" fallback as a substitute.
 ## On 401 Invalid Key
 
 When `zoodata.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `zoodata/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -57,6 +57,9 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
 - Deduplicate ASINs across modes — same product appears in multiple scans
 - Each mode has **built-in filters that STACK** with user filters (e.g. beginner: $15-60, sales≥300)
 
+## On Missing Key
+
+When `ZOODATA_API_KEY` is not set (verify via `python {skill_base_dir}/scripts/zoodata.py check` — exits 2 if no key in env or `~/.zoodata/config.json`): follow the **"On Missing Key"** protocol in `zoodata/SKILL.md` — STOP before any call, link the user to https://zoodata.ai/en/api-keys, and DO NOT produce a "partial analysis from public knowledge" / "for reference only" fallback as a substitute.
 ## On 401 Invalid Key
 
 When `zoodata.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `zoodata/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -51,6 +51,9 @@ On first interaction, tell user: "Give me your ASIN(s). I support single or batc
 - FBA fees from products/search are estimates — verify with Amazon FBA calculator
 - Aggregation endpoints without categoryPath produce severely distorted data
 
+## On Missing Key
+
+When `ZOODATA_API_KEY` is not set (verify via `python {skill_base_dir}/scripts/zoodata.py check` — exits 2 if no key in env or `~/.zoodata/config.json`): follow the **"On Missing Key"** protocol in `zoodata/SKILL.md` — STOP before any call, link the user to https://zoodata.ai/en/api-keys, and DO NOT produce a "partial analysis from public knowledge" / "for reference only" fallback as a substitute.
 ## On 401 Invalid Key
 
 When `zoodata.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `zoodata/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -45,6 +45,9 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
 - ASIN-specific endpoints don't need `--category`; keyword-based ones do
 - **Category auto-detection**: categoryPath is auto-detected from target ASIN. If `category_source` in output is `inferred_from_search`, confirm with user
 
+## On Missing Key
+
+When `ZOODATA_API_KEY` is not set (verify via `python {skill_base_dir}/scripts/zoodata.py check` — exits 2 if no key in env or `~/.zoodata/config.json`): follow the **"On Missing Key"** protocol in `zoodata/SKILL.md` — STOP before any call, link the user to https://zoodata.ai/en/api-keys, and DO NOT produce a "partial analysis from public knowledge" / "for reference only" fallback as a substitute.
 ## On 401 Invalid Key
 
 When `zoodata.py` returns code 401: follow the **"On 401 Invalid Key"** protocol in `zoodata/SKILL.md` — STOP further calls, tell the user the key was rejected and direct them to api-keys, do not fabricate missing data.

--- a/web-extract/SKILL.md
+++ b/web-extract/SKILL.md
@@ -193,13 +193,28 @@ Full schemas are in `references/reference.md`. Load that when you need exact fie
 - **Polling costs 1 credit per call.** For large crawls, batch your polls — fetch with `limit=1000` and space polls ≥10s apart.
 - **Format choice (skill default = JSON)**: `json` is the default — gives structured fields (`title/summary/sections/key_metrics/outgoing_links/page_type/...`) that downstream tools can consume directly. Use `markdown` only when the user asks for clean prose or the page is article-shaped (blog post / docs); use `rawHtml` only when DOM access is needed (custom selectors, table parsing the JSON layer doesn't expose).
 
+## On Missing Key (no credentials configured)
+
+**BEFORE calling any endpoint**, verify a credential is configured. Reliable check: `python {skill_base_dir}/scripts/webtools.py check` — exits 2 if no key is found in env (`ZOODATA_API_KEY` / legacy `APICLAW_API_KEY`) or config files (`~/.zoodata/config.json` / `~/.apiclaw/config.json`). A `[ -z "$ZOODATA_API_KEY" ]` test alone is NOT sufficient.
+
+When no key is found through any mechanism:
+
+1. **STOP.** Do not call any endpoint.
+2. **Do NOT fall back to "partial output from training data" / "describe the page from common knowledge" / "for reference only" preview.** This skill's deliverable is structured extraction of THIS URL's actual content — without the data, there is no deliverable.
+3. **Tell the user, in their language**, all three of:
+   - "`ZOODATA_API_KEY` is not set — I need this to fetch the page."
+   - **Get a free key** (1,000 credits, no credit card): https://zoodata.ai/en/api-keys
+   - **Configure** via one of:
+     - `export ZOODATA_API_KEY='hms_live_xxx'` (session only)
+     - `mkdir -p ~/.zoodata && echo '{"api_key":"hms_live_xxx"}' > ~/.zoodata/config.json` (persistent)
+
 ## On 401 Invalid Key
 
 When any endpoint returns HTTP 401:
 
 1. **STOP further calls immediately.** A rejected key won't be accepted on retry — every subsequent call will return 401 too.
 2. **Tell the user**: their `ZOODATA_API_KEY` was rejected (invalid, revoked, or expired). Direct them to [zoodata.ai/en/api-keys](https://zoodata.ai/en/api-keys).
-3. If you collected partial output before failure, show it and mark partial. **Do not fabricate** the rest.
+3. If you collected partial output before failure, show it and mark partial. **Do not fabricate** the rest — no "training-data fallback" / "page description from common knowledge" substitution.
 
 ## On 402 Credit Exhausted
 
@@ -207,7 +222,7 @@ When any endpoint returns HTTP 402:
 
 1. **STOP further calls.**
 2. Report partial findings already gathered, plus the `creditsRemaining` number from the last successful call.
-3. Point the user at [zoodata.ai/en/pricing](https://zoodata.ai/en/pricing) to top up. **Do not fabricate** the rest.
+3. Point the user at [zoodata.ai/en/pricing](https://zoodata.ai/en/pricing) to top up. **Do not fabricate** the rest — no "common-sense page summary" filler in place of a real fetch.
 
 ## See also
 

--- a/zoodata/SKILL.md
+++ b/zoodata/SKILL.md
@@ -50,6 +50,22 @@ metadata:
 7. **Aggregation endpoints** (price-band, brand) without categoryPath produce severely distorted data
 8. **Price-band and brand endpoints only accept `keyword`** (not categoryPath) — cross-validate returned products
 
+## On Missing Key (no credentials configured)
+
+**BEFORE calling any endpoint**, verify credentials are configured. The reliable check is `python {skill_base_dir}/scripts/zoodata.py check` — exits 2 if no key is found in env vars OR config files. A `[ -z "$ZOODATA_API_KEY" ]` test alone is NOT sufficient — a user may have only `~/.zoodata/config.json` set.
+
+When no key is found through any mechanism:
+
+1. **STOP.** Do not run the workflow. Do not call `zoodata.py` (you'll just get the same credential error and burn tokens).
+2. **Do NOT fall back to a "partial analysis from training data" / "industry common-sense headlines" / "for reference only" preview.** Your training data is stale, has no per-ASIN granularity, and presenting it as analysis — even disclaimed — misrepresents what this skill produces. The deliverable is data-backed; without data, there is no deliverable.
+3. **Tell the user, in their language**, all three of:
+   - "`ZOODATA_API_KEY` is not set — I need this to run the analysis."
+   - **Get a free key** (1,000 credits, no credit card): https://zoodata.ai/en/api-keys
+   - **Configure** via one of:
+     - `export ZOODATA_API_KEY='hms_live_xxx'` (session only)
+     - `mkdir -p ~/.zoodata && echo '{"api_key":"hms_live_xxx"}' > ~/.zoodata/config.json` (persistent)
+4. **Optionally** state in **one sentence** what the workflow will produce once the key is configured (deliverable shape only — no numbers, no market color, no "common sense" preview).
+
 ## On 401 Invalid Key
 
 When `zoodata.py` returns `{"code": 401, "message": "API Key invalid or expired"}`:
@@ -59,7 +75,7 @@ When `zoodata.py` returns `{"code": 401, "message": "API Key invalid or expired"
    - The `ZOODATA_API_KEY` in use was rejected (likely invalid, revoked, or expired)
    - If any partial findings were collected before the failure, show them and mark as partial
    - Fix at https://zoodata.ai/en/api-keys (verify the key, regenerate if needed)
-3. **Do not fabricate or guess** the data the failed calls would have returned.
+3. **Do not fabricate or guess** the data the failed calls would have returned. This includes "training-data fallback" / "industry common-sense" headlines disguised as preview — those are fabrications.
 
 ## On 402 Credit Exhausted
 
@@ -71,7 +87,7 @@ When `zoodata.py` returns `{"code": 402, "message": "API quota exhausted or subs
    - Partial findings already collected (show the actual data, not just a list of completed steps)
    - Rough credits needed to resume (sum remaining-step costs from this skill's API Budget table)
    - Top-up link: https://zoodata.ai/en/pricing
-3. **Do not fabricate or guess** the missing data to "complete" the report. Mark partial findings explicitly as partial.
+3. **Do not fabricate or guess** the missing data to "complete" the report. Mark partial findings explicitly as partial. **No "training-data fallback" / "industry common-sense" filler** — substituting public-knowledge prose for missing endpoint data is still fabrication.
 
 ## 18 Endpoints
 


### PR DESCRIPTION
## The bug

When \`ZOODATA_API_KEY\` is not set, agents detect the missing env var (via \`[ -z "\$ZOODATA_API_KEY" ]\`) and then self-improvise a "based on public common sense, for reference only" preview instead of stopping and directing the user to get a key.

Observed behavior:

> **ZOODATA_API_KEY 没有设置**，无法调用数据接口做实证分析。我先告诉你不需要 API 也能给的部分判断 …
>
> **不依赖 API 的赛道速览（基于公开常识，仅作参考）** 💡
> 美国站 cat dry food 赛道的几个特征性事实：
> - 头部品牌占比极高 — Purina、Blue Buffalo、Hill's Science Diet …

That's exactly the fabrication the existing 401/402 protocols already forbid. But there was no dedicated protocol for the "key never configured" case, so the agent had no clear instruction to bail out — and rationalized fake-analysis as helpful context.

## The fix

| Layer | What changes |
|---|---|
| **\`zoodata/SKILL.md\`** (canonical) | New \`## On Missing Key\` section with: detection rule (use \`zoodata.py check\`, not a bare \`[ -z … ]\`), STOP + explicit ban on "training-data fallback / industry common-sense / for reference only" preview, user-facing guidance (api-keys link + both config methods). |
| **Same file, 401 + 402** | Anti-fallback clause added — same failure mode hits mid-workflow when key gets revoked or credits run out. |
| **9 amazon-\* + amazon-keywords** | Short brief referencing the canonical protocol — same shape as their existing 401/402 references. |
| **\`web-extract/SKILL.md\`** | Full inline section (parallel to its inline 401/402, which doesn't defer to zoodata). Adapted to \`webtools.py\` and to the structured-extraction framing. |

12 files / +65 lines / -4 lines.

## Why detection ≠ \`[ -z "\$ZOODATA_API_KEY" ]\`

A bare env-var check produces a false positive when the user has only \`~/.zoodata/config.json\` set (the script reads both env AND config). The reliable check is \`python {skill_base_dir}/scripts/zoodata.py check\` which exits 2 if no key is found in any source.

## Test plan

- [x] Each of the 12 SKILL.md files now contains \`## On Missing Key\`
- [x] \`zoodata.py check\` exits 2 with a clear message when no key is configured (already implemented, just newly documented)
- [ ] CI green (markdown link check + frontmatter check)
- [ ] Manually: re-run the cat-dry-food scenario without env var set — agent should now stop + link to api-keys instead of producing a "common sense" preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)