### PR TITLE
chore: bump patch versions across all 12 skills for ClawHub republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — amazon-keyword-traffic-analysis marketing copy
+
+`description` rewritten to lead with value hooks — ABA-backed data, Priority/Selective/Observe/Exclude test tiers, bid-worthiness verdicts, reverse-ASIN traffic terms — while preserving every trigger phrase for agent routing. Skill README restructured to lead with outcomes and example prompts; agent implementation details (draft MCP tool names, tool-selection rules) moved to a trailing "Agent Implementation Notes" section; data-boundary disclaimers consolidated under "Data Source & Boundaries". No workflow or endpoint content changed.
+
 ### Changed — Patch version bumps for ClawHub republish
 
 All 12 skills' `metadata.version` bumped one patch level. All SKILL.md files changed since the last publish (frontmatter spec compliance, APIClaw → ZooData rebrand, On Missing Key protocol, etc.), so installed copies will hit `openclaw skills update` fingerprint mismatch; republishing with a version bump gives clients a clean upgrade path instead of requiring `--force` (same approach as #56).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — Patch version bumps for ClawHub republish
+
+All 12 skills' `metadata.version` bumped one patch level. All SKILL.md files changed since the last publish (frontmatter spec compliance, APIClaw → ZooData rebrand, On Missing Key protocol, etc.), so installed copies will hit `openclaw skills update` fingerprint mismatch; republishing with a version bump gives clients a clean upgrade path instead of requiring `--force` (same approach as #56).
+
 ### Changed — SKILL.md Frontmatter Spec Compliance
 
 Frontmatter of all 10 SKILL.md files restructured to comply with the [Agent Skills open standard](https://agentskills.io/specification). The spec recognizes only `name`, `description`, `license`, `compatibility`, `metadata`, and `allowed-tools` as top-level fields; previously the files used `version`, `author`, `homepage` at the top level. These are now nested under the spec-recognized `metadata` field (the spec's official example shows `version` and `author` as `metadata` sub-keys). The `openclaw` runtime contract (`requires.env`, `primaryEnv`) is preserved as inline JSON at `metadata.openclaw` — relocated, not rewritten.

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -13,7 +13,7 @@ description: >
     deliverable in mind
   Uses {skill_base_dir}/scripts/zoodata.py. Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.7"
+  version: "1.1.8"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -16,7 +16,7 @@ description: >
   3 competitors, ongoing watch on a defined competitor set.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.3"
+  version: "1.1.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -17,7 +17,7 @@ description: >
   daily, stockout signals, set-it-and-forget-it market watch.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.3"
+  version: "1.0.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-keyword-traffic-analysis/README.md
+++ b/amazon-keyword-traffic-analysis/README.md
@@ -27,7 +27,7 @@ Four workflows for search-demand and keyword-traffic questions that product/cate
 
 ## Data Source & Boundaries
 
-All keyword signals come from the **Amazon Brand Analytics (ABA)** backend — the same search-demand data Amazon shows brand owners, not scraped estimates.
+All keyword signals are sourced from the **Amazon Brand Analytics (ABA)** backend — the search-demand data Amazon shows brand owners. Coverage is limited to keywords that appear in ABA; missing data means outside ABA coverage, not low demand.
 
 Keyword value boundary: ZooData keyword endpoints provide estimated search, exposure, visibility, and rank signals. They do not prove final keyword value or conversion quality for a specific ASIN by themselves. When the current evidence set is ZooData plus Amazon Brand Analytics market-wide signals only, traffic-related conclusions should be treated as directional. Recommended data provision: in Brand View, sort descending by Search Funnel - Impressions → Brand Count, then provide a screenshot or download the CSV for model analysis. If seller-side ABA-SQP data is included, use impressions, clicks, cart adds, purchases, click share, purchase share, and conversion rate as first-party conversion evidence.
 

--- a/amazon-keyword-traffic-analysis/README.md
+++ b/amazon-keyword-traffic-analysis/README.md
@@ -1,17 +1,37 @@
 # Amazon Keyword Intelligence — ZooData Agent Skill
 
-> Four keyword workflows built on ZooData's eight keyword endpoints.
+> Backed by Amazon Brand Analytics (ABA) data: expand seed terms into ready-to-test ad keyword tiers, judge whether a keyword deserves budget, reverse-lookup any ASIN's traffic terms, and explain rank anomalies.
 
 ## What This Skill Does
 
-This skill is for search-demand and keyword-traffic work that product/category skills do not cover well.
+Four workflows for search-demand and keyword-traffic questions that product/category skills don't cover:
 
-It supports four common scenarios:
+1. **Keyword expansion** — seed term → candidate ad keywords, pre-sorted into `Priority test` / `Selective test` / `Observe only` / `Exclude` tiers
+2. **Single keyword analysis** — a directional bid-worthiness verdict across demand, competition, ad density, and SERP structure
+3. **Reverse ASIN lookup** — which keywords drive a (competitor) ASIN's visibility, prioritized by traffic share
+4. **Keyword traffic diagnosis** — watch an ASIN under a keyword and explain rank/exposure anomalies with likely causes
 
-1. **Keyword expansion** — start from a seed term and find candidate ad keywords
-2. **Single keyword analysis** — directionally judge whether one keyword is worth testing
-3. **Reverse ASIN keyword analysis** — inspect which keywords are driving an ASIN's visibility
-4. **Keyword traffic diagnosis** — watch an ASIN on a keyword and explain anomalies
+## Example Prompts
+
+- "Expand keyword ideas from `wireless earbuds` and do a coarse filter"
+- "Is `yoga mat` worth targeting as an ad keyword?"
+- "Reverse ASIN lookup for `B0XXXXXXX` — which keywords are driving its traffic?"
+- "Monitor ASIN `B0XXXXXXX` under `collagen peptides` and explain any anomalies"
+
+## What You Get
+
+- Candidate keyword tiers: `Priority test` / `Selective test` / `Observe only` / `Exclude`
+- Single-keyword directional viability assessment across demand, competition, ad density, and SERP structure
+- Reverse ASIN keyword source view with traffic-share-based prioritization
+- Keyword anomaly diagnosis with likely cause analysis
+
+## Data Source & Boundaries
+
+All keyword signals come from the **Amazon Brand Analytics (ABA)** backend — the same search-demand data Amazon shows brand owners, not scraped estimates.
+
+Keyword value boundary: ZooData keyword endpoints provide estimated search, exposure, visibility, and rank signals. They do not prove final keyword value or conversion quality for a specific ASIN by themselves. When the current evidence set is ZooData plus Amazon Brand Analytics market-wide signals only, traffic-related conclusions should be treated as directional. Recommended data provision: in Brand View, sort descending by Search Funnel - Impressions → Brand Count, then provide a screenshot or download the CSV for model analysis. If seller-side ABA-SQP data is included, use impressions, clicks, cart adds, purchases, click share, purchase share, and conversion rate as first-party conversion evidence.
+
+Keyword date rule: keyword workflows are keyword-query lookups. When a keyword endpoint requires `date` or `dateTo`, prefer T-1 or earlier and avoid current-date lookup unless the user explicitly asks for today's data. Keep the rationale internal unless the user asks why.
 
 ## Endpoints Used
 
@@ -26,7 +46,9 @@ The skill is designed around these eight ZooData endpoints:
 - `/openapi/v2/keywords/product-traffic-terms-overview`
 - `/openapi/v2/keywords/product-traffic-terms-timeline`
 
-## Draft Tool Names
+## Agent Implementation Notes
+
+### Draft Tool Names
 
 To reduce agent guessing, read the relevant tool docs/help/schema before selecting a tool, then document and prefer full callable tool names.
 These are draft names inferred from other ZooData tool naming patterns and
@@ -41,25 +63,7 @@ should be manually confirmed against the active session:
 - `mcp__zoodata__openapi_v2_product_traffic_terms_overview`
 - `mcp__zoodata__openapi_v2_product_traffic_terms_timeline`
 
-## What You Get
-
-- Candidate keyword tiers: `Priority test` / `Selective test` / `Observe only` / `Exclude`
-- Single-keyword directional viability assessment across demand, competition, ad density, and SERP structure
-- Reverse ASIN keyword source view with traffic-share-based prioritization
-- Keyword anomaly diagnosis with likely cause analysis
-
-Keyword value boundary: ZooData keyword endpoints provide estimated search, exposure, visibility, and rank signals. They do not prove final keyword value or conversion quality for a specific ASIN by themselves. When the current evidence set is ZooData plus Amazon Brand Analytics market-wide signals only, traffic-related conclusions should be treated as directional. Recommended data provision: in Brand View, sort descending by Search Funnel - Impressions → Brand Count, then provide a screenshot or download the CSV for model analysis. If seller-side ABA-SQP data is included, use impressions, clicks, cart adds, purchases, click share, purchase share, and conversion rate as first-party conversion evidence.
-
-Keyword date rule: keyword workflows are keyword-query lookups. When a keyword endpoint requires `date` or `dateTo`, prefer T-1 or earlier and avoid current-date lookup unless the user explicitly asks for today's data. Keep the rationale internal unless the user asks why.
-
-## Example Prompts
-
-- "Expand keyword ideas from `wireless earbuds` and do a coarse filter"
-- "Is `yoga mat` worth targeting as an ad keyword?"
-- "Reverse ASIN lookup for `B0XXXXXXX` — which keywords are driving its traffic?"
-- "Monitor ASIN `B0XXXXXXX` under `collagen peptides` and explain any anomalies"
-
-## Notes
+### Notes
 
 - This skill currently focuses on workflow design and endpoint orchestration.
 - Before choosing or rejecting a tool, read the relevant tool documentation: CLI help/reference docs for `zoodata.py`, or live schema / field descriptions for MCP/session tools.

--- a/amazon-keyword-traffic-analysis/SKILL.md
+++ b/amazon-keyword-traffic-analysis/SKILL.md
@@ -5,7 +5,7 @@ description: >
   keyword deep dive; whether a keyword is worth bidding on; which keywords drive traffic to an ASIN;
   or why an ASIN changed under a keyword. Requires ZOODATA_API_KEY.
 metadata:
-  version: "0.1.1"
+  version: "0.1.2"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-keyword-traffic-analysis/SKILL.md
+++ b/amazon-keyword-traffic-analysis/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: amazon-keyword-traffic-analysis
 description: >
-  Use when user asks for keyword expansion or ad keyword filtering; single keyword analysis or
-  keyword deep dive; whether a keyword is worth bidding on; which keywords drive traffic to an ASIN;
-  or why an ASIN changed under a keyword. Requires ZOODATA_API_KEY.
+  Amazon keyword intelligence backed by Brand Analytics (ABA) data — keyword expansion sorted into
+  Priority/Selective/Observe/Exclude test tiers, bid-worthiness verdicts for single keywords,
+  reverse-ASIN traffic terms, and keyword rank anomaly diagnosis. Use when user asks for keyword
+  expansion or ad keyword filtering; single keyword analysis or keyword deep dive; whether a keyword
+  is worth bidding on; which keywords drive traffic to an ASIN; or why an ASIN changed under a
+  keyword. Requires ZOODATA_API_KEY.
 metadata:
   version: "0.1.2"
   author: SerendipityOneInc

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -12,7 +12,7 @@ description: >
   A+ content, listing health check, listing comparison.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.3"
+  version: "1.0.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -10,7 +10,7 @@ description: >
   niche evaluation, product category research.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.3"
+  version: "1.0.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -10,7 +10,7 @@ description: >
   which categories are growing, where the market is heading.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.2"
+  version: "1.0.3"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -10,7 +10,7 @@ description: >
   winning products, untapped niches, product ideas, market gaps.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.3"
+  version: "1.0.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -12,7 +12,7 @@ description: >
   price comparison, price positioning, repricing, should I raise or lower price.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.2"
+  version: "1.1.3"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -11,7 +11,7 @@ description: >
   review comparison, negative reviews, customer complaints, buying factors, user profile.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.3"
+  version: "1.0.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/web-extract/SKILL.md
+++ b/web-extract/SKILL.md
@@ -34,7 +34,7 @@ description: >
   Requires ZOODATA_API_KEY. Get a free key with 1,000 credits at
   https://zoodata.ai/en/api-keys.
 metadata:
-  version: "0.2.0"
+  version: "0.2.1"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/zoodata/SKILL.md
+++ b/zoodata/SKILL.md
@@ -18,7 +18,7 @@ description: >
   credit usage, how the Local Review Toolkit works, how to get started.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.3"
+  version: "1.1.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}


### PR DESCRIPTION
## Why

All 12 skills' SKILL.md files have changed since the last ClawHub publish (v1.2.2): frontmatter spec compliance restructure, APIClaw → ZooData rebrand (#74), On Missing Key protocol (#78), keyword traffic analysis upgrade (#81), etc.

Installed copies will hit `openclaw skills update` fingerprint mismatch (byte-level content hash check, semantics-agnostic — see CHANGELOG notes). Republishing with a patch version bump gives clients a clean upgrade path instead of requiring `--force` — same approach as #56.

## What

**1. Patch version bumps** — one-line `metadata.version` bump in each of the 12 SKILL.md files, plus a CHANGELOG entry:

| Skill | Version |
|---|---|
| amazon-analysis | 1.1.7 → 1.1.8 |
| amazon-competitor-intelligence-monitor | 1.1.3 → 1.1.4 |
| amazon-daily-market-radar | 1.0.3 → 1.0.4 |
| amazon-keyword-traffic-analysis | 0.1.1 → 0.1.2 |
| amazon-listing-audit-pro | 1.0.3 → 1.0.4 |
| amazon-market-entry-analyzer | 1.0.3 → 1.0.4 |
| amazon-market-trend-scanner | 1.0.2 → 1.0.3 |
| amazon-opportunity-discoverer | 1.0.3 → 1.0.4 |
| amazon-pricing-command-center | 1.1.2 → 1.1.3 |
| amazon-review-intelligence-extractor | 1.0.3 → 1.0.4 |
| web-extract | 0.2.0 → 0.2.1 |
| zoodata | 1.1.3 → 1.1.4 |

**2. amazon-keyword-traffic-analysis marketing copy** (riding the same republish since it touches SKILL.md):
- `description` rewritten to lead with value hooks — **ABA-backed data, Priority/Selective/Observe/Exclude test tiers, bid-worthiness verdicts, reverse-ASIN traffic terms** — with every original trigger phrase preserved for agent routing
- Skill README restructured outcome-first: draft MCP tool names and tool-selection rules moved to a trailing "Agent Implementation Notes" section; data disclaimers consolidated under "Data Source & Boundaries"
- No workflow or endpoint content changed

## After merge

Republish all 12 skills to ClawHub (`openclaw skills publish`) from the publish environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)