### PR TITLE
fix(skills): backend-contract 422 fix + mode-doc corrections + republish bumps (folds #82)

### DIFF
--- a/.github/workflows/skill-md-checks.yml
+++ b/.github/workflows/skill-md-checks.yml
@@ -31,3 +31,49 @@ jobs:
           done < <(find . -name 'SKILL.md' | sort)
 
           exit $FAILED
+
+  check-frontmatter:
+    name: Check SKILL.md frontmatter completeness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate name / description / metadata across all SKILL.md
+        run: |
+          python3 - <<'PY'
+          import glob, os, re, sys
+          fail = 0
+          for f in sorted(glob.glob("**/SKILL.md", recursive=True)):
+              if "/.agents/" in f or f.startswith(".agents/"):
+                  continue
+              d = os.path.basename(os.path.dirname(f))
+              t = open(f, encoding="utf-8").read()
+              m = re.match(r"^---\n(.*?)\n---", t, re.S)
+              if not m:
+                  print(f"ERROR {f}: no YAML frontmatter"); fail = 1; continue
+              fm = m.group(1)
+              name = re.search(r"^name:\s*(\S+)", fm, re.M)
+              if not name:
+                  print(f"ERROR {f}: missing name"); fail = 1
+              else:
+                  nm = name.group(1)
+                  if not re.match(r"^[a-z0-9-]{1,64}$", nm):
+                      print(f"ERROR {f}: name '{nm}' not kebab-case / >64 chars"); fail = 1
+                  if nm != d:
+                      print(f"ERROR {f}: name '{nm}' != parent directory '{d}'"); fail = 1
+              dm = re.search(r"^description:\s*(.*?)(?=^\w[\w-]*:|\Z)", fm + "\n", re.S | re.M)
+              desc = re.sub(r"\s+", " ", dm.group(1)).strip() if dm else ""
+              if not desc:
+                  print(f"ERROR {f}: missing/empty description"); fail = 1
+              elif len(desc) > 1024:
+                  print(f"ERROR {f}: description {len(desc)} chars > 1024 (keep concise)"); fail = 1
+              if not re.search(r"^metadata:", fm, re.M):
+                  print(f"ERROR {f}: missing metadata block"); fail = 1
+              else:
+                  if not re.search(r"version:", fm):
+                      print(f"ERROR {f}: missing metadata.version"); fail = 1
+                  if "openclaw" not in fm:
+                      print(f"ERROR {f}: missing metadata.openclaw (ClawHub credential contract)"); fail = 1
+          print("frontmatter check: OK" if not fail else "frontmatter check: FAILED")
+          sys.exit(fail)
+          PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — amazon-keyword-traffic-analysis marketing copy
+
+`description` rewritten to lead with value hooks — ABA-backed data, Priority/Selective/Observe/Exclude test tiers, bid-worthiness verdicts, reverse-ASIN traffic terms — while preserving every trigger phrase for agent routing. Skill README restructured to lead with outcomes and example prompts; agent implementation details (draft MCP tool names, tool-selection rules) moved to a trailing "Agent Implementation Notes" section; data-boundary disclaimers consolidated under "Data Source & Boundaries". No workflow or endpoint content changed.
+
 ### Changed — Patch version bumps for ClawHub republish
 
 All 12 skills' `metadata.version` bumped one patch level. All SKILL.md files changed since the last publish (frontmatter spec compliance, APIClaw → ZooData rebrand, On Missing Key protocol, etc.), so installed copies will hit `openclaw skills update` fingerprint mismatch; republishing with a version bump gives clients a clean upgrade path instead of requiring `--force` (same approach as #56).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed — Patch version bumps for ClawHub republish
+
+All 12 skills' `metadata.version` bumped one patch level. All SKILL.md files changed since the last publish (frontmatter spec compliance, APIClaw → ZooData rebrand, On Missing Key protocol, etc.), so installed copies will hit `openclaw skills update` fingerprint mismatch; republishing with a version bump gives clients a clean upgrade path instead of requiring `--force` (same approach as #56).
+
 ### Changed — SKILL.md Frontmatter Spec Compliance
 
 Frontmatter of all 10 SKILL.md files restructured to comply with the [Agent Skills open standard](https://agentskills.io/specification). The spec recognizes only `name`, `description`, `license`, `compatibility`, `metadata`, and `allowed-tools` as top-level fields; previously the files used `version`, `author`, `homepage` at the top level. These are now nested under the spec-recognized `metadata` field (the spec's official example shows `version` and `author` as `metadata` sub-keys). The `openclaw` runtime contract (`requires.env`, `primaryEnv`) is preserved as inline JSON at `metadata.openclaw` — relocated, not rewritten.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ python amazon-analysis/scripts/zoodata.py products --keyword "wireless earbuds" 
 
 | Endpoint | Description | Example Use Case |
 |----------|-------------|-----------------|
-| 🔍 `products/search` | Product search with 13 preset modes, 20+ filters | *"Find running shoes under $80 with 4+ stars"* |
+| 🔍 `products/search` | Product search with 20+ filters (13 preset modes via the CLI) | *"Find running shoes under $80 with 4+ stars"* |
 | 📊 `markets/search` | Market-level metrics — concentration, brand share, pricing | *"How competitive is the yoga mat market?"* |
 | 🏷️ `products/competitors` | Competitor discovery by keyword, brand, or ASIN | *"Who are the top sellers in this niche?"* |
 | ⚡ `realtime/product` | Real-time product details — reviews, features, variants | *"Get current details for ASIN B0D5CRV4KL"* |
@@ -135,7 +135,7 @@ python amazon-analysis/scripts/zoodata.py products --keyword "wireless earbuds" 
 
 ## 13 Product Search Modes
 
-The `products/search` endpoint supports 13 preset modes for different research strategies:
+The skill CLI (`zoodata.py --mode`) provides 13 preset modes for different research strategies. Modes are expanded into concrete filter fields (`monthlySalesMin`, `salesGrowthRateMin`, …) on the client side — `mode` is **not** an API parameter, and sending it to `/openapi/v2/products/search` returns 422:
 
 | Mode | Strategy | Target |
 |------|----------|--------|

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Ask your AI agent:
 Or use the CLI directly:
 
 ```bash
-python amazon-analysis/scripts/zoodata.py products --keyword "wireless earbuds" --mode competitive_landscape
+python amazon-analysis/scripts/zoodata.py products --keyword "wireless earbuds" --mode fast-movers
 ```
 
 ## API Endpoints

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -107,7 +107,7 @@ export ZOODATA_API_KEY='hms_live_xxx'   # 在 zoodata.ai/en/api-keys 免费获�
 或者直接用命令行：
 
 ```bash
-python amazon-analysis/scripts/zoodata.py products --keyword "wireless earbuds" --mode competitive_landscape
+python amazon-analysis/scripts/zoodata.py products --keyword "wireless earbuds" --mode fast-movers
 ```
 
 ## API 接口

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -118,7 +118,7 @@ python amazon-analysis/scripts/zoodata.py products --keyword "wireless earbuds" 
 
 | 接口 | 说明 | 使用场景 |
 |------|------|----------|
-| 🔍 `products/search` | 商品搜索，13 种预设模式，20+ 筛选条件 | *"找 80 美元以下、4 星以上的跑步鞋"* |
+| 🔍 `products/search` | 商品搜索，20+ 筛选条件（CLI 另提供 13 种预设模式） | *"找 80 美元以下、4 星以上的跑步鞋"* |
 | 📊 `markets/search` | 市场维度指标——集中度、品牌份额、定价分布 | *"瑜伽垫市场竞争激烈吗？"* |
 | 🏷️ `products/competitor-lookup` | 按关键词、品牌或 ASIN 发现竞品 | *"这个细分类目的头部卖家有哪些？"* |
 | ⚡ `realtime/product` | 实时商品详情——评论、功能、变体 | *"查一下 ASIN B0D5CRV4KL 的最新信息"* |
@@ -132,7 +132,7 @@ python amazon-analysis/scripts/zoodata.py products --keyword "wireless earbuds" 
 
 ## 13 种选品模式
 
-`products/search` 接口支持 13 种预设模式，覆盖不同的选品策略：
+技能 CLI（`zoodata.py --mode`）提供 13 种预设模式，覆盖不同的选品策略。模式在客户端展开为真实筛选字段（`monthlySalesMin`、`salesGrowthRateMin` 等）——`mode` **不是** API 参数，直接发给 `/openapi/v2/products/search` 会返回 422：
 
 | 模式 | 策略 | 适用人群 |
 |------|------|----------|

--- a/amazon-analysis/README.md
+++ b/amazon-analysis/README.md
@@ -1,14 +1,14 @@
 # Amazon Analysis — Full-Spectrum Research & Seller Intelligence
 
-> 14 product selection strategies. One skill to rule them all.
+> 13 product selection strategies. One skill to rule them all.
 
 ## What This Skill Does
 
-The Swiss Army knife of Amazon product research. Supports 14 built-in selection modes — from hot products and rising stars to long-tail niches and FBM-friendly picks. Combines market research, product selection, competitor analysis, ASIN evaluation, pricing reference, and category research into a single unified workflow.
+The Swiss Army knife of Amazon product research. Supports 13 built-in selection modes — from fast-movers and emerging products to long-tail niches and FBM-friendly picks. Combines market research, product selection, competitor analysis, ASIN evaluation, pricing reference, and category research into a single unified workflow.
 
 ### What Makes This Different
 
-- **14 selection modes**: hot-products, rising-stars, underserved, high-demand-low-barrier, beginner, fast-movers, emerging, single-variant, long-tail, new-release, low-price, top-bsr, fbm-friendly, broad-catalog
+- **13 selection modes**: fast-movers, emerging, single-variant, high-demand-low-barrier, long-tail, underserved, new-release, fbm-friendly, low-price, broad-catalog, selective-catalog, speculative, top-bsr
 - **Composite commands**: `report` and `opportunity` run multi-endpoint pipelines in one shot
 - **Flexible filtering**: Modes stack with explicit filters (`--price-max`, `--sales-min`, etc.)
 - **Confidence tagging**: Every data point tagged as 📊 Data-backed, 🔍 Inferred, or 💡 Directional
@@ -32,7 +32,7 @@ Select **Amazon Analysis** when prompted.
 ## Example Prompts
 
 - *"Analyze the yoga mat market on Amazon"*
-- *"Use the rising-stars mode to find products in the $15-30 range"*
+- *"Use the emerging mode to find products in the $15-30 range"*
 - *"Find beginner-friendly products in kitchen gadgets under $25"*
 - *"Run a full report on keyword 'silicone spatula'"*
 - *"Use the underserved mode to find improvable products rated below 3.7"*
@@ -53,7 +53,7 @@ Select **Amazon Analysis** when prompted.
 |----------|---------|
 | `categories` | Lock category path before analysis |
 | `markets/search` | Market-level metrics and context |
-| `products/search` | Product scanning with 14 selection modes |
+| `products/search` | Product scanning with 20+ filter fields (13 CLI presets) |
 | `products/competitors` | Competitive landscape |
 | `realtime/product` | Live ASIN validation |
 | `reviews/analysis` | Consumer pain points and sentiment |

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -74,7 +74,7 @@ When `zoodata.py` returns code 402: follow the **"On 402 Credit Exhausted"** pro
 
 ## 13 Product Selection Modes
 
-> **Modes are CLI-local presets, NOT API parameters.** `zoodata.py` expands `--mode` into real filter fields before the call — copy them from `PRODUCT_MODES` in `scripts/zoodata.py` if you bypass the CLI. Before any raw `products/search` request, follow the **`mode`/CLI-flags-are-CLI-local** pitfall in `zoodata/SKILL.md` (Critical API Pitfalls #9): `mode`/`salesMin`/`ratingsMax` raw → 422, `ratingMax` ≠ `ratingCountMax`, `categoryPath` must be a JSON array.
+> **Modes are CLI-local presets, NOT API parameters.** `zoodata.py` expands `--mode` into real filter fields before the call — copy them from `PRODUCT_MODES` in `{skill_base_dir}/scripts/zoodata.py` if you bypass the CLI. Before any raw `products/search` request, follow the **`mode`/CLI-flags-are-CLI-local** pitfall in `zoodata/SKILL.md` (Critical API Pitfalls #9): `mode`/`salesMin`/`ratingsMax` raw → 422, `ratingMax` ≠ `ratingCountMax`, `categoryPath` must be a JSON array.
 
 | Mode | One-line Description |
 |------|---------------------|

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -72,26 +72,25 @@ When `zoodata.py` returns code 401: follow the **"On 401 Invalid Key"** protocol
 
 When `zoodata.py` returns code 402: follow the **"On 402 Credit Exhausted"** protocol in `zoodata/SKILL.md` — STOP further calls, report partial findings already gathered, do not fabricate missing data.
 
-## 14 Product Selection Modes
+## 13 Product Selection Modes
 
 > **Modes are CLI-local presets, NOT API parameters.** `zoodata.py` expands `--mode` into real filter fields (`monthlySalesMin`, `salesGrowthRateMin`, …) before calling the API. Never send `mode` (or `salesMin` — the API field is `monthlySalesMin`) in a raw HTTP request to `/openapi/v2/products/search`; the API rejects unknown fields with 422. Watch the near-miss pair: `--ratings-max` (review count) maps to `ratingCountMax`, while `ratingMax` is a *different valid field* (max star rating) — mixing them up returns wrong results silently instead of a 422. If you bypass the CLI, copy the filter expansion from `PRODUCT_MODES` in `scripts/zoodata.py`, and pass `categoryPath` as a JSON array (`["Electronics"]`), not a string.
 
 | Mode | One-line Description |
 |------|---------------------|
-| `hot-products` | High sales + strong growth momentum |
-| `rising-stars` | Low base + rapid growth trajectory |
-| `underserved` | Monthly sales≥300, rating≤3.7 — improvable products |
-| `high-demand-low-barrier` | Monthly sales≥300, reviews≤50 — easy entry |
-| `beginner` | $15-60, FBA, monthly sales≥300 — new seller friendly |
 | `fast-movers` | Monthly sales≥300, growth≥10% — quick turnover |
 | `emerging` | Monthly sales≤600, growth≥10%, ≤6 months old |
 | `single-variant` | Growth≥20%, 1 variant, ≤6 months — small & rising |
+| `high-demand-low-barrier` | Monthly sales≥300, reviews≤50 — easy entry |
 | `long-tail` | BSR 10K-50K, ≤$30, exclusive sellers — niche |
+| `underserved` | Monthly sales≥300, rating≤3.7 — improvable products |
 | `new-release` | Monthly sales≤500, New Release tag |
-| `low-price` | ≤$10 products |
-| `top-bsr` | BSR≤1000 best sellers |
 | `fbm-friendly` | Monthly sales≥300, self-fulfilled |
+| `low-price` | ≤$10 products |
 | `broad-catalog` | BSR growth≥99%, reviews≤10, ≤90 days |
+| `selective-catalog` | BSR growth≥99%, ≤90 days |
+| `speculative` | Monthly sales≥600, ≥3 sellers |
+| `top-bsr` | BSR≤1000 best sellers |
 
 Modes can combine with explicit filters (`--price-max`, `--sales-min`, etc). Overrides win.
 

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -74,6 +74,8 @@ When `zoodata.py` returns code 402: follow the **"On 402 Credit Exhausted"** pro
 
 ## 14 Product Selection Modes
 
+> **Modes are CLI-local presets, NOT API parameters.** `zoodata.py` expands `--mode` into real filter fields (`monthlySalesMin`, `salesGrowthRateMin`, …) before calling the API. Never send `mode` (or `salesMin` — the API field is `monthlySalesMin`) in a raw HTTP request to `/openapi/v2/products/search`; the API rejects unknown fields with 422. If you bypass the CLI, copy the filter expansion from `PRODUCT_MODES` in `scripts/zoodata.py`, and pass `categoryPath` as a JSON array (`["Electronics"]`), not a string.
+
 | Mode | One-line Description |
 |------|---------------------|
 | `hot-products` | High sales + strong growth momentum |

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -74,7 +74,7 @@ When `zoodata.py` returns code 402: follow the **"On 402 Credit Exhausted"** pro
 
 ## 13 Product Selection Modes
 
-> **Modes are CLI-local presets, NOT API parameters.** `zoodata.py` expands `--mode` into real filter fields before the call — copy them from `PRODUCT_MODES` in `{skill_base_dir}/scripts/zoodata.py` if you bypass the CLI. Before any raw `products/search` request, follow the **`mode`/CLI-flags-are-CLI-local** pitfall in `zoodata/SKILL.md` (Critical API Pitfalls #9): `mode`/`salesMin`/`ratingsMax` raw → 422, `ratingMax` ≠ `ratingCountMax`, `categoryPath` must be a JSON array.
+> **Modes are CLI-local presets, NOT API parameters.** `zoodata.py` expands `--mode` into real filter fields before the call — copy them from `PRODUCT_MODES` in `{skill_base_dir}/scripts/zoodata.py` if you bypass the CLI. Before any raw `products/search` request, follow the **`mode`/CLI-flags** pitfalls in `zoodata/SKILL.md` (Critical API Pitfalls #9–#10): `mode`/`salesMin`/`ratingsMax` raw → 422, `ratingMax` ≠ `ratingCountMax`, `categoryPath` must be a JSON array.
 
 | Mode | One-line Description |
 |------|---------------------|

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -13,7 +13,7 @@ description: >
     deliverable in mind
   Uses {skill_base_dir}/scripts/zoodata.py. Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.7"
+  version: "1.1.8"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -74,7 +74,7 @@ When `zoodata.py` returns code 402: follow the **"On 402 Credit Exhausted"** pro
 
 ## 14 Product Selection Modes
 
-> **Modes are CLI-local presets, NOT API parameters.** `zoodata.py` expands `--mode` into real filter fields (`monthlySalesMin`, `salesGrowthRateMin`, …) before calling the API. Never send `mode` (or `salesMin` — the API field is `monthlySalesMin`) in a raw HTTP request to `/openapi/v2/products/search`; the API rejects unknown fields with 422. If you bypass the CLI, copy the filter expansion from `PRODUCT_MODES` in `scripts/zoodata.py`, and pass `categoryPath` as a JSON array (`["Electronics"]`), not a string.
+> **Modes are CLI-local presets, NOT API parameters.** `zoodata.py` expands `--mode` into real filter fields (`monthlySalesMin`, `salesGrowthRateMin`, …) before calling the API. Never send `mode` (or `salesMin` — the API field is `monthlySalesMin`) in a raw HTTP request to `/openapi/v2/products/search`; the API rejects unknown fields with 422. Watch the near-miss pair: `--ratings-max` (review count) maps to `ratingCountMax`, while `ratingMax` is a *different valid field* (max star rating) — mixing them up returns wrong results silently instead of a 422. If you bypass the CLI, copy the filter expansion from `PRODUCT_MODES` in `scripts/zoodata.py`, and pass `categoryPath` as a JSON array (`["Electronics"]`), not a string.
 
 | Mode | One-line Description |
 |------|---------------------|

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -74,7 +74,7 @@ When `zoodata.py` returns code 402: follow the **"On 402 Credit Exhausted"** pro
 
 ## 13 Product Selection Modes
 
-> **Modes are CLI-local presets, NOT API parameters.** `zoodata.py` expands `--mode` into real filter fields (`monthlySalesMin`, `salesGrowthRateMin`, …) before calling the API. Never send `mode` (or `salesMin` — the API field is `monthlySalesMin`) in a raw HTTP request to `/openapi/v2/products/search`; the API rejects unknown fields with 422. Watch the near-miss pair: `--ratings-max` (review count) maps to `ratingCountMax`, while `ratingMax` is a *different valid field* (max star rating) — mixing them up returns wrong results silently instead of a 422. If you bypass the CLI, copy the filter expansion from `PRODUCT_MODES` in `scripts/zoodata.py`, and pass `categoryPath` as a JSON array (`["Electronics"]`), not a string.
+> **Modes are CLI-local presets, NOT API parameters.** `zoodata.py` expands `--mode` into real filter fields before the call — copy them from `PRODUCT_MODES` in `scripts/zoodata.py` if you bypass the CLI. Before any raw `products/search` request, follow the **`mode`/CLI-flags-are-CLI-local** pitfall in `zoodata/SKILL.md` (Critical API Pitfalls #9): `mode`/`salesMin`/`ratingsMax` raw → 422, `ratingMax` ≠ `ratingCountMax`, `categoryPath` must be a JSON array.
 
 | Mode | One-line Description |
 |------|---------------------|

--- a/amazon-analysis/references/execution-guide.md
+++ b/amazon-analysis/references/execution-guide.md
@@ -22,7 +22,7 @@ Load when performing comprehensive product selection, market analysis, or compet
 
 Before running any Full-mode product selection or market analysis, **complete this checklist**:
 
-- [ ] **Step 1 — Mode Selection:** Check the Product Selection Mode Mapping table in SKILL.md. If ANY of the 14 preset modes matches the user's intent, **USE IT** (`--mode xxx`). Do NOT manually piece together filters when a preset mode exists.
+- [ ] **Step 1 — Mode Selection:** Check the Product Selection Mode Mapping table in SKILL.md. If ANY of the 13 preset modes matches the user's intent, **USE IT** (`--mode xxx`). Do NOT manually piece together filters when a preset mode exists.
 - [ ] **Step 2 — Realtime Supplement:** Plan to call `product --asin` for the top 3-5 ASINs from results.
 - [ ] **Step 3 — Review Analysis:** Plan to call `analyze --asins` for top ASINs to get consumer insights (especially painPoints, improvements, buyingFactors).
 - [ ] **Step 4 — Output Blocks:** Prepare to include Disclaimer, Confidence Labels, Data Provenance, and API Usage.

--- a/amazon-analysis/references/reference.md
+++ b/amazon-analysis/references/reference.md
@@ -76,7 +76,7 @@ All endpoints return: `{success, data, error, meta}` with `meta.creditsRemaining
 ## 3. products/search — Shared Product Object
 
 **Key Request Params:**
-- `keyword`, `categoryPath`, `mode` (14 presets), `keywordMatchType`
+- `keyword`, `categoryPath`, `keywordMatchType` (`mode` is a CLI-only preset — `zoodata.py` expands it into the filter pairs below client-side; it is NOT an API field and returns 422 if sent raw)
 - Filter pairs: `monthlySalesMin/Max`, `priceMin/Max`, `ratingMin/Max`, etc.
 - `pageSize` (max 20), `page`, `sortBy`, `sortOrder`
 - `includeBrands`, `excludeBrands`

--- a/amazon-analysis/scripts/zoodata.py
+++ b/amazon-analysis/scripts/zoodata.py
@@ -2776,7 +2776,7 @@ Examples:
 
     # Common args
     parser.add_argument("--format", choices=["json", "compact"], default="json",
-                        help="Output format (default: json)")
+                        help="Output format (default: json). Global flag — must come BEFORE the subcommand")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -2795,7 +2795,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field")
+    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2820,7 +2820,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
+    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2834,7 +2834,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor)")
+    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-analysis/scripts/zoodata.py
+++ b/amazon-analysis/scripts/zoodata.py
@@ -78,17 +78,17 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Each maps to a set of products/search filter parameters
 PRODUCT_MODES = {
     "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
-    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
-    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
-    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180"},
+    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180d"},
+    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180d"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180d"},
     "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
-    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
-    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillments": ["FBA", "FBM"]},
-    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180"},
+    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180d"},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["newRelease"], "fulfillments": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180d"},
     "low-price":                {"priceMax": 10},
-    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90"},
-    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
-    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90d"},
+    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90d"},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180d"},
     # "beginner" mode disabled — excludeKeywords filter not working
     "top-bsr":                  {"subBsrMax": 1000},
 }
@@ -2800,8 +2800,8 @@ Examples:
     p_prod.add_argument("--rating-min", type=float, help="Min rating")
     p_prod.add_argument("--rating-max", type=float, help="Max rating")
     p_prod.add_argument("--growth-min", type=float, help="Min sales growth rate")
-    p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
-    p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
+    p_prod.add_argument("--listing-age", help="Max listing age: 30d, 90d, 180d, 1y, or 2y")
+    p_prod.add_argument("--badges", nargs="+", help="Badge filters: bestSeller, amazonChoice, newRelease, aPlus, video")
     p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")

--- a/amazon-analysis/scripts/zoodata.py
+++ b/amazon-analysis/scripts/zoodata.py
@@ -421,15 +421,28 @@ def output(data, fmt="json"):
 
 def parse_category(cat_str: str) -> list:
     """Parse category path string into a list.
-    
+
     Supported formats:
-      - 'Pet Supplies,Dogs,Toys'           (comma-separated)
-      - 'Pet Supplies > Dogs > Toys'       (spaced arrow)
+      - '["Pet Supplies", "Dogs"]'         (JSON array — unambiguous, safest)
+      - 'Pet Supplies > Dogs > Toys'       (spaced arrow — recommended)
       - 'Pet Supplies>Dogs>Toys'           (bare arrow, no spaces)
+      - 'Pet Supplies,Dogs,Toys'           (comma-separated — AVOID for names
+        that contain commas, e.g. "Headphones, Earbuds & Accessories";
+        use '>' or JSON array for those)
     """
     if not cat_str:
         return []
-    # Support comma, ' > ' (spaced), and '>' (bare) separators
+    # JSON array input — exact segments, no separator ambiguity
+    stripped = cat_str.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if str(c).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON — fall through to separator parsing
+    # Arrow separators take priority: category names never contain '>',
+    # but they DO contain commas (e.g. "Headphones, Earbuds & Accessories")
     if " > " in cat_str:
         return [c.strip() for c in cat_str.split(" > ")]
     if ">" in cat_str:
@@ -2770,14 +2783,14 @@ Examples:
     # ── categories ──
     p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
-    p_cat.add_argument("--category", help="Exact category path (comma-separated)")
+    p_cat.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
     p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
-    p_mkt.add_argument("--category", help="Category path (comma-separated)")
+    p_mkt.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
@@ -2789,7 +2802,7 @@ Examples:
     # ── products ──
     p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
-    p_prod.add_argument("--category", help="Category path (comma-separated)")
+    p_prod.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
     p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
     p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2816,7 +2829,7 @@ Examples:
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
-    p_comp.add_argument("--category", help="Category path (comma-separated)")
+    p_comp.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_comp.add_argument("--date-range", default="30d", help="Date range (default: 30d)")
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
@@ -2847,41 +2860,41 @@ Examples:
     # ── market-entry (composite: full analysis) ──
     p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
-    p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
+    p_me.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
     p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
-    p_ca.add_argument("--category", help="Category path")
+    p_ca.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
     p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
-    p_pa.add_argument("--category", help="Category path")
+    p_pa.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
     p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
-    p_dr.add_argument("--category", help="Category path")
+    p_dr.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
     p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
-    p_la.add_argument("--category", help="Category path")
+    p_la.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
     p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
-    p_os.add_argument("--category", help="Category path")
+    p_os.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. emerging,underserved,high-demand-low-barrier). Omit to use custom filters only.")
     p_os.add_argument("--sales-min", type=int, help="Min monthly sales (e.g. 300)")
     p_os.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2897,7 +2910,7 @@ Examples:
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
-    p_rd.add_argument("--category", help="Category path")
+    p_rd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
@@ -2936,7 +2949,7 @@ Examples:
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
-    p_analyze.add_argument("--category", help="Category path")
+    p_analyze.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_analyze.add_argument("--label-type", help="Filter dimensions (comma-separated)")
     p_analyze.add_argument("--period", help="Time period: 1m, 3m, 6m, 1y, 2y", default="6m")
     p_analyze.set_defaults(func=cmd_analyze)
@@ -2944,7 +2957,7 @@ Examples:
     # ── price-band-overview ──
     p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
-    p_pbo.add_argument("--category", help="Category path")
+    p_pbo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbo.add_argument("--page-size", type=int, default=20)
     p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
@@ -2952,7 +2965,7 @@ Examples:
     # ── price-band-detail ──
     p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
-    p_pbd.add_argument("--category", help="Category path")
+    p_pbd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbd.add_argument("--page-size", type=int, default=20)
     p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
@@ -2960,7 +2973,7 @@ Examples:
     # ── brand-overview ──
     p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
-    p_bo.add_argument("--category", help="Category path")
+    p_bo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bo.add_argument("--page-size", type=int, default=20)
     p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
@@ -2968,7 +2981,7 @@ Examples:
     # ── brand-detail ──
     p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
-    p_bd.add_argument("--category", help="Category path")
+    p_bd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bd.add_argument("--page-size", type=int, default=20)
     p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -16,7 +16,7 @@ description: >
   3 competitors, ongoing watch on a defined competitor set.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.3"
+  version: "1.1.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-competitor-intelligence-monitor/references/reference.md
+++ b/amazon-competitor-intelligence-monitor/references/reference.md
@@ -76,7 +76,7 @@ All endpoints return: `{success, data, error, meta}` with `meta.creditsRemaining
 ## 3. products/search — Shared Product Object
 
 **Key Request Params:**
-- `keyword`, `categoryPath`, `mode` (14 presets), `keywordMatchType`
+- `keyword`, `categoryPath`, `keywordMatchType` (`mode` is a CLI-only preset — `zoodata.py` expands it into the filter pairs below client-side; it is NOT an API field and returns 422 if sent raw)
 - Filter pairs: `monthlySalesMin/Max`, `priceMin/Max`, `ratingMin/Max`, etc.
 - `pageSize` (max 20), `page`, `sortBy`, `sortOrder`
 - `includeBrands`, `excludeBrands`

--- a/amazon-competitor-intelligence-monitor/scripts/zoodata.py
+++ b/amazon-competitor-intelligence-monitor/scripts/zoodata.py
@@ -2776,7 +2776,7 @@ Examples:
 
     # Common args
     parser.add_argument("--format", choices=["json", "compact"], default="json",
-                        help="Output format (default: json)")
+                        help="Output format (default: json). Global flag — must come BEFORE the subcommand")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -2795,7 +2795,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field")
+    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2820,7 +2820,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
+    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2834,7 +2834,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor)")
+    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-competitor-intelligence-monitor/scripts/zoodata.py
+++ b/amazon-competitor-intelligence-monitor/scripts/zoodata.py
@@ -78,17 +78,17 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Each maps to a set of products/search filter parameters
 PRODUCT_MODES = {
     "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
-    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
-    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
-    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180"},
+    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180d"},
+    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180d"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180d"},
     "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
-    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
-    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillments": ["FBA", "FBM"]},
-    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180"},
+    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180d"},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["newRelease"], "fulfillments": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180d"},
     "low-price":                {"priceMax": 10},
-    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90"},
-    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
-    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90d"},
+    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90d"},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180d"},
     # "beginner" mode disabled — excludeKeywords filter not working
     "top-bsr":                  {"subBsrMax": 1000},
 }
@@ -2800,8 +2800,8 @@ Examples:
     p_prod.add_argument("--rating-min", type=float, help="Min rating")
     p_prod.add_argument("--rating-max", type=float, help="Max rating")
     p_prod.add_argument("--growth-min", type=float, help="Min sales growth rate")
-    p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
-    p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
+    p_prod.add_argument("--listing-age", help="Max listing age: 30d, 90d, 180d, 1y, or 2y")
+    p_prod.add_argument("--badges", nargs="+", help="Badge filters: bestSeller, amazonChoice, newRelease, aPlus, video")
     p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")

--- a/amazon-competitor-intelligence-monitor/scripts/zoodata.py
+++ b/amazon-competitor-intelligence-monitor/scripts/zoodata.py
@@ -421,15 +421,28 @@ def output(data, fmt="json"):
 
 def parse_category(cat_str: str) -> list:
     """Parse category path string into a list.
-    
+
     Supported formats:
-      - 'Pet Supplies,Dogs,Toys'           (comma-separated)
-      - 'Pet Supplies > Dogs > Toys'       (spaced arrow)
+      - '["Pet Supplies", "Dogs"]'         (JSON array — unambiguous, safest)
+      - 'Pet Supplies > Dogs > Toys'       (spaced arrow — recommended)
       - 'Pet Supplies>Dogs>Toys'           (bare arrow, no spaces)
+      - 'Pet Supplies,Dogs,Toys'           (comma-separated — AVOID for names
+        that contain commas, e.g. "Headphones, Earbuds & Accessories";
+        use '>' or JSON array for those)
     """
     if not cat_str:
         return []
-    # Support comma, ' > ' (spaced), and '>' (bare) separators
+    # JSON array input — exact segments, no separator ambiguity
+    stripped = cat_str.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if str(c).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON — fall through to separator parsing
+    # Arrow separators take priority: category names never contain '>',
+    # but they DO contain commas (e.g. "Headphones, Earbuds & Accessories")
     if " > " in cat_str:
         return [c.strip() for c in cat_str.split(" > ")]
     if ">" in cat_str:
@@ -2770,14 +2783,14 @@ Examples:
     # ── categories ──
     p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
-    p_cat.add_argument("--category", help="Exact category path (comma-separated)")
+    p_cat.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
     p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
-    p_mkt.add_argument("--category", help="Category path (comma-separated)")
+    p_mkt.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
@@ -2789,7 +2802,7 @@ Examples:
     # ── products ──
     p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
-    p_prod.add_argument("--category", help="Category path (comma-separated)")
+    p_prod.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
     p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
     p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2816,7 +2829,7 @@ Examples:
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
-    p_comp.add_argument("--category", help="Category path (comma-separated)")
+    p_comp.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_comp.add_argument("--date-range", default="30d", help="Date range (default: 30d)")
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
@@ -2847,41 +2860,41 @@ Examples:
     # ── market-entry (composite: full analysis) ──
     p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
-    p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
+    p_me.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
     p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
-    p_ca.add_argument("--category", help="Category path")
+    p_ca.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
     p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
-    p_pa.add_argument("--category", help="Category path")
+    p_pa.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
     p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
-    p_dr.add_argument("--category", help="Category path")
+    p_dr.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
     p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
-    p_la.add_argument("--category", help="Category path")
+    p_la.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
     p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
-    p_os.add_argument("--category", help="Category path")
+    p_os.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. emerging,underserved,high-demand-low-barrier). Omit to use custom filters only.")
     p_os.add_argument("--sales-min", type=int, help="Min monthly sales (e.g. 300)")
     p_os.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2897,7 +2910,7 @@ Examples:
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
-    p_rd.add_argument("--category", help="Category path")
+    p_rd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
@@ -2936,7 +2949,7 @@ Examples:
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
-    p_analyze.add_argument("--category", help="Category path")
+    p_analyze.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_analyze.add_argument("--label-type", help="Filter dimensions (comma-separated)")
     p_analyze.add_argument("--period", help="Time period: 1m, 3m, 6m, 1y, 2y", default="6m")
     p_analyze.set_defaults(func=cmd_analyze)
@@ -2944,7 +2957,7 @@ Examples:
     # ── price-band-overview ──
     p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
-    p_pbo.add_argument("--category", help="Category path")
+    p_pbo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbo.add_argument("--page-size", type=int, default=20)
     p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
@@ -2952,7 +2965,7 @@ Examples:
     # ── price-band-detail ──
     p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
-    p_pbd.add_argument("--category", help="Category path")
+    p_pbd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbd.add_argument("--page-size", type=int, default=20)
     p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
@@ -2960,7 +2973,7 @@ Examples:
     # ── brand-overview ──
     p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
-    p_bo.add_argument("--category", help="Category path")
+    p_bo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bo.add_argument("--page-size", type=int, default=20)
     p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
@@ -2968,7 +2981,7 @@ Examples:
     # ── brand-detail ──
     p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
-    p_bd.add_argument("--category", help="Category path")
+    p_bd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bd.add_argument("--page-size", type=int, default=20)
     p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -17,7 +17,7 @@ description: >
   daily, stockout signals, set-it-and-forget-it market watch.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.3"
+  version: "1.0.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-daily-market-radar/references/reference.md
+++ b/amazon-daily-market-radar/references/reference.md
@@ -76,7 +76,7 @@ All endpoints return: `{success, data, error, meta}` with `meta.creditsRemaining
 ## 3. products/search — Shared Product Object
 
 **Key Request Params:**
-- `keyword`, `categoryPath`, `mode` (14 presets), `keywordMatchType`
+- `keyword`, `categoryPath`, `keywordMatchType` (`mode` is a CLI-only preset — `zoodata.py` expands it into the filter pairs below client-side; it is NOT an API field and returns 422 if sent raw)
 - Filter pairs: `monthlySalesMin/Max`, `priceMin/Max`, `ratingMin/Max`, etc.
 - `pageSize` (max 20), `page`, `sortBy`, `sortOrder`
 - `includeBrands`, `excludeBrands`

--- a/amazon-daily-market-radar/scripts/zoodata.py
+++ b/amazon-daily-market-radar/scripts/zoodata.py
@@ -2776,7 +2776,7 @@ Examples:
 
     # Common args
     parser.add_argument("--format", choices=["json", "compact"], default="json",
-                        help="Output format (default: json)")
+                        help="Output format (default: json). Global flag — must come BEFORE the subcommand")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -2795,7 +2795,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field")
+    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2820,7 +2820,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
+    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2834,7 +2834,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor)")
+    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-daily-market-radar/scripts/zoodata.py
+++ b/amazon-daily-market-radar/scripts/zoodata.py
@@ -78,17 +78,17 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Each maps to a set of products/search filter parameters
 PRODUCT_MODES = {
     "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
-    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
-    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
-    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180"},
+    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180d"},
+    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180d"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180d"},
     "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
-    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
-    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillments": ["FBA", "FBM"]},
-    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180"},
+    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180d"},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["newRelease"], "fulfillments": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180d"},
     "low-price":                {"priceMax": 10},
-    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90"},
-    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
-    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90d"},
+    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90d"},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180d"},
     # "beginner" mode disabled — excludeKeywords filter not working
     "top-bsr":                  {"subBsrMax": 1000},
 }
@@ -2800,8 +2800,8 @@ Examples:
     p_prod.add_argument("--rating-min", type=float, help="Min rating")
     p_prod.add_argument("--rating-max", type=float, help="Max rating")
     p_prod.add_argument("--growth-min", type=float, help="Min sales growth rate")
-    p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
-    p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
+    p_prod.add_argument("--listing-age", help="Max listing age: 30d, 90d, 180d, 1y, or 2y")
+    p_prod.add_argument("--badges", nargs="+", help="Badge filters: bestSeller, amazonChoice, newRelease, aPlus, video")
     p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")

--- a/amazon-daily-market-radar/scripts/zoodata.py
+++ b/amazon-daily-market-radar/scripts/zoodata.py
@@ -421,15 +421,28 @@ def output(data, fmt="json"):
 
 def parse_category(cat_str: str) -> list:
     """Parse category path string into a list.
-    
+
     Supported formats:
-      - 'Pet Supplies,Dogs,Toys'           (comma-separated)
-      - 'Pet Supplies > Dogs > Toys'       (spaced arrow)
+      - '["Pet Supplies", "Dogs"]'         (JSON array — unambiguous, safest)
+      - 'Pet Supplies > Dogs > Toys'       (spaced arrow — recommended)
       - 'Pet Supplies>Dogs>Toys'           (bare arrow, no spaces)
+      - 'Pet Supplies,Dogs,Toys'           (comma-separated — AVOID for names
+        that contain commas, e.g. "Headphones, Earbuds & Accessories";
+        use '>' or JSON array for those)
     """
     if not cat_str:
         return []
-    # Support comma, ' > ' (spaced), and '>' (bare) separators
+    # JSON array input — exact segments, no separator ambiguity
+    stripped = cat_str.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if str(c).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON — fall through to separator parsing
+    # Arrow separators take priority: category names never contain '>',
+    # but they DO contain commas (e.g. "Headphones, Earbuds & Accessories")
     if " > " in cat_str:
         return [c.strip() for c in cat_str.split(" > ")]
     if ">" in cat_str:
@@ -2770,14 +2783,14 @@ Examples:
     # ── categories ──
     p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
-    p_cat.add_argument("--category", help="Exact category path (comma-separated)")
+    p_cat.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
     p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
-    p_mkt.add_argument("--category", help="Category path (comma-separated)")
+    p_mkt.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
@@ -2789,7 +2802,7 @@ Examples:
     # ── products ──
     p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
-    p_prod.add_argument("--category", help="Category path (comma-separated)")
+    p_prod.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
     p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
     p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2816,7 +2829,7 @@ Examples:
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
-    p_comp.add_argument("--category", help="Category path (comma-separated)")
+    p_comp.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_comp.add_argument("--date-range", default="30d", help="Date range (default: 30d)")
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
@@ -2847,41 +2860,41 @@ Examples:
     # ── market-entry (composite: full analysis) ──
     p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
-    p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
+    p_me.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
     p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
-    p_ca.add_argument("--category", help="Category path")
+    p_ca.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
     p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
-    p_pa.add_argument("--category", help="Category path")
+    p_pa.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
     p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
-    p_dr.add_argument("--category", help="Category path")
+    p_dr.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
     p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
-    p_la.add_argument("--category", help="Category path")
+    p_la.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
     p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
-    p_os.add_argument("--category", help="Category path")
+    p_os.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. emerging,underserved,high-demand-low-barrier). Omit to use custom filters only.")
     p_os.add_argument("--sales-min", type=int, help="Min monthly sales (e.g. 300)")
     p_os.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2897,7 +2910,7 @@ Examples:
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
-    p_rd.add_argument("--category", help="Category path")
+    p_rd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
@@ -2936,7 +2949,7 @@ Examples:
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
-    p_analyze.add_argument("--category", help="Category path")
+    p_analyze.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_analyze.add_argument("--label-type", help="Filter dimensions (comma-separated)")
     p_analyze.add_argument("--period", help="Time period: 1m, 3m, 6m, 1y, 2y", default="6m")
     p_analyze.set_defaults(func=cmd_analyze)
@@ -2944,7 +2957,7 @@ Examples:
     # ── price-band-overview ──
     p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
-    p_pbo.add_argument("--category", help="Category path")
+    p_pbo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbo.add_argument("--page-size", type=int, default=20)
     p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
@@ -2952,7 +2965,7 @@ Examples:
     # ── price-band-detail ──
     p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
-    p_pbd.add_argument("--category", help="Category path")
+    p_pbd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbd.add_argument("--page-size", type=int, default=20)
     p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
@@ -2960,7 +2973,7 @@ Examples:
     # ── brand-overview ──
     p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
-    p_bo.add_argument("--category", help="Category path")
+    p_bo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bo.add_argument("--page-size", type=int, default=20)
     p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
@@ -2968,7 +2981,7 @@ Examples:
     # ── brand-detail ──
     p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
-    p_bd.add_argument("--category", help="Category path")
+    p_bd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bd.add_argument("--page-size", type=int, default=20)
     p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)

--- a/amazon-keyword-traffic-analysis/README.md
+++ b/amazon-keyword-traffic-analysis/README.md
@@ -27,7 +27,7 @@ Four workflows for search-demand and keyword-traffic questions that product/cate
 
 ## Data Source & Boundaries
 
-All keyword signals come from the **Amazon Brand Analytics (ABA)** backend — the same search-demand data Amazon shows brand owners, not scraped estimates.
+All keyword signals are sourced from the **Amazon Brand Analytics (ABA)** backend — the search-demand data Amazon shows brand owners. Coverage is limited to keywords that appear in ABA; missing data means outside ABA coverage, not low demand.
 
 Keyword value boundary: ZooData keyword endpoints provide estimated search, exposure, visibility, and rank signals. They do not prove final keyword value or conversion quality for a specific ASIN by themselves. When the current evidence set is ZooData plus Amazon Brand Analytics market-wide signals only, traffic-related conclusions should be treated as directional. Recommended data provision: in Brand View, sort descending by Search Funnel - Impressions → Brand Count, then provide a screenshot or download the CSV for model analysis. If seller-side ABA-SQP data is included, use impressions, clicks, cart adds, purchases, click share, purchase share, and conversion rate as first-party conversion evidence.
 

--- a/amazon-keyword-traffic-analysis/README.md
+++ b/amazon-keyword-traffic-analysis/README.md
@@ -1,17 +1,37 @@
 # Amazon Keyword Intelligence — ZooData Agent Skill
 
-> Four keyword workflows built on ZooData's eight keyword endpoints.
+> Backed by Amazon Brand Analytics (ABA) data: expand seed terms into ready-to-test ad keyword tiers, judge whether a keyword deserves budget, reverse-lookup any ASIN's traffic terms, and explain rank anomalies.
 
 ## What This Skill Does
 
-This skill is for search-demand and keyword-traffic work that product/category skills do not cover well.
+Four workflows for search-demand and keyword-traffic questions that product/category skills don't cover:
 
-It supports four common scenarios:
+1. **Keyword expansion** — seed term → candidate ad keywords, pre-sorted into `Priority test` / `Selective test` / `Observe only` / `Exclude` tiers
+2. **Single keyword analysis** — a directional bid-worthiness verdict across demand, competition, ad density, and SERP structure
+3. **Reverse ASIN lookup** — which keywords drive a (competitor) ASIN's visibility, prioritized by traffic share
+4. **Keyword traffic diagnosis** — watch an ASIN under a keyword and explain rank/exposure anomalies with likely causes
 
-1. **Keyword expansion** — start from a seed term and find candidate ad keywords
-2. **Single keyword analysis** — directionally judge whether one keyword is worth testing
-3. **Reverse ASIN keyword analysis** — inspect which keywords are driving an ASIN's visibility
-4. **Keyword traffic diagnosis** — watch an ASIN on a keyword and explain anomalies
+## Example Prompts
+
+- "Expand keyword ideas from `wireless earbuds` and do a coarse filter"
+- "Is `yoga mat` worth targeting as an ad keyword?"
+- "Reverse ASIN lookup for `B0XXXXXXX` — which keywords are driving its traffic?"
+- "Monitor ASIN `B0XXXXXXX` under `collagen peptides` and explain any anomalies"
+
+## What You Get
+
+- Candidate keyword tiers: `Priority test` / `Selective test` / `Observe only` / `Exclude`
+- Single-keyword directional viability assessment across demand, competition, ad density, and SERP structure
+- Reverse ASIN keyword source view with traffic-share-based prioritization
+- Keyword anomaly diagnosis with likely cause analysis
+
+## Data Source & Boundaries
+
+All keyword signals come from the **Amazon Brand Analytics (ABA)** backend — the same search-demand data Amazon shows brand owners, not scraped estimates.
+
+Keyword value boundary: ZooData keyword endpoints provide estimated search, exposure, visibility, and rank signals. They do not prove final keyword value or conversion quality for a specific ASIN by themselves. When the current evidence set is ZooData plus Amazon Brand Analytics market-wide signals only, traffic-related conclusions should be treated as directional. Recommended data provision: in Brand View, sort descending by Search Funnel - Impressions → Brand Count, then provide a screenshot or download the CSV for model analysis. If seller-side ABA-SQP data is included, use impressions, clicks, cart adds, purchases, click share, purchase share, and conversion rate as first-party conversion evidence.
+
+Keyword date rule: keyword workflows are keyword-query lookups. When a keyword endpoint requires `date` or `dateTo`, prefer T-1 or earlier and avoid current-date lookup unless the user explicitly asks for today's data. Keep the rationale internal unless the user asks why.
 
 ## Endpoints Used
 
@@ -26,7 +46,9 @@ The skill is designed around these eight ZooData endpoints:
 - `/openapi/v2/keywords/product-traffic-terms-overview`
 - `/openapi/v2/keywords/product-traffic-terms-timeline`
 
-## Draft Tool Names
+## Agent Implementation Notes
+
+### Draft Tool Names
 
 To reduce agent guessing, read the relevant tool docs/help/schema before selecting a tool, then document and prefer full callable tool names.
 These are draft names inferred from other ZooData tool naming patterns and
@@ -41,25 +63,7 @@ should be manually confirmed against the active session:
 - `mcp__zoodata__openapi_v2_product_traffic_terms_overview`
 - `mcp__zoodata__openapi_v2_product_traffic_terms_timeline`
 
-## What You Get
-
-- Candidate keyword tiers: `Priority test` / `Selective test` / `Observe only` / `Exclude`
-- Single-keyword directional viability assessment across demand, competition, ad density, and SERP structure
-- Reverse ASIN keyword source view with traffic-share-based prioritization
-- Keyword anomaly diagnosis with likely cause analysis
-
-Keyword value boundary: ZooData keyword endpoints provide estimated search, exposure, visibility, and rank signals. They do not prove final keyword value or conversion quality for a specific ASIN by themselves. When the current evidence set is ZooData plus Amazon Brand Analytics market-wide signals only, traffic-related conclusions should be treated as directional. Recommended data provision: in Brand View, sort descending by Search Funnel - Impressions → Brand Count, then provide a screenshot or download the CSV for model analysis. If seller-side ABA-SQP data is included, use impressions, clicks, cart adds, purchases, click share, purchase share, and conversion rate as first-party conversion evidence.
-
-Keyword date rule: keyword workflows are keyword-query lookups. When a keyword endpoint requires `date` or `dateTo`, prefer T-1 or earlier and avoid current-date lookup unless the user explicitly asks for today's data. Keep the rationale internal unless the user asks why.
-
-## Example Prompts
-
-- "Expand keyword ideas from `wireless earbuds` and do a coarse filter"
-- "Is `yoga mat` worth targeting as an ad keyword?"
-- "Reverse ASIN lookup for `B0XXXXXXX` — which keywords are driving its traffic?"
-- "Monitor ASIN `B0XXXXXXX` under `collagen peptides` and explain any anomalies"
-
-## Notes
+### Notes
 
 - This skill currently focuses on workflow design and endpoint orchestration.
 - Before choosing or rejecting a tool, read the relevant tool documentation: CLI help/reference docs for `zoodata.py`, or live schema / field descriptions for MCP/session tools.

--- a/amazon-keyword-traffic-analysis/SKILL.md
+++ b/amazon-keyword-traffic-analysis/SKILL.md
@@ -5,7 +5,7 @@ description: >
   keyword deep dive; whether a keyword is worth bidding on; which keywords drive traffic to an ASIN;
   or why an ASIN changed under a keyword. Requires ZOODATA_API_KEY.
 metadata:
-  version: "0.1.1"
+  version: "0.1.2"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-keyword-traffic-analysis/SKILL.md
+++ b/amazon-keyword-traffic-analysis/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: amazon-keyword-traffic-analysis
 description: >
-  Use when user asks for keyword expansion or ad keyword filtering; single keyword analysis or
-  keyword deep dive; whether a keyword is worth bidding on; which keywords drive traffic to an ASIN;
-  or why an ASIN changed under a keyword. Requires ZOODATA_API_KEY.
+  Amazon keyword intelligence backed by Brand Analytics (ABA) data — keyword expansion sorted into
+  Priority/Selective/Observe/Exclude test tiers, bid-worthiness verdicts for single keywords,
+  reverse-ASIN traffic terms, and keyword rank anomaly diagnosis. Use when user asks for keyword
+  expansion or ad keyword filtering; single keyword analysis or keyword deep dive; whether a keyword
+  is worth bidding on; which keywords drive traffic to an ASIN; or why an ASIN changed under a
+  keyword. Requires ZOODATA_API_KEY.
 metadata:
   version: "0.1.2"
   author: SerendipityOneInc

--- a/amazon-keyword-traffic-analysis/scripts/zoodata.py
+++ b/amazon-keyword-traffic-analysis/scripts/zoodata.py
@@ -2776,7 +2776,7 @@ Examples:
 
     # Common args
     parser.add_argument("--format", choices=["json", "compact"], default="json",
-                        help="Output format (default: json)")
+                        help="Output format (default: json). Global flag — must come BEFORE the subcommand")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -2795,7 +2795,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field")
+    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2820,7 +2820,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
+    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2834,7 +2834,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor)")
+    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-keyword-traffic-analysis/scripts/zoodata.py
+++ b/amazon-keyword-traffic-analysis/scripts/zoodata.py
@@ -78,17 +78,17 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Each maps to a set of products/search filter parameters
 PRODUCT_MODES = {
     "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
-    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
-    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
-    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180"},
+    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180d"},
+    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180d"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180d"},
     "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
-    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
-    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillments": ["FBA", "FBM"]},
-    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180"},
+    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180d"},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["newRelease"], "fulfillments": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180d"},
     "low-price":                {"priceMax": 10},
-    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90"},
-    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
-    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90d"},
+    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90d"},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180d"},
     # "beginner" mode disabled — excludeKeywords filter not working
     "top-bsr":                  {"subBsrMax": 1000},
 }
@@ -2800,8 +2800,8 @@ Examples:
     p_prod.add_argument("--rating-min", type=float, help="Min rating")
     p_prod.add_argument("--rating-max", type=float, help="Max rating")
     p_prod.add_argument("--growth-min", type=float, help="Min sales growth rate")
-    p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
-    p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
+    p_prod.add_argument("--listing-age", help="Max listing age: 30d, 90d, 180d, 1y, or 2y")
+    p_prod.add_argument("--badges", nargs="+", help="Badge filters: bestSeller, amazonChoice, newRelease, aPlus, video")
     p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")

--- a/amazon-keyword-traffic-analysis/scripts/zoodata.py
+++ b/amazon-keyword-traffic-analysis/scripts/zoodata.py
@@ -421,15 +421,28 @@ def output(data, fmt="json"):
 
 def parse_category(cat_str: str) -> list:
     """Parse category path string into a list.
-    
+
     Supported formats:
-      - 'Pet Supplies,Dogs,Toys'           (comma-separated)
-      - 'Pet Supplies > Dogs > Toys'       (spaced arrow)
+      - '["Pet Supplies", "Dogs"]'         (JSON array — unambiguous, safest)
+      - 'Pet Supplies > Dogs > Toys'       (spaced arrow — recommended)
       - 'Pet Supplies>Dogs>Toys'           (bare arrow, no spaces)
+      - 'Pet Supplies,Dogs,Toys'           (comma-separated — AVOID for names
+        that contain commas, e.g. "Headphones, Earbuds & Accessories";
+        use '>' or JSON array for those)
     """
     if not cat_str:
         return []
-    # Support comma, ' > ' (spaced), and '>' (bare) separators
+    # JSON array input — exact segments, no separator ambiguity
+    stripped = cat_str.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if str(c).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON — fall through to separator parsing
+    # Arrow separators take priority: category names never contain '>',
+    # but they DO contain commas (e.g. "Headphones, Earbuds & Accessories")
     if " > " in cat_str:
         return [c.strip() for c in cat_str.split(" > ")]
     if ">" in cat_str:
@@ -2770,14 +2783,14 @@ Examples:
     # ── categories ──
     p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
-    p_cat.add_argument("--category", help="Exact category path (comma-separated)")
+    p_cat.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
     p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
-    p_mkt.add_argument("--category", help="Category path (comma-separated)")
+    p_mkt.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
@@ -2789,7 +2802,7 @@ Examples:
     # ── products ──
     p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
-    p_prod.add_argument("--category", help="Category path (comma-separated)")
+    p_prod.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
     p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
     p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2816,7 +2829,7 @@ Examples:
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
-    p_comp.add_argument("--category", help="Category path (comma-separated)")
+    p_comp.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_comp.add_argument("--date-range", default="30d", help="Date range (default: 30d)")
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
@@ -2847,41 +2860,41 @@ Examples:
     # ── market-entry (composite: full analysis) ──
     p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
-    p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
+    p_me.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
     p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
-    p_ca.add_argument("--category", help="Category path")
+    p_ca.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
     p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
-    p_pa.add_argument("--category", help="Category path")
+    p_pa.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
     p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
-    p_dr.add_argument("--category", help="Category path")
+    p_dr.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
     p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
-    p_la.add_argument("--category", help="Category path")
+    p_la.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
     p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
-    p_os.add_argument("--category", help="Category path")
+    p_os.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. emerging,underserved,high-demand-low-barrier). Omit to use custom filters only.")
     p_os.add_argument("--sales-min", type=int, help="Min monthly sales (e.g. 300)")
     p_os.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2897,7 +2910,7 @@ Examples:
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
-    p_rd.add_argument("--category", help="Category path")
+    p_rd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
@@ -2936,7 +2949,7 @@ Examples:
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
-    p_analyze.add_argument("--category", help="Category path")
+    p_analyze.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_analyze.add_argument("--label-type", help="Filter dimensions (comma-separated)")
     p_analyze.add_argument("--period", help="Time period: 1m, 3m, 6m, 1y, 2y", default="6m")
     p_analyze.set_defaults(func=cmd_analyze)
@@ -2944,7 +2957,7 @@ Examples:
     # ── price-band-overview ──
     p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
-    p_pbo.add_argument("--category", help="Category path")
+    p_pbo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbo.add_argument("--page-size", type=int, default=20)
     p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
@@ -2952,7 +2965,7 @@ Examples:
     # ── price-band-detail ──
     p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
-    p_pbd.add_argument("--category", help="Category path")
+    p_pbd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbd.add_argument("--page-size", type=int, default=20)
     p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
@@ -2960,7 +2973,7 @@ Examples:
     # ── brand-overview ──
     p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
-    p_bo.add_argument("--category", help="Category path")
+    p_bo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bo.add_argument("--page-size", type=int, default=20)
     p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
@@ -2968,7 +2981,7 @@ Examples:
     # ── brand-detail ──
     p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
-    p_bd.add_argument("--category", help="Category path")
+    p_bd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bd.add_argument("--page-size", type=int, default=20)
     p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -12,7 +12,7 @@ description: >
   A+ content, listing health check, listing comparison.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.3"
+  version: "1.0.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-listing-audit-pro/references/reference.md
+++ b/amazon-listing-audit-pro/references/reference.md
@@ -76,7 +76,7 @@ All endpoints return: `{success, data, error, meta}` with `meta.creditsRemaining
 ## 3. products/search — Shared Product Object
 
 **Key Request Params:**
-- `keyword`, `categoryPath`, `mode` (14 presets), `keywordMatchType`
+- `keyword`, `categoryPath`, `keywordMatchType` (`mode` is a CLI-only preset — `zoodata.py` expands it into the filter pairs below client-side; it is NOT an API field and returns 422 if sent raw)
 - Filter pairs: `monthlySalesMin/Max`, `priceMin/Max`, `ratingMin/Max`, etc.
 - `pageSize` (max 20), `page`, `sortBy`, `sortOrder`
 - `includeBrands`, `excludeBrands`

--- a/amazon-listing-audit-pro/scripts/zoodata.py
+++ b/amazon-listing-audit-pro/scripts/zoodata.py
@@ -2776,7 +2776,7 @@ Examples:
 
     # Common args
     parser.add_argument("--format", choices=["json", "compact"], default="json",
-                        help="Output format (default: json)")
+                        help="Output format (default: json). Global flag — must come BEFORE the subcommand")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -2795,7 +2795,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field")
+    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2820,7 +2820,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
+    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2834,7 +2834,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor)")
+    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-listing-audit-pro/scripts/zoodata.py
+++ b/amazon-listing-audit-pro/scripts/zoodata.py
@@ -78,17 +78,17 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Each maps to a set of products/search filter parameters
 PRODUCT_MODES = {
     "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
-    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
-    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
-    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180"},
+    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180d"},
+    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180d"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180d"},
     "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
-    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
-    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillments": ["FBA", "FBM"]},
-    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180"},
+    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180d"},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["newRelease"], "fulfillments": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180d"},
     "low-price":                {"priceMax": 10},
-    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90"},
-    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
-    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90d"},
+    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90d"},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180d"},
     # "beginner" mode disabled — excludeKeywords filter not working
     "top-bsr":                  {"subBsrMax": 1000},
 }
@@ -2800,8 +2800,8 @@ Examples:
     p_prod.add_argument("--rating-min", type=float, help="Min rating")
     p_prod.add_argument("--rating-max", type=float, help="Max rating")
     p_prod.add_argument("--growth-min", type=float, help="Min sales growth rate")
-    p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
-    p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
+    p_prod.add_argument("--listing-age", help="Max listing age: 30d, 90d, 180d, 1y, or 2y")
+    p_prod.add_argument("--badges", nargs="+", help="Badge filters: bestSeller, amazonChoice, newRelease, aPlus, video")
     p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")

--- a/amazon-listing-audit-pro/scripts/zoodata.py
+++ b/amazon-listing-audit-pro/scripts/zoodata.py
@@ -421,15 +421,28 @@ def output(data, fmt="json"):
 
 def parse_category(cat_str: str) -> list:
     """Parse category path string into a list.
-    
+
     Supported formats:
-      - 'Pet Supplies,Dogs,Toys'           (comma-separated)
-      - 'Pet Supplies > Dogs > Toys'       (spaced arrow)
+      - '["Pet Supplies", "Dogs"]'         (JSON array — unambiguous, safest)
+      - 'Pet Supplies > Dogs > Toys'       (spaced arrow — recommended)
       - 'Pet Supplies>Dogs>Toys'           (bare arrow, no spaces)
+      - 'Pet Supplies,Dogs,Toys'           (comma-separated — AVOID for names
+        that contain commas, e.g. "Headphones, Earbuds & Accessories";
+        use '>' or JSON array for those)
     """
     if not cat_str:
         return []
-    # Support comma, ' > ' (spaced), and '>' (bare) separators
+    # JSON array input — exact segments, no separator ambiguity
+    stripped = cat_str.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if str(c).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON — fall through to separator parsing
+    # Arrow separators take priority: category names never contain '>',
+    # but they DO contain commas (e.g. "Headphones, Earbuds & Accessories")
     if " > " in cat_str:
         return [c.strip() for c in cat_str.split(" > ")]
     if ">" in cat_str:
@@ -2770,14 +2783,14 @@ Examples:
     # ── categories ──
     p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
-    p_cat.add_argument("--category", help="Exact category path (comma-separated)")
+    p_cat.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
     p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
-    p_mkt.add_argument("--category", help="Category path (comma-separated)")
+    p_mkt.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
@@ -2789,7 +2802,7 @@ Examples:
     # ── products ──
     p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
-    p_prod.add_argument("--category", help="Category path (comma-separated)")
+    p_prod.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
     p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
     p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2816,7 +2829,7 @@ Examples:
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
-    p_comp.add_argument("--category", help="Category path (comma-separated)")
+    p_comp.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_comp.add_argument("--date-range", default="30d", help="Date range (default: 30d)")
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
@@ -2847,41 +2860,41 @@ Examples:
     # ── market-entry (composite: full analysis) ──
     p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
-    p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
+    p_me.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
     p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
-    p_ca.add_argument("--category", help="Category path")
+    p_ca.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
     p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
-    p_pa.add_argument("--category", help="Category path")
+    p_pa.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
     p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
-    p_dr.add_argument("--category", help="Category path")
+    p_dr.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
     p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
-    p_la.add_argument("--category", help="Category path")
+    p_la.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
     p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
-    p_os.add_argument("--category", help="Category path")
+    p_os.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. emerging,underserved,high-demand-low-barrier). Omit to use custom filters only.")
     p_os.add_argument("--sales-min", type=int, help="Min monthly sales (e.g. 300)")
     p_os.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2897,7 +2910,7 @@ Examples:
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
-    p_rd.add_argument("--category", help="Category path")
+    p_rd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
@@ -2936,7 +2949,7 @@ Examples:
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
-    p_analyze.add_argument("--category", help="Category path")
+    p_analyze.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_analyze.add_argument("--label-type", help="Filter dimensions (comma-separated)")
     p_analyze.add_argument("--period", help="Time period: 1m, 3m, 6m, 1y, 2y", default="6m")
     p_analyze.set_defaults(func=cmd_analyze)
@@ -2944,7 +2957,7 @@ Examples:
     # ── price-band-overview ──
     p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
-    p_pbo.add_argument("--category", help="Category path")
+    p_pbo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbo.add_argument("--page-size", type=int, default=20)
     p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
@@ -2952,7 +2965,7 @@ Examples:
     # ── price-band-detail ──
     p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
-    p_pbd.add_argument("--category", help="Category path")
+    p_pbd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbd.add_argument("--page-size", type=int, default=20)
     p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
@@ -2960,7 +2973,7 @@ Examples:
     # ── brand-overview ──
     p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
-    p_bo.add_argument("--category", help="Category path")
+    p_bo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bo.add_argument("--page-size", type=int, default=20)
     p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
@@ -2968,7 +2981,7 @@ Examples:
     # ── brand-detail ──
     p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
-    p_bd.add_argument("--category", help="Category path")
+    p_bd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bd.add_argument("--page-size", type=int, default=20)
     p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -8,6 +8,9 @@ description: >
   Use when user asks about: market entry, can I sell, should I enter, market viability,
   is this niche worth it, category analysis, market opportunity, market assessment,
   niche evaluation, product category research.
+  Pick this to EVALUATE a specific niche/category the user already named (one GO/CAUTION/AVOID
+  verdict). To discover what to sell with no target in mind, use amazon-opportunity-discoverer;
+  to track how categories shift over time, use amazon-market-trend-scanner.
   Requires ZOODATA_API_KEY.
 metadata:
   version: "1.0.4"

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -10,7 +10,7 @@ description: >
   niche evaluation, product category research.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.3"
+  version: "1.0.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-market-entry-analyzer/references/reference.md
+++ b/amazon-market-entry-analyzer/references/reference.md
@@ -76,7 +76,7 @@ All endpoints return: `{success, data, error, meta}` with `meta.creditsRemaining
 ## 3. products/search — Shared Product Object
 
 **Key Request Params:**
-- `keyword`, `categoryPath`, `mode` (14 presets), `keywordMatchType`
+- `keyword`, `categoryPath`, `keywordMatchType` (`mode` is a CLI-only preset — `zoodata.py` expands it into the filter pairs below client-side; it is NOT an API field and returns 422 if sent raw)
 - Filter pairs: `monthlySalesMin/Max`, `priceMin/Max`, `ratingMin/Max`, etc.
 - `pageSize` (max 20), `page`, `sortBy`, `sortOrder`
 - `includeBrands`, `excludeBrands`

--- a/amazon-market-entry-analyzer/scripts/zoodata.py
+++ b/amazon-market-entry-analyzer/scripts/zoodata.py
@@ -2776,7 +2776,7 @@ Examples:
 
     # Common args
     parser.add_argument("--format", choices=["json", "compact"], default="json",
-                        help="Output format (default: json)")
+                        help="Output format (default: json). Global flag — must come BEFORE the subcommand")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -2795,7 +2795,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field")
+    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2820,7 +2820,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
+    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2834,7 +2834,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor)")
+    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-market-entry-analyzer/scripts/zoodata.py
+++ b/amazon-market-entry-analyzer/scripts/zoodata.py
@@ -78,17 +78,17 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Each maps to a set of products/search filter parameters
 PRODUCT_MODES = {
     "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
-    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
-    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
-    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180"},
+    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180d"},
+    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180d"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180d"},
     "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
-    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
-    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillments": ["FBA", "FBM"]},
-    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180"},
+    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180d"},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["newRelease"], "fulfillments": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180d"},
     "low-price":                {"priceMax": 10},
-    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90"},
-    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
-    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90d"},
+    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90d"},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180d"},
     # "beginner" mode disabled — excludeKeywords filter not working
     "top-bsr":                  {"subBsrMax": 1000},
 }
@@ -2800,8 +2800,8 @@ Examples:
     p_prod.add_argument("--rating-min", type=float, help="Min rating")
     p_prod.add_argument("--rating-max", type=float, help="Max rating")
     p_prod.add_argument("--growth-min", type=float, help="Min sales growth rate")
-    p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
-    p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
+    p_prod.add_argument("--listing-age", help="Max listing age: 30d, 90d, 180d, 1y, or 2y")
+    p_prod.add_argument("--badges", nargs="+", help="Badge filters: bestSeller, amazonChoice, newRelease, aPlus, video")
     p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")

--- a/amazon-market-entry-analyzer/scripts/zoodata.py
+++ b/amazon-market-entry-analyzer/scripts/zoodata.py
@@ -421,15 +421,28 @@ def output(data, fmt="json"):
 
 def parse_category(cat_str: str) -> list:
     """Parse category path string into a list.
-    
+
     Supported formats:
-      - 'Pet Supplies,Dogs,Toys'           (comma-separated)
-      - 'Pet Supplies > Dogs > Toys'       (spaced arrow)
+      - '["Pet Supplies", "Dogs"]'         (JSON array — unambiguous, safest)
+      - 'Pet Supplies > Dogs > Toys'       (spaced arrow — recommended)
       - 'Pet Supplies>Dogs>Toys'           (bare arrow, no spaces)
+      - 'Pet Supplies,Dogs,Toys'           (comma-separated — AVOID for names
+        that contain commas, e.g. "Headphones, Earbuds & Accessories";
+        use '>' or JSON array for those)
     """
     if not cat_str:
         return []
-    # Support comma, ' > ' (spaced), and '>' (bare) separators
+    # JSON array input — exact segments, no separator ambiguity
+    stripped = cat_str.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if str(c).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON — fall through to separator parsing
+    # Arrow separators take priority: category names never contain '>',
+    # but they DO contain commas (e.g. "Headphones, Earbuds & Accessories")
     if " > " in cat_str:
         return [c.strip() for c in cat_str.split(" > ")]
     if ">" in cat_str:
@@ -2770,14 +2783,14 @@ Examples:
     # ── categories ──
     p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
-    p_cat.add_argument("--category", help="Exact category path (comma-separated)")
+    p_cat.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
     p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
-    p_mkt.add_argument("--category", help="Category path (comma-separated)")
+    p_mkt.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
@@ -2789,7 +2802,7 @@ Examples:
     # ── products ──
     p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
-    p_prod.add_argument("--category", help="Category path (comma-separated)")
+    p_prod.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
     p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
     p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2816,7 +2829,7 @@ Examples:
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
-    p_comp.add_argument("--category", help="Category path (comma-separated)")
+    p_comp.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_comp.add_argument("--date-range", default="30d", help="Date range (default: 30d)")
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
@@ -2847,41 +2860,41 @@ Examples:
     # ── market-entry (composite: full analysis) ──
     p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
-    p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
+    p_me.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
     p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
-    p_ca.add_argument("--category", help="Category path")
+    p_ca.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
     p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
-    p_pa.add_argument("--category", help="Category path")
+    p_pa.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
     p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
-    p_dr.add_argument("--category", help="Category path")
+    p_dr.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
     p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
-    p_la.add_argument("--category", help="Category path")
+    p_la.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
     p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
-    p_os.add_argument("--category", help="Category path")
+    p_os.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. emerging,underserved,high-demand-low-barrier). Omit to use custom filters only.")
     p_os.add_argument("--sales-min", type=int, help="Min monthly sales (e.g. 300)")
     p_os.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2897,7 +2910,7 @@ Examples:
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
-    p_rd.add_argument("--category", help="Category path")
+    p_rd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
@@ -2936,7 +2949,7 @@ Examples:
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
-    p_analyze.add_argument("--category", help="Category path")
+    p_analyze.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_analyze.add_argument("--label-type", help="Filter dimensions (comma-separated)")
     p_analyze.add_argument("--period", help="Time period: 1m, 3m, 6m, 1y, 2y", default="6m")
     p_analyze.set_defaults(func=cmd_analyze)
@@ -2944,7 +2957,7 @@ Examples:
     # ── price-band-overview ──
     p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
-    p_pbo.add_argument("--category", help="Category path")
+    p_pbo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbo.add_argument("--page-size", type=int, default=20)
     p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
@@ -2952,7 +2965,7 @@ Examples:
     # ── price-band-detail ──
     p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
-    p_pbd.add_argument("--category", help="Category path")
+    p_pbd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbd.add_argument("--page-size", type=int, default=20)
     p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
@@ -2960,7 +2973,7 @@ Examples:
     # ── brand-overview ──
     p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
-    p_bo.add_argument("--category", help="Category path")
+    p_bo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bo.add_argument("--page-size", type=int, default=20)
     p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
@@ -2968,7 +2981,7 @@ Examples:
     # ── brand-detail ──
     p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
-    p_bd.add_argument("--category", help="Category path")
+    p_bd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bd.add_argument("--page-size", type=int, default=20)
     p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -8,6 +8,9 @@ description: >
   Use when user asks about: market trends, category trends, trending
   categories, what's hot, emerging categories, trend scanner,
   which categories are growing, where the market is heading.
+  Pick this to track how categories shift OVER TIME (trends, momentum, emerging niches). To
+  evaluate one specific niche right now, use amazon-market-entry-analyzer; to discover products
+  to sell, use amazon-opportunity-discoverer.
   Requires ZOODATA_API_KEY.
 metadata:
   version: "1.0.3"

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -10,7 +10,7 @@ description: >
   which categories are growing, where the market is heading.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.2"
+  version: "1.0.3"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -44,6 +44,7 @@ Required: 1+ category paths or keywords. Optional: scan depth, metric preference
 2. **All keyword endpoints MUST include `--category`**; omitting it distorts aggregation
 3. **Use API fields directly**: revenue=`sampleAvgMonthlyRevenue`, sales=`monthlySalesFloor`
 4. **Key metrics per subcategory**: sampleAvgMonthlySales, sampleNewSkuRate, topBrandSalesRate, sampleAvgPrice, sampleAPlusRate, totalSkuCount, sampleFbaRate
+5. **`--mode` presets are CLI-local, NOT API params** — `zoodata.py` expands them via `PRODUCT_MODES` before the call; a raw `products/search` request must send the expanded filter fields (`mode` raw → 422). Follow the **`mode`/CLI-flags** pitfall (#9) in `zoodata/SKILL.md`
 
 ## On Missing Key
 
@@ -66,8 +67,6 @@ When `zoodata.py` returns code 402: follow the **"On 402 Credit Exhausted"** pro
 6. Save baseline → `{skill_base_dir}/scan-data/baseline.json`, config → `{skill_base_dir}/scan-data/watchlist.json`
 7. Output full trend report (see Output Spec)
 8. Offer Auto-Monitor setup
-
-> `--mode emerging` / `--mode new-release` are CLI-local presets — `zoodata.py` expands them into real filter fields (see `PRODUCT_MODES` in `scripts/zoodata.py`) before calling the API. `mode` is NOT an API parameter; a raw HTTP request to `products/search` must send the expanded filter fields instead (unknown fields → 422).
 
 ## Mode 2: Quick Check (scheduled)
 

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -67,6 +67,8 @@ When `zoodata.py` returns code 402: follow the **"On 402 Credit Exhausted"** pro
 7. Output full trend report (see Output Spec)
 8. Offer Auto-Monitor setup
 
+> `--mode emerging` / `--mode new-release` are CLI-local presets — `zoodata.py` expands them into real filter fields (see `PRODUCT_MODES` in `scripts/zoodata.py`) before calling the API. `mode` is NOT an API parameter; a raw HTTP request to `products/search` must send the expanded filter fields instead (unknown fields → 422).
+
 ## Mode 2: Quick Check (scheduled)
 
 1. Read `{skill_base_dir}/scan-data/watchlist.json` + `{skill_base_dir}/scan-data/baseline.json`

--- a/amazon-market-trend-scanner/references/reference.md
+++ b/amazon-market-trend-scanner/references/reference.md
@@ -76,7 +76,7 @@ All endpoints return: `{success, data, error, meta}` with `meta.creditsRemaining
 ## 3. products/search — Shared Product Object
 
 **Key Request Params:**
-- `keyword`, `categoryPath`, `mode` (14 presets), `keywordMatchType`
+- `keyword`, `categoryPath`, `keywordMatchType` (`mode` is a CLI-only preset — `zoodata.py` expands it into the filter pairs below client-side; it is NOT an API field and returns 422 if sent raw)
 - Filter pairs: `monthlySalesMin/Max`, `priceMin/Max`, `ratingMin/Max`, etc.
 - `pageSize` (max 20), `page`, `sortBy`, `sortOrder`
 - `includeBrands`, `excludeBrands`

--- a/amazon-market-trend-scanner/scripts/zoodata.py
+++ b/amazon-market-trend-scanner/scripts/zoodata.py
@@ -2776,7 +2776,7 @@ Examples:
 
     # Common args
     parser.add_argument("--format", choices=["json", "compact"], default="json",
-                        help="Output format (default: json)")
+                        help="Output format (default: json). Global flag — must come BEFORE the subcommand")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -2795,7 +2795,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field")
+    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2820,7 +2820,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
+    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2834,7 +2834,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor)")
+    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-market-trend-scanner/scripts/zoodata.py
+++ b/amazon-market-trend-scanner/scripts/zoodata.py
@@ -78,17 +78,17 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Each maps to a set of products/search filter parameters
 PRODUCT_MODES = {
     "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
-    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
-    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
-    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180"},
+    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180d"},
+    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180d"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180d"},
     "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
-    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
-    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillments": ["FBA", "FBM"]},
-    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180"},
+    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180d"},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["newRelease"], "fulfillments": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180d"},
     "low-price":                {"priceMax": 10},
-    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90"},
-    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
-    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90d"},
+    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90d"},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180d"},
     # "beginner" mode disabled — excludeKeywords filter not working
     "top-bsr":                  {"subBsrMax": 1000},
 }
@@ -2800,8 +2800,8 @@ Examples:
     p_prod.add_argument("--rating-min", type=float, help="Min rating")
     p_prod.add_argument("--rating-max", type=float, help="Max rating")
     p_prod.add_argument("--growth-min", type=float, help="Min sales growth rate")
-    p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
-    p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
+    p_prod.add_argument("--listing-age", help="Max listing age: 30d, 90d, 180d, 1y, or 2y")
+    p_prod.add_argument("--badges", nargs="+", help="Badge filters: bestSeller, amazonChoice, newRelease, aPlus, video")
     p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")

--- a/amazon-market-trend-scanner/scripts/zoodata.py
+++ b/amazon-market-trend-scanner/scripts/zoodata.py
@@ -421,15 +421,28 @@ def output(data, fmt="json"):
 
 def parse_category(cat_str: str) -> list:
     """Parse category path string into a list.
-    
+
     Supported formats:
-      - 'Pet Supplies,Dogs,Toys'           (comma-separated)
-      - 'Pet Supplies > Dogs > Toys'       (spaced arrow)
+      - '["Pet Supplies", "Dogs"]'         (JSON array — unambiguous, safest)
+      - 'Pet Supplies > Dogs > Toys'       (spaced arrow — recommended)
       - 'Pet Supplies>Dogs>Toys'           (bare arrow, no spaces)
+      - 'Pet Supplies,Dogs,Toys'           (comma-separated — AVOID for names
+        that contain commas, e.g. "Headphones, Earbuds & Accessories";
+        use '>' or JSON array for those)
     """
     if not cat_str:
         return []
-    # Support comma, ' > ' (spaced), and '>' (bare) separators
+    # JSON array input — exact segments, no separator ambiguity
+    stripped = cat_str.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if str(c).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON — fall through to separator parsing
+    # Arrow separators take priority: category names never contain '>',
+    # but they DO contain commas (e.g. "Headphones, Earbuds & Accessories")
     if " > " in cat_str:
         return [c.strip() for c in cat_str.split(" > ")]
     if ">" in cat_str:
@@ -2770,14 +2783,14 @@ Examples:
     # ── categories ──
     p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
-    p_cat.add_argument("--category", help="Exact category path (comma-separated)")
+    p_cat.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
     p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
-    p_mkt.add_argument("--category", help="Category path (comma-separated)")
+    p_mkt.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
@@ -2789,7 +2802,7 @@ Examples:
     # ── products ──
     p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
-    p_prod.add_argument("--category", help="Category path (comma-separated)")
+    p_prod.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
     p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
     p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2816,7 +2829,7 @@ Examples:
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
-    p_comp.add_argument("--category", help="Category path (comma-separated)")
+    p_comp.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_comp.add_argument("--date-range", default="30d", help="Date range (default: 30d)")
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
@@ -2847,41 +2860,41 @@ Examples:
     # ── market-entry (composite: full analysis) ──
     p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
-    p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
+    p_me.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
     p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
-    p_ca.add_argument("--category", help="Category path")
+    p_ca.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
     p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
-    p_pa.add_argument("--category", help="Category path")
+    p_pa.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
     p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
-    p_dr.add_argument("--category", help="Category path")
+    p_dr.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
     p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
-    p_la.add_argument("--category", help="Category path")
+    p_la.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
     p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
-    p_os.add_argument("--category", help="Category path")
+    p_os.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. emerging,underserved,high-demand-low-barrier). Omit to use custom filters only.")
     p_os.add_argument("--sales-min", type=int, help="Min monthly sales (e.g. 300)")
     p_os.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2897,7 +2910,7 @@ Examples:
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
-    p_rd.add_argument("--category", help="Category path")
+    p_rd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
@@ -2936,7 +2949,7 @@ Examples:
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
-    p_analyze.add_argument("--category", help="Category path")
+    p_analyze.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_analyze.add_argument("--label-type", help="Filter dimensions (comma-separated)")
     p_analyze.add_argument("--period", help="Time period: 1m, 3m, 6m, 1y, 2y", default="6m")
     p_analyze.set_defaults(func=cmd_analyze)
@@ -2944,7 +2957,7 @@ Examples:
     # ── price-band-overview ──
     p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
-    p_pbo.add_argument("--category", help="Category path")
+    p_pbo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbo.add_argument("--page-size", type=int, default=20)
     p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
@@ -2952,7 +2965,7 @@ Examples:
     # ── price-band-detail ──
     p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
-    p_pbd.add_argument("--category", help="Category path")
+    p_pbd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbd.add_argument("--page-size", type=int, default=20)
     p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
@@ -2960,7 +2973,7 @@ Examples:
     # ── brand-overview ──
     p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
-    p_bo.add_argument("--category", help="Category path")
+    p_bo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bo.add_argument("--page-size", type=int, default=20)
     p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
@@ -2968,7 +2981,7 @@ Examples:
     # ── brand-detail ──
     p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
-    p_bd.add_argument("--category", help="Category path")
+    p_bd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bd.add_argument("--page-size", type=int, default=20)
     p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)

--- a/amazon-opportunity-discoverer/README.md
+++ b/amazon-opportunity-discoverer/README.md
@@ -4,7 +4,7 @@
 
 ## What This Skill Does
 
-Automated product opportunity scanner tailored to your seller profile. Tell it your budget, experience level, and risk tolerance — it selects the right strategies from 14 preset modes, scans categories, validates candidates with real-time data, and ranks opportunities by a 7-dimension composite score (1-100). From beginner-friendly picks to advanced aggressive plays.
+Automated product opportunity scanner tailored to your seller profile. Tell it your budget, experience level, and risk tolerance — it selects the right strategies from 13 preset modes, scans categories, validates candidates with real-time data, and ranks opportunities by a 7-dimension composite score (1-100). From beginner-friendly picks to advanced aggressive plays.
 
 ### What Makes This Different
 

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -108,7 +108,7 @@ Scan with `market --keyword "{broad}" --topn 10`, rank subcategories by: newSkuR
 | 40-59 | B | ⚠️ Moderate — needs differentiation |
 | 0-39 | C | ❌ Weak — skip |
 
-**Quick-Scan Mode** (~10 credits): 2 modes × 1 page, skip realtime/trend. Label as "directional only."
+**Quick-Scan Mode** (~10 credits): 2 modes × 1 page, skip realtime/trend. Label as "directional only." **Implementation: run per-mode `products --mode <m> --page-size 20` calls — do NOT use the `opportunity-scan` composite for Quick-Scan** (it always executes the full 6-step pipeline including realtime×10 + trend + reviews, ~25-30 credits, and has no skip flags).
 
 ## Composite Command
 ```bash

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -82,6 +82,8 @@ When `zoodata.py` returns code 402: follow the **"On 402 Credit Exhausted"** pro
 ### User Criteria → Filter Params
 Always translate: "300+ monthly sales" → `--sales-min 300`, "reviews <100" → `--ratings-max 100`, "$15-35" → `--price-min 15 --price-max 35`. If user has specific criteria, use custom filters (Approach B/C), NOT default modes.
 
+> **CLI flags and modes are client-side, NOT API fields.** `zoodata.py` expands them before calling the API: `--sales-min` → `monthlySalesMin`; `--ratings-max` (review count) → `ratingCountMax` — not `ratingMax`, which is a *different valid field* (max star rating) that returns wrong results silently; modes → the filter sets in `PRODUCT_MODES` in `scripts/zoodata.py`. Never send `mode`, `salesMin`, or `ratingsMax` in a raw HTTP request to `/openapi/v2/products/search` — the API rejects unknown fields with 422.
+
 ### Data-Driven Category Selection (no specific category given)
 Scan with `market --keyword "{broad}" --topn 10`, rank subcategories by: newSkuRate>10%, topBrandSalesRate<60%, fbaRate>50%, avgPrice $10-50, avgMonthlySales>200. Pick top 3-5.
 

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -8,6 +8,9 @@ description: >
   Use when user asks about: find products to sell, product opportunity, what should I sell,
   niche discovery, profitable products, selection strategy, product scanner, opportunity scan,
   winning products, untapped niches, product ideas, market gaps.
+  Pick this to DISCOVER what to sell when the user has no specific target yet (ranked candidate
+  list). To evaluate a niche they already named, use amazon-market-entry-analyzer; to track
+  category trends over time, use amazon-market-trend-scanner.
   Requires ZOODATA_API_KEY.
 metadata:
   version: "1.0.4"

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -35,7 +35,7 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
 ## API Pitfalls (see zoodata skill for full list)
 - categoryPath is auto-resolved via `categories`, with fallback to top search result. If `category_source` is `inferred_from_search`, confirm with user — keyword-only queries contaminate results
 - All keyword-based endpoints MUST include `--category` when locked
-- **`mode`/`--sales-min`/`--ratings-max` are CLI-local, expanded client-side** — NOT API fields (raw request → 422; `ratingMax` ≠ `ratingCountMax`). Follow the **`mode`/CLI-flags** pitfall (#9) in `zoodata/SKILL.md`
+- **`mode`/`--sales-min`/`--ratings-max` are CLI-local, expanded client-side** — NOT API fields (raw request → 422; `ratingMax` ≠ `ratingCountMax`). Follow the **`mode`/CLI-flags** pitfalls (#9–#10) in `zoodata/SKILL.md`
 - Revenue = `sampleAvgMonthlyRevenue` directly. Sales = `monthlySalesFloor` (lower bound)
 - `reviews/analysis` needs 50+ reviews. Fallback chain when sample is insufficient:
   1. **Lightweight**: `realtime/product` ratingBreakdown — only star distribution, no themes

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -2,7 +2,7 @@
 name: amazon-opportunity-discoverer
 description: >
   Automated product opportunity scanner for Amazon sellers.
-  Scans categories using 14 preset selection strategies, validates candidates with
+  Scans categories using 13 preset selection strategies, validates candidates with
   real-time data, brand analysis, and price structure, then ranks opportunities
   by composite score (1-100). Uses all 11 ZooData API endpoints.
   Use when user asks about: find products to sell, product opportunity, what should I sell,
@@ -55,7 +55,7 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
      - **Small-sample rule (reviewCount<50)**: demote single-mention items 📊→🔍; NEVER attach table-level or section-header 📊 when any row inside is 🔍; suppress "🔴 Critical" verdicts on count=1
      - **Scope**: fallback replaces ONLY the `/reviews/analysis` aggregation. This skill's primary workflow outputs (opportunity scoring, mode-based selection, ranked candidate list) remain valid — do not re-run them.
 - Deduplicate ASINs across modes — same product appears in multiple scans
-- Each mode has **built-in filters that STACK** with user filters (e.g. beginner: $15-60, sales≥300)
+- Each mode has **built-in filters that STACK** with user filters (e.g. high-demand-low-barrier: sales≥300, reviews≤50)
 
 ## On Missing Key
 
@@ -73,8 +73,8 @@ When `zoodata.py` returns code 402: follow the **"On 402 Credit Exhausted"** pro
 ### Profile → Strategy Mapping
 | Profile | Primary Modes | Price | Max Reviews |
 |---------|--------------|-------|-------------|
-| Beginner + Conservative | beginner, long-tail, fbm-friendly | $15-60 | <50 |
-| Beginner + Moderate | beginner, emerging, low-price | $10-50 | <100 |
+| Beginner + Conservative | high-demand-low-barrier, long-tail, fbm-friendly | $15-60 | <50 |
+| Beginner + Moderate | high-demand-low-barrier, emerging, low-price | $10-50 | <100 |
 | Intermediate + Moderate | fast-movers, underserved, single-variant | $15-80 | <200 |
 | Intermediate + Aggressive | high-demand-low-barrier, speculative | $10-100 | <500 |
 | Advanced + Aggressive | fast-movers, speculative, top-bsr | any | any |
@@ -110,7 +110,7 @@ Scan with `market --keyword "{broad}" --topn 10`, rank subcategories by: newSkuR
 
 ## Composite Command
 ```bash
-python3 {skill_base_dir}/scripts/zoodata.py opportunity-scan --keyword "{kw}" --category "{path}" --modes "beginner,emerging,underserved"
+python3 {skill_base_dir}/scripts/zoodata.py opportunity-scan --keyword "{kw}" --category "{path}" --modes "high-demand-low-barrier,emerging,underserved"
 ```
 Or with custom filters: `--sales-min 300 --ratings-max 100 --price-min 15 --price-max 35`
 

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -10,7 +10,7 @@ description: >
   winning products, untapped niches, product ideas, market gaps.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.3"
+  version: "1.0.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -35,6 +35,7 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
 ## API Pitfalls (see zoodata skill for full list)
 - categoryPath is auto-resolved via `categories`, with fallback to top search result. If `category_source` is `inferred_from_search`, confirm with user — keyword-only queries contaminate results
 - All keyword-based endpoints MUST include `--category` when locked
+- **`mode`/`--sales-min`/`--ratings-max` are CLI-local, expanded client-side** — NOT API fields (raw request → 422; `ratingMax` ≠ `ratingCountMax`). Follow the **`mode`/CLI-flags** pitfall (#9) in `zoodata/SKILL.md`
 - Revenue = `sampleAvgMonthlyRevenue` directly. Sales = `monthlySalesFloor` (lower bound)
 - `reviews/analysis` needs 50+ reviews. Fallback chain when sample is insufficient:
   1. **Lightweight**: `realtime/product` ratingBreakdown — only star distribution, no themes
@@ -80,9 +81,7 @@ When `zoodata.py` returns code 402: follow the **"On 402 Credit Exhausted"** pro
 | Advanced + Aggressive | fast-movers, speculative, top-bsr | any | any |
 
 ### User Criteria → Filter Params
-Always translate: "300+ monthly sales" → `--sales-min 300`, "reviews <100" → `--ratings-max 100`, "$15-35" → `--price-min 15 --price-max 35`. If user has specific criteria, use custom filters (Approach B/C), NOT default modes.
-
-> **CLI flags and modes are client-side, NOT API fields.** `zoodata.py` expands them before calling the API: `--sales-min` → `monthlySalesMin`; `--ratings-max` (review count) → `ratingCountMax` — not `ratingMax`, which is a *different valid field* (max star rating) that returns wrong results silently; modes → the filter sets in `PRODUCT_MODES` in `scripts/zoodata.py`. Never send `mode`, `salesMin`, or `ratingsMax` in a raw HTTP request to `/openapi/v2/products/search` — the API rejects unknown fields with 422.
+Always translate: "300+ monthly sales" → `--sales-min 300`, "reviews <100" → `--ratings-max 100`, "$15-35" → `--price-min 15 --price-max 35`. If user has specific criteria, use custom filters (Approach B/C), NOT default modes. (`--sales-min`/`--ratings-max`/`--modes` are CLI-local — see API Pitfalls before any raw call.)
 
 ### Data-Driven Category Selection (no specific category given)
 Scan with `market --keyword "{broad}" --topn 10`, rank subcategories by: newSkuRate>10%, topBrandSalesRate<60%, fbaRate>50%, avgPrice $10-50, avgMonthlySales>200. Pick top 3-5.

--- a/amazon-opportunity-discoverer/references/reference.md
+++ b/amazon-opportunity-discoverer/references/reference.md
@@ -76,7 +76,7 @@ All endpoints return: `{success, data, error, meta}` with `meta.creditsRemaining
 ## 3. products/search — Shared Product Object
 
 **Key Request Params:**
-- `keyword`, `categoryPath`, `mode` (14 presets), `keywordMatchType`
+- `keyword`, `categoryPath`, `keywordMatchType` (`mode` is a CLI-only preset — `zoodata.py` expands it into the filter pairs below client-side; it is NOT an API field and returns 422 if sent raw)
 - Filter pairs: `monthlySalesMin/Max`, `priceMin/Max`, `ratingMin/Max`, etc.
 - `pageSize` (max 20), `page`, `sortBy`, `sortOrder`
 - `includeBrands`, `excludeBrands`

--- a/amazon-opportunity-discoverer/scripts/zoodata.py
+++ b/amazon-opportunity-discoverer/scripts/zoodata.py
@@ -2776,7 +2776,7 @@ Examples:
 
     # Common args
     parser.add_argument("--format", choices=["json", "compact"], default="json",
-                        help="Output format (default: json)")
+                        help="Output format (default: json). Global flag — must come BEFORE the subcommand")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -2795,7 +2795,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field")
+    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2820,7 +2820,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
+    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2834,7 +2834,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor)")
+    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-opportunity-discoverer/scripts/zoodata.py
+++ b/amazon-opportunity-discoverer/scripts/zoodata.py
@@ -78,17 +78,17 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Each maps to a set of products/search filter parameters
 PRODUCT_MODES = {
     "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
-    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
-    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
-    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180"},
+    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180d"},
+    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180d"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180d"},
     "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
-    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
-    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillments": ["FBA", "FBM"]},
-    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180"},
+    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180d"},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["newRelease"], "fulfillments": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180d"},
     "low-price":                {"priceMax": 10},
-    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90"},
-    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
-    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90d"},
+    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90d"},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180d"},
     # "beginner" mode disabled — excludeKeywords filter not working
     "top-bsr":                  {"subBsrMax": 1000},
 }
@@ -2800,8 +2800,8 @@ Examples:
     p_prod.add_argument("--rating-min", type=float, help="Min rating")
     p_prod.add_argument("--rating-max", type=float, help="Max rating")
     p_prod.add_argument("--growth-min", type=float, help="Min sales growth rate")
-    p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
-    p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
+    p_prod.add_argument("--listing-age", help="Max listing age: 30d, 90d, 180d, 1y, or 2y")
+    p_prod.add_argument("--badges", nargs="+", help="Badge filters: bestSeller, amazonChoice, newRelease, aPlus, video")
     p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")

--- a/amazon-opportunity-discoverer/scripts/zoodata.py
+++ b/amazon-opportunity-discoverer/scripts/zoodata.py
@@ -421,15 +421,28 @@ def output(data, fmt="json"):
 
 def parse_category(cat_str: str) -> list:
     """Parse category path string into a list.
-    
+
     Supported formats:
-      - 'Pet Supplies,Dogs,Toys'           (comma-separated)
-      - 'Pet Supplies > Dogs > Toys'       (spaced arrow)
+      - '["Pet Supplies", "Dogs"]'         (JSON array — unambiguous, safest)
+      - 'Pet Supplies > Dogs > Toys'       (spaced arrow — recommended)
       - 'Pet Supplies>Dogs>Toys'           (bare arrow, no spaces)
+      - 'Pet Supplies,Dogs,Toys'           (comma-separated — AVOID for names
+        that contain commas, e.g. "Headphones, Earbuds & Accessories";
+        use '>' or JSON array for those)
     """
     if not cat_str:
         return []
-    # Support comma, ' > ' (spaced), and '>' (bare) separators
+    # JSON array input — exact segments, no separator ambiguity
+    stripped = cat_str.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if str(c).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON — fall through to separator parsing
+    # Arrow separators take priority: category names never contain '>',
+    # but they DO contain commas (e.g. "Headphones, Earbuds & Accessories")
     if " > " in cat_str:
         return [c.strip() for c in cat_str.split(" > ")]
     if ">" in cat_str:
@@ -2770,14 +2783,14 @@ Examples:
     # ── categories ──
     p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
-    p_cat.add_argument("--category", help="Exact category path (comma-separated)")
+    p_cat.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
     p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
-    p_mkt.add_argument("--category", help="Category path (comma-separated)")
+    p_mkt.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
@@ -2789,7 +2802,7 @@ Examples:
     # ── products ──
     p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
-    p_prod.add_argument("--category", help="Category path (comma-separated)")
+    p_prod.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
     p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
     p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2816,7 +2829,7 @@ Examples:
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
-    p_comp.add_argument("--category", help="Category path (comma-separated)")
+    p_comp.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_comp.add_argument("--date-range", default="30d", help="Date range (default: 30d)")
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
@@ -2847,41 +2860,41 @@ Examples:
     # ── market-entry (composite: full analysis) ──
     p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
-    p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
+    p_me.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
     p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
-    p_ca.add_argument("--category", help="Category path")
+    p_ca.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
     p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
-    p_pa.add_argument("--category", help="Category path")
+    p_pa.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
     p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
-    p_dr.add_argument("--category", help="Category path")
+    p_dr.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
     p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
-    p_la.add_argument("--category", help="Category path")
+    p_la.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
     p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
-    p_os.add_argument("--category", help="Category path")
+    p_os.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. emerging,underserved,high-demand-low-barrier). Omit to use custom filters only.")
     p_os.add_argument("--sales-min", type=int, help="Min monthly sales (e.g. 300)")
     p_os.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2897,7 +2910,7 @@ Examples:
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
-    p_rd.add_argument("--category", help="Category path")
+    p_rd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
@@ -2936,7 +2949,7 @@ Examples:
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
-    p_analyze.add_argument("--category", help="Category path")
+    p_analyze.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_analyze.add_argument("--label-type", help="Filter dimensions (comma-separated)")
     p_analyze.add_argument("--period", help="Time period: 1m, 3m, 6m, 1y, 2y", default="6m")
     p_analyze.set_defaults(func=cmd_analyze)
@@ -2944,7 +2957,7 @@ Examples:
     # ── price-band-overview ──
     p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
-    p_pbo.add_argument("--category", help="Category path")
+    p_pbo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbo.add_argument("--page-size", type=int, default=20)
     p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
@@ -2952,7 +2965,7 @@ Examples:
     # ── price-band-detail ──
     p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
-    p_pbd.add_argument("--category", help="Category path")
+    p_pbd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbd.add_argument("--page-size", type=int, default=20)
     p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
@@ -2960,7 +2973,7 @@ Examples:
     # ── brand-overview ──
     p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
-    p_bo.add_argument("--category", help="Category path")
+    p_bo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bo.add_argument("--page-size", type=int, default=20)
     p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
@@ -2968,7 +2981,7 @@ Examples:
     # ── brand-detail ──
     p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
-    p_bd.add_argument("--category", help="Category path")
+    p_bd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bd.add_argument("--page-size", type=int, default=20)
     p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -12,7 +12,7 @@ description: >
   price comparison, price positioning, repricing, should I raise or lower price.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.2"
+  version: "1.1.3"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-pricing-command-center/references/reference.md
+++ b/amazon-pricing-command-center/references/reference.md
@@ -76,7 +76,7 @@ All endpoints return: `{success, data, error, meta}` with `meta.creditsRemaining
 ## 3. products/search — Shared Product Object
 
 **Key Request Params:**
-- `keyword`, `categoryPath`, `mode` (14 presets), `keywordMatchType`
+- `keyword`, `categoryPath`, `keywordMatchType` (`mode` is a CLI-only preset — `zoodata.py` expands it into the filter pairs below client-side; it is NOT an API field and returns 422 if sent raw)
 - Filter pairs: `monthlySalesMin/Max`, `priceMin/Max`, `ratingMin/Max`, etc.
 - `pageSize` (max 20), `page`, `sortBy`, `sortOrder`
 - `includeBrands`, `excludeBrands`

--- a/amazon-pricing-command-center/scripts/zoodata.py
+++ b/amazon-pricing-command-center/scripts/zoodata.py
@@ -2776,7 +2776,7 @@ Examples:
 
     # Common args
     parser.add_argument("--format", choices=["json", "compact"], default="json",
-                        help="Output format (default: json)")
+                        help="Output format (default: json). Global flag — must come BEFORE the subcommand")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -2795,7 +2795,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field")
+    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2820,7 +2820,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
+    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2834,7 +2834,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor)")
+    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-pricing-command-center/scripts/zoodata.py
+++ b/amazon-pricing-command-center/scripts/zoodata.py
@@ -78,17 +78,17 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Each maps to a set of products/search filter parameters
 PRODUCT_MODES = {
     "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
-    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
-    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
-    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180"},
+    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180d"},
+    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180d"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180d"},
     "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
-    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
-    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillments": ["FBA", "FBM"]},
-    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180"},
+    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180d"},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["newRelease"], "fulfillments": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180d"},
     "low-price":                {"priceMax": 10},
-    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90"},
-    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
-    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90d"},
+    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90d"},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180d"},
     # "beginner" mode disabled — excludeKeywords filter not working
     "top-bsr":                  {"subBsrMax": 1000},
 }
@@ -2800,8 +2800,8 @@ Examples:
     p_prod.add_argument("--rating-min", type=float, help="Min rating")
     p_prod.add_argument("--rating-max", type=float, help="Max rating")
     p_prod.add_argument("--growth-min", type=float, help="Min sales growth rate")
-    p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
-    p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
+    p_prod.add_argument("--listing-age", help="Max listing age: 30d, 90d, 180d, 1y, or 2y")
+    p_prod.add_argument("--badges", nargs="+", help="Badge filters: bestSeller, amazonChoice, newRelease, aPlus, video")
     p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")

--- a/amazon-pricing-command-center/scripts/zoodata.py
+++ b/amazon-pricing-command-center/scripts/zoodata.py
@@ -421,15 +421,28 @@ def output(data, fmt="json"):
 
 def parse_category(cat_str: str) -> list:
     """Parse category path string into a list.
-    
+
     Supported formats:
-      - 'Pet Supplies,Dogs,Toys'           (comma-separated)
-      - 'Pet Supplies > Dogs > Toys'       (spaced arrow)
+      - '["Pet Supplies", "Dogs"]'         (JSON array — unambiguous, safest)
+      - 'Pet Supplies > Dogs > Toys'       (spaced arrow — recommended)
       - 'Pet Supplies>Dogs>Toys'           (bare arrow, no spaces)
+      - 'Pet Supplies,Dogs,Toys'           (comma-separated — AVOID for names
+        that contain commas, e.g. "Headphones, Earbuds & Accessories";
+        use '>' or JSON array for those)
     """
     if not cat_str:
         return []
-    # Support comma, ' > ' (spaced), and '>' (bare) separators
+    # JSON array input — exact segments, no separator ambiguity
+    stripped = cat_str.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if str(c).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON — fall through to separator parsing
+    # Arrow separators take priority: category names never contain '>',
+    # but they DO contain commas (e.g. "Headphones, Earbuds & Accessories")
     if " > " in cat_str:
         return [c.strip() for c in cat_str.split(" > ")]
     if ">" in cat_str:
@@ -2770,14 +2783,14 @@ Examples:
     # ── categories ──
     p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
-    p_cat.add_argument("--category", help="Exact category path (comma-separated)")
+    p_cat.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
     p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
-    p_mkt.add_argument("--category", help="Category path (comma-separated)")
+    p_mkt.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
@@ -2789,7 +2802,7 @@ Examples:
     # ── products ──
     p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
-    p_prod.add_argument("--category", help="Category path (comma-separated)")
+    p_prod.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
     p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
     p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2816,7 +2829,7 @@ Examples:
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
-    p_comp.add_argument("--category", help="Category path (comma-separated)")
+    p_comp.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_comp.add_argument("--date-range", default="30d", help="Date range (default: 30d)")
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
@@ -2847,41 +2860,41 @@ Examples:
     # ── market-entry (composite: full analysis) ──
     p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
-    p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
+    p_me.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
     p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
-    p_ca.add_argument("--category", help="Category path")
+    p_ca.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
     p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
-    p_pa.add_argument("--category", help="Category path")
+    p_pa.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
     p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
-    p_dr.add_argument("--category", help="Category path")
+    p_dr.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
     p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
-    p_la.add_argument("--category", help="Category path")
+    p_la.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
     p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
-    p_os.add_argument("--category", help="Category path")
+    p_os.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. emerging,underserved,high-demand-low-barrier). Omit to use custom filters only.")
     p_os.add_argument("--sales-min", type=int, help="Min monthly sales (e.g. 300)")
     p_os.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2897,7 +2910,7 @@ Examples:
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
-    p_rd.add_argument("--category", help="Category path")
+    p_rd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
@@ -2936,7 +2949,7 @@ Examples:
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
-    p_analyze.add_argument("--category", help="Category path")
+    p_analyze.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_analyze.add_argument("--label-type", help="Filter dimensions (comma-separated)")
     p_analyze.add_argument("--period", help="Time period: 1m, 3m, 6m, 1y, 2y", default="6m")
     p_analyze.set_defaults(func=cmd_analyze)
@@ -2944,7 +2957,7 @@ Examples:
     # ── price-band-overview ──
     p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
-    p_pbo.add_argument("--category", help="Category path")
+    p_pbo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbo.add_argument("--page-size", type=int, default=20)
     p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
@@ -2952,7 +2965,7 @@ Examples:
     # ── price-band-detail ──
     p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
-    p_pbd.add_argument("--category", help="Category path")
+    p_pbd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbd.add_argument("--page-size", type=int, default=20)
     p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
@@ -2960,7 +2973,7 @@ Examples:
     # ── brand-overview ──
     p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
-    p_bo.add_argument("--category", help="Category path")
+    p_bo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bo.add_argument("--page-size", type=int, default=20)
     p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
@@ -2968,7 +2981,7 @@ Examples:
     # ── brand-detail ──
     p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
-    p_bd.add_argument("--category", help="Category path")
+    p_bd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bd.add_argument("--page-size", type=int, default=20)
     p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -11,7 +11,7 @@ description: >
   review comparison, negative reviews, customer complaints, buying factors, user profile.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.3"
+  version: "1.0.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-review-intelligence-extractor/references/reference.md
+++ b/amazon-review-intelligence-extractor/references/reference.md
@@ -76,7 +76,7 @@ All endpoints return: `{success, data, error, meta}` with `meta.creditsRemaining
 ## 3. products/search — Shared Product Object
 
 **Key Request Params:**
-- `keyword`, `categoryPath`, `mode` (14 presets), `keywordMatchType`
+- `keyword`, `categoryPath`, `keywordMatchType` (`mode` is a CLI-only preset — `zoodata.py` expands it into the filter pairs below client-side; it is NOT an API field and returns 422 if sent raw)
 - Filter pairs: `monthlySalesMin/Max`, `priceMin/Max`, `ratingMin/Max`, etc.
 - `pageSize` (max 20), `page`, `sortBy`, `sortOrder`
 - `includeBrands`, `excludeBrands`

--- a/amazon-review-intelligence-extractor/scripts/zoodata.py
+++ b/amazon-review-intelligence-extractor/scripts/zoodata.py
@@ -2776,7 +2776,7 @@ Examples:
 
     # Common args
     parser.add_argument("--format", choices=["json", "compact"], default="json",
-                        help="Output format (default: json)")
+                        help="Output format (default: json). Global flag — must come BEFORE the subcommand")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -2795,7 +2795,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field")
+    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2820,7 +2820,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
+    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2834,7 +2834,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor)")
+    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-review-intelligence-extractor/scripts/zoodata.py
+++ b/amazon-review-intelligence-extractor/scripts/zoodata.py
@@ -78,17 +78,17 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Each maps to a set of products/search filter parameters
 PRODUCT_MODES = {
     "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
-    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
-    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
-    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180"},
+    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180d"},
+    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180d"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180d"},
     "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
-    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
-    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillments": ["FBA", "FBM"]},
-    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180"},
+    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180d"},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["newRelease"], "fulfillments": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180d"},
     "low-price":                {"priceMax": 10},
-    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90"},
-    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
-    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90d"},
+    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90d"},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180d"},
     # "beginner" mode disabled — excludeKeywords filter not working
     "top-bsr":                  {"subBsrMax": 1000},
 }
@@ -2800,8 +2800,8 @@ Examples:
     p_prod.add_argument("--rating-min", type=float, help="Min rating")
     p_prod.add_argument("--rating-max", type=float, help="Max rating")
     p_prod.add_argument("--growth-min", type=float, help="Min sales growth rate")
-    p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
-    p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
+    p_prod.add_argument("--listing-age", help="Max listing age: 30d, 90d, 180d, 1y, or 2y")
+    p_prod.add_argument("--badges", nargs="+", help="Badge filters: bestSeller, amazonChoice, newRelease, aPlus, video")
     p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")

--- a/amazon-review-intelligence-extractor/scripts/zoodata.py
+++ b/amazon-review-intelligence-extractor/scripts/zoodata.py
@@ -421,15 +421,28 @@ def output(data, fmt="json"):
 
 def parse_category(cat_str: str) -> list:
     """Parse category path string into a list.
-    
+
     Supported formats:
-      - 'Pet Supplies,Dogs,Toys'           (comma-separated)
-      - 'Pet Supplies > Dogs > Toys'       (spaced arrow)
+      - '["Pet Supplies", "Dogs"]'         (JSON array — unambiguous, safest)
+      - 'Pet Supplies > Dogs > Toys'       (spaced arrow — recommended)
       - 'Pet Supplies>Dogs>Toys'           (bare arrow, no spaces)
+      - 'Pet Supplies,Dogs,Toys'           (comma-separated — AVOID for names
+        that contain commas, e.g. "Headphones, Earbuds & Accessories";
+        use '>' or JSON array for those)
     """
     if not cat_str:
         return []
-    # Support comma, ' > ' (spaced), and '>' (bare) separators
+    # JSON array input — exact segments, no separator ambiguity
+    stripped = cat_str.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if str(c).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON — fall through to separator parsing
+    # Arrow separators take priority: category names never contain '>',
+    # but they DO contain commas (e.g. "Headphones, Earbuds & Accessories")
     if " > " in cat_str:
         return [c.strip() for c in cat_str.split(" > ")]
     if ">" in cat_str:
@@ -2770,14 +2783,14 @@ Examples:
     # ── categories ──
     p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
-    p_cat.add_argument("--category", help="Exact category path (comma-separated)")
+    p_cat.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
     p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
-    p_mkt.add_argument("--category", help="Category path (comma-separated)")
+    p_mkt.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
@@ -2789,7 +2802,7 @@ Examples:
     # ── products ──
     p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
-    p_prod.add_argument("--category", help="Category path (comma-separated)")
+    p_prod.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
     p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
     p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2816,7 +2829,7 @@ Examples:
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
-    p_comp.add_argument("--category", help="Category path (comma-separated)")
+    p_comp.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_comp.add_argument("--date-range", default="30d", help="Date range (default: 30d)")
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
@@ -2847,41 +2860,41 @@ Examples:
     # ── market-entry (composite: full analysis) ──
     p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
-    p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
+    p_me.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
     p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
-    p_ca.add_argument("--category", help="Category path")
+    p_ca.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
     p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
-    p_pa.add_argument("--category", help="Category path")
+    p_pa.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
     p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
-    p_dr.add_argument("--category", help="Category path")
+    p_dr.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
     p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
-    p_la.add_argument("--category", help="Category path")
+    p_la.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
     p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
-    p_os.add_argument("--category", help="Category path")
+    p_os.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. emerging,underserved,high-demand-low-barrier). Omit to use custom filters only.")
     p_os.add_argument("--sales-min", type=int, help="Min monthly sales (e.g. 300)")
     p_os.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2897,7 +2910,7 @@ Examples:
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
-    p_rd.add_argument("--category", help="Category path")
+    p_rd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
@@ -2936,7 +2949,7 @@ Examples:
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
-    p_analyze.add_argument("--category", help="Category path")
+    p_analyze.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_analyze.add_argument("--label-type", help="Filter dimensions (comma-separated)")
     p_analyze.add_argument("--period", help="Time period: 1m, 3m, 6m, 1y, 2y", default="6m")
     p_analyze.set_defaults(func=cmd_analyze)
@@ -2944,7 +2957,7 @@ Examples:
     # ── price-band-overview ──
     p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
-    p_pbo.add_argument("--category", help="Category path")
+    p_pbo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbo.add_argument("--page-size", type=int, default=20)
     p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
@@ -2952,7 +2965,7 @@ Examples:
     # ── price-band-detail ──
     p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
-    p_pbd.add_argument("--category", help="Category path")
+    p_pbd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbd.add_argument("--page-size", type=int, default=20)
     p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
@@ -2960,7 +2973,7 @@ Examples:
     # ── brand-overview ──
     p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
-    p_bo.add_argument("--category", help="Category path")
+    p_bo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bo.add_argument("--page-size", type=int, default=20)
     p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
@@ -2968,7 +2981,7 @@ Examples:
     # ── brand-detail ──
     p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
-    p_bd.add_argument("--category", help="Category path")
+    p_bd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bd.add_argument("--page-size", type=int, default=20)
     p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)

--- a/tests/test_zoodata.py
+++ b/tests/test_zoodata.py
@@ -3,7 +3,7 @@ Test suite for zoodata/scripts/zoodata.py
 
 Coverage:
   - parse_category: all supported separators and edge cases
-  - PRODUCT_MODES: all 14 modes accepted without error
+  - PRODUCT_MODES: all 13 modes accepted; enum values match backend contract
   - argparse: all subcommands have valid --help; allow_abbrev=False regression
   - param construction: each subcommand passes the right keys to api_call
   - output format: json and compact both produce valid JSON
@@ -135,6 +135,28 @@ class TestProductModes(unittest.TestCase):
              self.assertRaises(SystemExit) as cm:
             zoodata.main()
         self.assertNotEqual(cm.exception.code, 0)
+
+    # Backend enum contracts — mirror hermes-service
+    # app/api/openapi/schemas/products.py (LISTING_AGE_VALUES / BADGE_VALUES / FULFILLMENT_VALUES).
+    # These guard against the CLI emitting preset values the API rejects with 422.
+    BACKEND_LISTING_AGE = {"30d", "90d", "180d", "1y", "2y"}
+    BACKEND_BADGES = {"bestSeller", "amazonChoice", "newRelease", "aPlus", "video"}
+    BACKEND_FULFILLMENTS = {"AMZ", "FBA", "FBM"}
+
+    def test_mode_enum_values_match_backend_contract(self):
+        """Every enum-constrained filter value in a preset must be one the backend accepts.
+        Regression: modes once sent listingAge '180' and badges ['New Release'] → hard 422."""
+        for mode, filters in zoodata.PRODUCT_MODES.items():
+            with self.subTest(mode=mode):
+                if "listingAge" in filters:
+                    self.assertIn(filters["listingAge"], self.BACKEND_LISTING_AGE,
+                                  f"{mode}: listingAge {filters['listingAge']!r} not a backend enum value")
+                for badge in filters.get("badges", []):
+                    self.assertIn(badge, self.BACKEND_BADGES,
+                                  f"{mode}: badge {badge!r} not a backend enum value")
+                for ful in filters.get("fulfillments", []):
+                    self.assertIn(ful, self.BACKEND_FULFILLMENTS,
+                                  f"{mode}: fulfillment {ful!r} not a backend enum value")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_zoodata.py
+++ b/tests/test_zoodata.py
@@ -110,6 +110,25 @@ class TestParseCategory(unittest.TestCase):
         self.assertEqual(zoodata.parse_category("  Pet Supplies , Dogs "),
                          ["Pet Supplies", "Dogs"])
 
+    def test_arrow_protects_comma_in_category_name(self):
+        """Amazon category names can contain commas; '>' must not split them.
+        Regression: comma-split broke 'Headphones, Earbuds & Accessories'."""
+        self.assertEqual(
+            zoodata.parse_category("Electronics > Headphones, Earbuds & Accessories > Earbud Headphones"),
+            ["Electronics", "Headphones, Earbuds & Accessories", "Earbud Headphones"])
+
+    def test_json_array_input(self):
+        self.assertEqual(zoodata.parse_category('["Sports & Outdoors"]'),
+                         ["Sports & Outdoors"])
+
+    def test_json_array_with_comma_in_name(self):
+        self.assertEqual(
+            zoodata.parse_category('["Health & Household", "Vitamins, Minerals & Supplements", "Collagen"]'),
+            ["Health & Household", "Vitamins, Minerals & Supplements", "Collagen"])
+
+    def test_malformed_json_falls_through_to_separator_parsing(self):
+        self.assertEqual(zoodata.parse_category("[not json"), ["[not json"])
+
 
 # ---------------------------------------------------------------------------
 # 2. PRODUCT_MODES completeness

--- a/web-extract/SKILL.md
+++ b/web-extract/SKILL.md
@@ -1,38 +1,24 @@
 ---
 name: web-extract
 description: >
-  Extract structured JSON from web pages, search engines, and entire
-  sites — the agent gets ready-to-consume {title, summary, sections,
-  key_metrics, outgoing_links, author, date, page_type, ...} fields in
-  ONE call, with NO second LLM pass needed to parse markdown or HTML
-  into structure. Six endpoints: scrape (single URL), scrape-interactive
-  (JS-rendered pages with click/scroll/wait/type/JS actions), search
-  (Google SERP + optional deep-scrape per result), map (URL discovery
-  on a domain), crawl + crawl-status (async multi-page recursive crawl
-  with depth and path filters). Markdown and raw HTML are available
-  when the user explicitly asks for prose or DOM access.
+  Extract structured JSON from web pages, search engines, and entire sites
+  in ONE call — {title, summary, sections, key_metrics, outgoing_links,
+  author, date, page_type, ...} fields, no second LLM pass to parse HTML.
+  Six endpoints: scrape (single URL), scrape-interactive (JS-rendered pages
+  with click/scroll/type), search (Google SERP + deep-scrape), map (URL
+  discovery), crawl + crawl-status (async recursive crawl). Markdown/raw
+  HTML on request.
 
-  USE this when the user needs page DATA for downstream work — product
-  pricing/specs, article fields, link graphs, docs-site full text,
-  competitor pages, JS-heavy SPAs, Google search results with content,
-  any "give me the structured data from this page/site" task.
+  USE when the user needs page DATA — product pricing/specs, article fields,
+  link graphs, JS-heavy SPAs, Google results with content. Prefer over
+  browser-act (automation/screenshots) and WebFetch (static, no JS, no
+  structured fields). Not for citation-rich research (use deep-research).
 
-  PREFER OVER browser-act (which is for browser automation, screenshots,
-  and form-filling — not structured extraction) and built-in WebFetch
-  (static fetch only — no JS render, no structured fields, you'd have to
-  re-LLM the markdown to get structure). DON'T use for: multi-source
-  citation-rich research reports (use deep-research instead), or tasks
-  that need visual verification / screenshots (use browser-act).
+  Trigger (EN): scrape this URL, extract data from page, crawl this site,
+  deep-scrape search results, map a domain's URLs, render this JS page.
+  触发词：抓取/爬取/网页提取/结构化抽取/搜索带内容/全站爬取/JS 渲染抓取/点击后抓取.
 
-  Trigger phrases (EN): scrape this URL, extract data from page, crawl
-  this site, get structured fields from a webpage, deep-scrape search
-  results, map this domain's URLs, render this JS page, fetch with
-  click/scroll, structured web extraction.
-  触发词 (中文)：抓取/爬取/扒下来/网页提取/结构化抽取/搜索带内容/
-  全站爬取/拉取整个站点/JS 渲染抓取/点击后抓取/带交互抓取.
-
-  Requires ZOODATA_API_KEY. Get a free key with 1,000 credits at
-  https://zoodata.ai/en/api-keys.
+  Requires ZOODATA_API_KEY (free key: https://zoodata.ai/en/api-keys).
 metadata:
   version: "0.2.1"
   author: SerendipityOneInc

--- a/web-extract/SKILL.md
+++ b/web-extract/SKILL.md
@@ -34,7 +34,7 @@ description: >
   Requires ZOODATA_API_KEY. Get a free key with 1,000 credits at
   https://zoodata.ai/en/api-keys.
 metadata:
-  version: "0.2.0"
+  version: "0.2.1"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/zoodata/README.md
+++ b/zoodata/README.md
@@ -4,7 +4,7 @@
 
 ## What This Skill Does
 
-The foundational data layer for all ZooData agent skills. Provides direct access to 20 API endpoints covering category browsing, market metrics, product search (14 modes), competitor lookup, real-time ASIN detail, AI review analysis, price band analysis, brand intelligence, product history, and keyword intelligence. Use this skill when you need raw API access or want to understand what data is available.
+The foundational data layer for all ZooData agent skills. Provides direct access to 20 API endpoints covering category browsing, market metrics, product search (20+ filter fields), competitor lookup, real-time ASIN detail, AI review analysis, price band analysis, brand intelligence, product history, and keyword intelligence. Use this skill when you need raw API access or want to understand what data is available.
 
 ### What Makes This Different
 
@@ -53,7 +53,7 @@ Select **ZooData** when prompted.
 |---|----------|---------|
 | 1 | `categories` | Browse/search category tree |
 | 2 | `markets/search` | Market-level metrics (sales, price, concentration) |
-| 3 | `products/search` | Product search with 14 selection modes |
+| 3 | `products/search` | Product search with 20+ filter fields (13 CLI presets) |
 | 4 | `products/competitors` | Competitor discovery |
 | 5 | `realtime/product` | Live ASIN detail (rating, BSR, Buy Box, variants) |
 | 6 | `reviews/analysis` | AI review insights (sentiment, pain points, keywords) |

--- a/zoodata/SKILL.md
+++ b/zoodata/SKILL.md
@@ -50,7 +50,8 @@ metadata:
       Local Review Toolkit below — see "Local Review Toolkit" section
 7. **Aggregation endpoints** (price-band, brand) without categoryPath produce severely distorted data
 8. **Price-band and brand endpoints only accept `keyword`** (not categoryPath) — cross-validate returned products
-9. **`mode` and CLI flags are CLI-local, NOT API fields** → `zoodata.py` expands them client-side before the request. Modes → filter sets in `PRODUCT_MODES` (`{skill_base_dir}/scripts/zoodata.py`, 13 presets); `--sales-min` → `monthlySalesMin`; `--ratings-max` (review count) → `ratingCountMax`, **not** `ratingMax` (a different valid field — max star rating — that returns wrong results silently, no 422). Sending `mode`/`salesMin`/`ratingsMax` in a raw request → 422. Pass `categoryPath` as a JSON array (`["Electronics"]`), never a string.
+9. **`mode` is CLI-local, NOT an API parameter** → `zoodata.py` expands `--mode` client-side into the filter sets in `PRODUCT_MODES` (`{skill_base_dir}/scripts/zoodata.py`, 13 presets) before the request; sending `mode` raw → 422
+10. **CLI filter flags ≠ API field names** → `--sales-min` → `monthlySalesMin`; `--ratings-max` (review count) → `ratingCountMax`, **not** `ratingMax` (a different valid field — max star rating — that returns wrong results silently, no 422). Pass `categoryPath` as a JSON array (`["Electronics"]`), never a string. Unknown fields (`salesMin`, `ratingsMax`, …) → 422
 
 ## On Missing Key (no credentials configured)
 

--- a/zoodata/SKILL.md
+++ b/zoodata/SKILL.md
@@ -18,7 +18,7 @@ description: >
   credit usage, how the Local Review Toolkit works, how to get started.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.3"
+  version: "1.1.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/zoodata/SKILL.md
+++ b/zoodata/SKILL.md
@@ -50,6 +50,7 @@ metadata:
       Local Review Toolkit below — see "Local Review Toolkit" section
 7. **Aggregation endpoints** (price-band, brand) without categoryPath produce severely distorted data
 8. **Price-band and brand endpoints only accept `keyword`** (not categoryPath) — cross-validate returned products
+9. **`mode` and CLI flags are CLI-local, NOT API fields** → `zoodata.py` expands them client-side before the request. Modes → filter sets in `PRODUCT_MODES` (`amazon-analysis/scripts/zoodata.py`, 13 presets); `--sales-min` → `monthlySalesMin`; `--ratings-max` (review count) → `ratingCountMax`, **not** `ratingMax` (a different valid field — max star rating — that returns wrong results silently, no 422). Sending `mode`/`salesMin`/`ratingsMax` in a raw request → 422. Pass `categoryPath` as a JSON array (`["Electronics"]`), never a string.
 
 ## On Missing Key (no credentials configured)
 

--- a/zoodata/SKILL.md
+++ b/zoodata/SKILL.md
@@ -96,7 +96,7 @@ When `zoodata.py` returns `{"code": 402, "message": "API quota exhausted or subs
 |---|----------|---------|------------|
 | 1 | `categories` | Browse/search category tree | categoryPath, productCount |
 | 2 | `markets/search` | Market-level metrics | sampleAvgMonthlySales, sampleAvgPrice, topSalesRate, sampleNewSkuRate |
-| 3 | `products/search` | Product search (14 modes) | asin, price, monthlySalesFloor, rating, ratingCount, fbaFee |
+| 3 | `products/search` | Product search (20+ filter fields) | asin, price, monthlySalesFloor, rating, ratingCount, fbaFee |
 | 4 | `products/competitors` | Competitor discovery | same fields as products/search |
 | 5 | `realtime/product` | Live ASIN detail | rating, features, bestsellersRank[], buyboxWinner.price, variants |
 | 6 | `reviews/analysis` | AI review insights (11 dims) | sentimentDistribution, consumerInsights, topKeywords |

--- a/zoodata/SKILL.md
+++ b/zoodata/SKILL.md
@@ -50,7 +50,7 @@ metadata:
       Local Review Toolkit below — see "Local Review Toolkit" section
 7. **Aggregation endpoints** (price-band, brand) without categoryPath produce severely distorted data
 8. **Price-band and brand endpoints only accept `keyword`** (not categoryPath) — cross-validate returned products
-9. **`mode` and CLI flags are CLI-local, NOT API fields** → `zoodata.py` expands them client-side before the request. Modes → filter sets in `PRODUCT_MODES` (`amazon-analysis/scripts/zoodata.py`, 13 presets); `--sales-min` → `monthlySalesMin`; `--ratings-max` (review count) → `ratingCountMax`, **not** `ratingMax` (a different valid field — max star rating — that returns wrong results silently, no 422). Sending `mode`/`salesMin`/`ratingsMax` in a raw request → 422. Pass `categoryPath` as a JSON array (`["Electronics"]`), never a string.
+9. **`mode` and CLI flags are CLI-local, NOT API fields** → `zoodata.py` expands them client-side before the request. Modes → filter sets in `PRODUCT_MODES` (`{skill_base_dir}/scripts/zoodata.py`, 13 presets); `--sales-min` → `monthlySalesMin`; `--ratings-max` (review count) → `ratingCountMax`, **not** `ratingMax` (a different valid field — max star rating — that returns wrong results silently, no 422). Sending `mode`/`salesMin`/`ratingsMax` in a raw request → 422. Pass `categoryPath` as a JSON array (`["Electronics"]`), never a string.
 
 ## On Missing Key (no credentials configured)
 

--- a/zoodata/SKILL.md
+++ b/zoodata/SKILL.md
@@ -125,6 +125,7 @@ When `zoodata.py` returns `{"code": 402, "message": "API quota exhausted or subs
 - `bsr` (int) in products vs `bestsellersRank` (array) in realtime
 - `buyboxWinner.price` — NOT top-level `price` in realtime
 - `realtime/product` does NOT return: monthlySalesFloor, fbaFee, sellerCount
+- `realtime/product` cold-start: first call for an uncached ASIN may return `success: true` with an EMPTY `data` (`asin: ""`) while the live fetch warms up — retry once after a few seconds before concluding "no data" (still billed 1 credit per call)
 - `reviewCountMin/Max` filters currently broken (API-56)
 - `reviews/analysis` may 500 for certain ASINs (API-58) — retry different ASIN
 - Rate limit: 100 req/min, 10 req/sec burst

--- a/zoodata/references/openapi-reference.md
+++ b/zoodata/references/openapi-reference.md
@@ -15,7 +15,7 @@ Method: All POST with JSON body
 | Parameter | Type | Note |
 |-----------|------|------|
 | categoryKeyword | String | Search by keyword |
-| categoryPath | String | Exact path lookup |
+| categoryPath | List\<String\> | Exact path lookup, e.g. `["Electronics", "Computers"]` |
 | parentCategoryPath | List\<String\> | Browse children |
 | _(no params)_ | — | Returns root categories |
 
@@ -63,13 +63,13 @@ Same as competitors, plus:
 | Parameter | Type | Note |
 |-----------|------|------|
 | keywordMatchType | String | `fuzzy` / `phrase` / `exact` |
-| listingAge | **String** | Max age in days ⚠️ must be string |
+| listingAge | **Enum String** | One of `30d` / `90d` / `180d` / `1y` / `2y` (⚠️ bare numbers like `180` → 422) |
 
 Filter pairs (all optional, Min/Max): `monthlySales`, `revenue`, `salesGrowthRate`, `bsr`, `subBsr`, `bsrGrowthRate`, `price`, `rating`, `ratingCount`, `fbaShipping`, `variantCount`, `grossMargin`, `sellerCount`
 
 > `mode` is **NOT** an API parameter. The 13 CLI presets in `zoodata.py` expand client-side into the filter pairs above before the request is sent; passing `mode` in a raw request returns 422.
 
-Additional: `includeBrands`, `excludeBrands`, `fulfillment` (`["FBA"]`/`["FBM"]`), `badges` (`["New Release"]`/`["Best Seller"]`)
+Additional: `includeBrands`, `excludeBrands`, `fulfillment` (`["FBA"]`/`["FBM"]`/`["AMZ"]`), `badges` — enum values `["bestSeller"]` / `["amazonChoice"]` / `["newRelease"]` / `["aPlus"]` / `["video"]` (⚠️ `"New Release"` with a space → 422)
 
 ---
 

--- a/zoodata/references/openapi-reference.md
+++ b/zoodata/references/openapi-reference.md
@@ -62,11 +62,12 @@ Same as competitors, plus:
 
 | Parameter | Type | Note |
 |-----------|------|------|
-| mode | String | 14 preset modes (see SKILL.md) |
 | keywordMatchType | String | `fuzzy` / `phrase` / `exact` |
 | listingAge | **String** | Max age in days ⚠️ must be string |
 
 Filter pairs (all optional, Min/Max): `monthlySales`, `revenue`, `salesGrowthRate`, `bsr`, `subBsr`, `bsrGrowthRate`, `price`, `rating`, `ratingCount`, `fbaShipping`, `variantCount`, `grossMargin`, `sellerCount`
+
+> `mode` is **NOT** an API parameter. The 13 CLI presets in `zoodata.py` expand client-side into the filter pairs above before the request is sent; passing `mode` in a raw request returns 422.
 
 Additional: `includeBrands`, `excludeBrands`, `fulfillment` (`["FBA"]`/`["FBM"]`), `badges` (`["New Release"]`/`["Best Seller"]`)
 

--- a/zoodata/references/reference.md
+++ b/zoodata/references/reference.md
@@ -76,7 +76,7 @@ All endpoints return: `{success, data, error, meta}` with `meta.creditsRemaining
 ## 3. products/search — Shared Product Object
 
 **Key Request Params:**
-- `keyword`, `categoryPath`, `mode` (14 presets), `keywordMatchType`
+- `keyword`, `categoryPath`, `keywordMatchType` (`mode` is a CLI-only preset — `zoodata.py` expands it into the filter pairs below client-side; it is NOT an API field and returns 422 if sent raw)
 - Filter pairs: `monthlySalesMin/Max`, `priceMin/Max`, `ratingMin/Max`, etc.
 - `pageSize` (max 20), `page`, `sortBy`, `sortOrder`
 - `includeBrands`, `excludeBrands`

--- a/zoodata/scripts/zoodata.py
+++ b/zoodata/scripts/zoodata.py
@@ -2776,7 +2776,7 @@ Examples:
 
     # Common args
     parser.add_argument("--format", choices=["json", "compact"], default="json",
-                        help="Output format (default: json)")
+                        help="Output format (default: json). Global flag — must come BEFORE the subcommand")
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -2795,7 +2795,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field")
+    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2820,7 +2820,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySales)")
+    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2834,7 +2834,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor)")
+    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/zoodata/scripts/zoodata.py
+++ b/zoodata/scripts/zoodata.py
@@ -78,17 +78,17 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 # Each maps to a set of products/search filter parameters
 PRODUCT_MODES = {
     "fast-movers":              {"monthlySalesMin": 300, "salesGrowthRateMin": 0.1},
-    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180"},
-    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180"},
-    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180"},
+    "emerging":                 {"monthlySalesMax": 600, "salesGrowthRateMin": 0.1, "listingAge": "180d"},
+    "single-variant":           {"salesGrowthRateMin": 0.2, "variantCountMax": 1, "listingAge": "180d"},
+    "high-demand-low-barrier":  {"monthlySalesMin": 300, "ratingCountMax": 50, "listingAge": "180d"},
     "long-tail":                {"bsrMin": 10000, "bsrMax": 50000, "priceMax": 30, "sellerCountMax": 1, "monthlySalesMax": 300},
-    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180"},
-    "new-release":              {"monthlySalesMax": 500, "badges": ["New Release"], "fulfillments": ["FBA", "FBM"]},
-    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180"},
+    "underserved":              {"monthlySalesMin": 300, "ratingMax": 3.7, "listingAge": "180d"},
+    "new-release":              {"monthlySalesMax": 500, "badges": ["newRelease"], "fulfillments": ["FBA", "FBM"]},
+    "fbm-friendly":             {"monthlySalesMin": 300, "fulfillments": ["FBM"], "listingAge": "180d"},
     "low-price":                {"priceMax": 10},
-    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90"},
-    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90"},
-    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180"},
+    "broad-catalog":            {"bsrGrowthRateMin": 0.99, "ratingCountMax": 10, "listingAge": "90d"},
+    "selective-catalog":        {"bsrGrowthRateMin": 0.99, "listingAge": "90d"},
+    "speculative":              {"monthlySalesMin": 600, "sellerCountMin": 3, "listingAge": "180d"},
     # "beginner" mode disabled — excludeKeywords filter not working
     "top-bsr":                  {"subBsrMax": 1000},
 }
@@ -2800,8 +2800,8 @@ Examples:
     p_prod.add_argument("--rating-min", type=float, help="Min rating")
     p_prod.add_argument("--rating-max", type=float, help="Max rating")
     p_prod.add_argument("--growth-min", type=float, help="Min sales growth rate")
-    p_prod.add_argument("--listing-age", help="Max listing age in days (string)")
-    p_prod.add_argument("--badges", nargs="+", help="Badge filters (e.g. 'New Release')")
+    p_prod.add_argument("--listing-age", help="Max listing age: 30d, 90d, 180d, 1y, or 2y")
+    p_prod.add_argument("--badges", nargs="+", help="Badge filters: bestSeller, amazonChoice, newRelease, aPlus, video")
     p_prod.add_argument("--fulfillment", nargs="+", help="Fulfillment filter (FBA, FBM)")
     p_prod.add_argument("--include-brands", help="Include brands (comma-separated)")
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")

--- a/zoodata/scripts/zoodata.py
+++ b/zoodata/scripts/zoodata.py
@@ -421,15 +421,28 @@ def output(data, fmt="json"):
 
 def parse_category(cat_str: str) -> list:
     """Parse category path string into a list.
-    
+
     Supported formats:
-      - 'Pet Supplies,Dogs,Toys'           (comma-separated)
-      - 'Pet Supplies > Dogs > Toys'       (spaced arrow)
+      - '["Pet Supplies", "Dogs"]'         (JSON array — unambiguous, safest)
+      - 'Pet Supplies > Dogs > Toys'       (spaced arrow — recommended)
       - 'Pet Supplies>Dogs>Toys'           (bare arrow, no spaces)
+      - 'Pet Supplies,Dogs,Toys'           (comma-separated — AVOID for names
+        that contain commas, e.g. "Headphones, Earbuds & Accessories";
+        use '>' or JSON array for those)
     """
     if not cat_str:
         return []
-    # Support comma, ' > ' (spaced), and '>' (bare) separators
+    # JSON array input — exact segments, no separator ambiguity
+    stripped = cat_str.strip()
+    if stripped.startswith("[") and stripped.endswith("]"):
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, list):
+                return [str(c).strip() for c in parsed if str(c).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass  # not valid JSON — fall through to separator parsing
+    # Arrow separators take priority: category names never contain '>',
+    # but they DO contain commas (e.g. "Headphones, Earbuds & Accessories")
     if " > " in cat_str:
         return [c.strip() for c in cat_str.split(" > ")]
     if ">" in cat_str:
@@ -2770,14 +2783,14 @@ Examples:
     # ── categories ──
     p_cat = sub.add_parser("categories", help="Query Amazon category tree", allow_abbrev=False)
     p_cat.add_argument("--keyword", help="Search categories by keyword")
-    p_cat.add_argument("--category", help="Exact category path (comma-separated)")
+    p_cat.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_cat.add_argument("--parent", help="Get child categories (comma-separated parent path)")
     p_cat.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_cat.set_defaults(func=cmd_categories)
 
     # ── market ──
     p_mkt = sub.add_parser("market", help="Search market-level data for a category", allow_abbrev=False)
-    p_mkt.add_argument("--category", help="Category path (comma-separated)")
+    p_mkt.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_mkt.add_argument("--keyword", help="Category keyword")
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
@@ -2789,7 +2802,7 @@ Examples:
     # ── products ──
     p_prod = sub.add_parser("products", help="Search products with filters (product selection)", allow_abbrev=False)
     p_prod.add_argument("--keyword", help="Search keyword")
-    p_prod.add_argument("--category", help="Category path (comma-separated)")
+    p_prod.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_prod.add_argument("--mode", help=f"Preset filter mode: {', '.join(sorted(PRODUCT_MODES.keys()))}")
     p_prod.add_argument("--sales-min", type=int, help="Min monthly sales")
     p_prod.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2816,7 +2829,7 @@ Examples:
     p_comp.add_argument("--keyword", help="Search keyword")
     p_comp.add_argument("--brand", help="Brand filter")
     p_comp.add_argument("--asin", help="ASIN filter")
-    p_comp.add_argument("--category", help="Category path (comma-separated)")
+    p_comp.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_comp.add_argument("--date-range", default="30d", help="Date range (default: 30d)")
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
@@ -2847,41 +2860,41 @@ Examples:
     # ── market-entry (composite: full analysis) ──
     p_me = sub.add_parser("market-entry", help="Full market entry analysis (runs ALL endpoints automatically)", allow_abbrev=False)
     p_me.add_argument("--keyword", help="Product keyword or niche")
-    p_me.add_argument("--category", help="Category path (e.g. 'Sports & Outdoors>Sports Sunglasses')")
+    p_me.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_me.set_defaults(func=cmd_market_entry)
 
     # ── competitor-analysis (composite) ──
     p_ca = sub.add_parser("competitor-analysis", help="Full competitor war room analysis", allow_abbrev=False)
     p_ca.add_argument("--keyword", help="Product keyword to discover competitors")
     p_ca.add_argument("--my-asin", help="Your product ASIN (optional)")
-    p_ca.add_argument("--category", help="Category path")
+    p_ca.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_ca.set_defaults(func=cmd_competitor_analysis)
 
     # ── pricing-analysis (composite) ──
     p_pa = sub.add_parser("pricing-analysis", help="Full pricing analysis with competitor benchmarking", allow_abbrev=False)
     p_pa.add_argument("--my-asin", required=True, help="Your product ASIN")
     p_pa.add_argument("--keyword", help="Product keyword for market context")
-    p_pa.add_argument("--category", help="Category path")
+    p_pa.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pa.set_defaults(func=cmd_pricing_analysis)
 
     # ── daily-radar (composite) ──
     p_dr = sub.add_parser("daily-radar", help="Daily market monitoring scan (runs all tracking endpoints)", allow_abbrev=False)
     p_dr.add_argument("--asins", required=True, help="Tracked ASINs (comma-separated, your products + competitors)")
     p_dr.add_argument("--keyword", help="Category keyword for market monitoring")
-    p_dr.add_argument("--category", help="Category path")
+    p_dr.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_dr.set_defaults(func=cmd_daily_radar)
 
     # ── listing-audit (composite) ──
     p_la = sub.add_parser("listing-audit", help="Full listing audit against category leaders", allow_abbrev=False)
     p_la.add_argument("--my-asin", required=True, help="ASIN to audit")
     p_la.add_argument("--keyword", help="Primary keyword for benchmark context")
-    p_la.add_argument("--category", help="Category path")
+    p_la.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_la.set_defaults(func=cmd_listing_audit)
 
     # ── opportunity-scan (composite) ──
     p_os = sub.add_parser("opportunity-scan", help="Multi-mode product opportunity discovery", allow_abbrev=False)
     p_os.add_argument("--keyword", help="Category keyword to scan")
-    p_os.add_argument("--category", help="Category path")
+    p_os.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_os.add_argument("--modes", help="Scan modes (comma-separated, e.g. emerging,underserved,high-demand-low-barrier). Omit to use custom filters only.")
     p_os.add_argument("--sales-min", type=int, help="Min monthly sales (e.g. 300)")
     p_os.add_argument("--sales-max", type=int, help="Max monthly sales")
@@ -2897,7 +2910,7 @@ Examples:
     p_rd.add_argument("--target-asin", help="ASIN to analyze in depth")
     p_rd.add_argument("--keyword", help="Keyword to find target (if no ASIN)")
     p_rd.add_argument("--comp-asins", help="Competitor ASINs for comparison (comma-separated)")
-    p_rd.add_argument("--category", help="Category path")
+    p_rd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_rd.set_defaults(func=cmd_review_deepdive)
 
     # ── reviews-raw (realtime/reviews with cursor pagination, up to 100 reviews) ──
@@ -2936,7 +2949,7 @@ Examples:
     p_analyze = sub.add_parser("analyze", help="AI-powered review analysis", allow_abbrev=False)
     p_analyze.add_argument("--asin", help="Single ASIN")
     p_analyze.add_argument("--asins", help="Multiple ASINs (comma-separated)")
-    p_analyze.add_argument("--category", help="Category path")
+    p_analyze.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_analyze.add_argument("--label-type", help="Filter dimensions (comma-separated)")
     p_analyze.add_argument("--period", help="Time period: 1m, 3m, 6m, 1y, 2y", default="6m")
     p_analyze.set_defaults(func=cmd_analyze)
@@ -2944,7 +2957,7 @@ Examples:
     # ── price-band-overview ──
     p_pbo = sub.add_parser("price-band-overview", help="Price band overview (hottest & best opportunity)", allow_abbrev=False)
     p_pbo.add_argument("--keyword", help="Search keyword")
-    p_pbo.add_argument("--category", help="Category path")
+    p_pbo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbo.add_argument("--page-size", type=int, default=20)
     p_pbo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbo.set_defaults(func=cmd_price_band_overview)
@@ -2952,7 +2965,7 @@ Examples:
     # ── price-band-detail ──
     p_pbd = sub.add_parser("price-band-detail", help="Price band detailed breakdown", allow_abbrev=False)
     p_pbd.add_argument("--keyword", help="Search keyword")
-    p_pbd.add_argument("--category", help="Category path")
+    p_pbd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_pbd.add_argument("--page-size", type=int, default=20)
     p_pbd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_pbd.set_defaults(func=cmd_price_band_detail)
@@ -2960,7 +2973,7 @@ Examples:
     # ── brand-overview ──
     p_bo = sub.add_parser("brand-overview", help="Brand landscape overview", allow_abbrev=False)
     p_bo.add_argument("--keyword", help="Search keyword")
-    p_bo.add_argument("--category", help="Category path")
+    p_bo.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bo.add_argument("--page-size", type=int, default=20)
     p_bo.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bo.set_defaults(func=cmd_brand_overview)
@@ -2968,7 +2981,7 @@ Examples:
     # ── brand-detail ──
     p_bd = sub.add_parser("brand-detail", help="Brand ranking with per-brand stats", allow_abbrev=False)
     p_bd.add_argument("--keyword", help="Search keyword")
-    p_bd.add_argument("--category", help="Category path")
+    p_bd.add_argument("--category", help="Category path, '>' separated (names may contain commas, e.g. \"Electronics > Headphones, Earbuds & Accessories\"); JSON array also accepted")
     p_bd.add_argument("--page-size", type=int, default=20)
     p_bd.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
     p_bd.set_defaults(func=cmd_brand_detail)


### PR DESCRIPTION
## Scope

One PR because every change feeds a **single ClawHub republish**: the #82 patch-version bumps must ride with all SKILL.md content changes so one fingerprint update covers everything. #82 has been merged into this branch and closed. This is **not docs-only** — it includes a real backend-contract code fix (§4).

## What changed

**1. Mode doc facts (13 not 14)** — dropped 3 phantom modes (`hot-products`/`rising-stars`/`beginner`), added the 2 real omitted ones (`selective-catalog`/`speculative`); 14→13 across READMEs, SKILL.md, execution-guide, 11 reference docs; fixed `--mode competitive_landscape` quick-start.

**2. `mode` is not an API param** — clarified across 10 `reference.md` + `openapi-reference.md`; added canonical Critical API Pitfalls **#9** (mode is CLI-local) and **#10** (CLI flags ≠ API field names, incl. `ratingCountMax` vs `ratingMax` trap + `categoryPath` array); consumer skills reference by one line (On-Missing-Key/401/402 convention).

**3. Correctness — disabled `beginner` mode** — `opportunity-discoverer` invoked the disabled `beginner` mode (silently ran with no filters); replaced with `high-demand-low-barrier`.

**4. Backend-contract 422 fix (CODE)** — cross-repo verification vs hermes-service found preset values the backend rejects via `extra=forbid` Literals → hard **422 on 9/13 modes**: `listingAge "180"/"90"` → `"180d"/"90d"`; `badges ["New Release"]` → `["newRelease"]`. Fixed in canonical `zoodata.py` + synced to 11 copies; argparse help + `openapi-reference.md` enum docs (listingAge, badges, categories `categoryPath` List-not-String) corrected; **new regression test** asserts every preset value is in the backend's allowed set.

**5. #82 folded in** — patch version bump on all 12 skills for republish; keyword-traffic marketing copy; **restored the metadata block #85 accidentally dropped** (openclaw credential contract + version).

**6. Skill quality/standards** — web-extract description trimmed under 1024; 3 market-facing skills got disambiguation clauses to cut mis-routing; **new CI job** validates SKILL.md frontmatter (name/description/metadata) — would have caught the #85 metadata drop.

## After merge
Run `openclaw skills publish` once — a single republish covers all SKILL.md changes.

## Deliberately NOT changed
`keywords/market-profile` "pre-release" caveat kept as-is: the endpoint is mounted on production, but the team still treats it as pre-release (verify-live-surface framing preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)