### PR TITLE
feat(security): Capabilities & Data Flow declarations + CLI hardening (SkillSpector audit response)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added — Security-audit response: Capabilities & Data Flow declarations (all 12 skills)
+
+ClawHub's SkillSpector audit flagged an under-declared capability surface (env-only metadata vs actual network/execution/file behavior) and missing data-flow transparency. Every SKILL.md now carries a standardized "Capabilities & Data Flow" section declaring: exact network host, the bundled shared CLI and which subcommands the skill's workflows use, local files written, what is/isn't sent to the API (user profile text never leaves the machine — it maps client-side to numeric filters), and a credit-cost confirmation rule for broad requests.
+
+### Changed — CLI hardening
+- `ZOODATA_BASE_URL` pointing at a non-zoodata.ai / non-localhost host now prints a Bearer-token warning before any request.
+- Missing-key hint now recommends the environment variable first; the `~/.zoodata/config.json` home config is listed as the persistent alternative.
+- Patch version bump on all 12 skills for ClawHub republish.
+
+
 ### Changed — amazon-keyword-traffic-analysis marketing copy
 
 `description` rewritten to lead with value hooks — ABA-backed data, Priority/Selective/Observe/Exclude test tiers, bid-worthiness verdicts, reverse-ASIN traffic terms — while preserving every trigger phrase for agent routing. Skill README restructured to lead with outcomes and example prompts; agent implementation details (draft MCP tool names, tool-selection rules) moved to a trailing "Agent Implementation Notes" section; data-boundary disclaimers consolidated under "Data Source & Boundaries". No workflow or endpoint content changed.

--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -13,7 +13,7 @@ description: >
     deliverable in mind
   Uses {skill_base_dir}/scripts/zoodata.py. Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.8"
+  version: "1.1.9"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}
@@ -34,6 +34,14 @@ metadata:
 ## Credential
 
 Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zoodata.ai/en/api-keys). Stored in `{skill_base_dir}/config.json` in skill root.
+
+## Capabilities & Data Flow
+
+- **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `categories`, `market`, `products`, `competitors`, `product`, `analyze`, `report`, `opportunity`, `history`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
+- **Local files**: a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
+- **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
 
 ## Input
 

--- a/amazon-analysis/references/scenarios-composite.md
+++ b/amazon-analysis/references/scenarios-composite.md
@@ -28,7 +28,7 @@
 python3 scripts/zoodata.py categories --keyword "pet toys"
 
 # Step 2: Market conditions
-python3 scripts/zoodata.py market --category "Pet Supplies,Dogs,Toys" --topn 10
+python3 scripts/zoodata.py market --category "Pet Supplies > Dogs > Toys" --topn 10
 
 # Step 3: Run 2-3 modes based on user profile
 # Beginner → beginner + high-demand-low-barrier
@@ -135,10 +135,10 @@ python3 scripts/zoodata.py competitors --keyword "wireless earbuds" --page-size 
 python3 scripts/zoodata.py categories --keyword "yoga mat"
 
 # Step 2: Market aggregate
-python3 scripts/zoodata.py market --category "Sports & Outdoors,Exercise & Fitness,Yoga,Yoga Mats" --topn 10
+python3 scripts/zoodata.py market --category "Sports & Outdoors > Exercise & Fitness > Yoga > Yoga Mats" --topn 10
 
 # Step 3: Product landscape
-python3 scripts/zoodata.py products --keyword "yoga mat" --category "Sports & Outdoors,Exercise & Fitness,Yoga,Yoga Mats" --page-size 30
+python3 scripts/zoodata.py products --keyword "yoga mat" --category "Sports & Outdoors > Exercise & Fitness > Yoga > Yoga Mats" --page-size 30
 
 # Step 4: Price band analysis
 python3 scripts/zoodata.py price-band-overview --keyword "yoga mat"
@@ -155,7 +155,7 @@ python3 scripts/zoodata.py product --asin B09XXXXX
 python3 scripts/zoodata.py history --asin B09XXXXX --period 90d
 
 # Step 8: Consumer insights
-python3 scripts/zoodata.py analyze --category "Sports & Outdoors,Exercise & Fitness,Yoga,Yoga Mats" --period 90d
+python3 scripts/zoodata.py analyze --category "Sports & Outdoors > Exercise & Fitness > Yoga > Yoga Mats" --period 90d
 ```
 
 **Cross-validation checks:**

--- a/amazon-analysis/references/scenarios-eval.md
+++ b/amazon-analysis/references/scenarios-eval.md
@@ -177,7 +177,7 @@ python3 scripts/zoodata.py competitors --asin B09XXXXX
 > Trigger: "category pain points" / "what do users want" / "consumer portrait" / "category user analysis" / "who is buying"
 
 ```bash
-python3 scripts/zoodata.py analyze --category "Pet Supplies,Dogs,Toys" --period 90d
+python3 scripts/zoodata.py analyze --category "Pet Supplies > Dogs > Toys" --period 90d
 ```
 
 **Use case:** Understand the consumer landscape of a category **before** product selection. Not about specific ASINs, but about what users in this category care about, complain about, and value.

--- a/amazon-analysis/references/scenarios-expand.md
+++ b/amazon-analysis/references/scenarios-expand.md
@@ -17,7 +17,7 @@
 python3 scripts/zoodata.py categories --parent "Pet Supplies,Dogs"
 
 # Step 2: Evaluate each
-python3 scripts/zoodata.py market --category "Pet Supplies,Dogs,Feeding & Watering" --topn 10
+python3 scripts/zoodata.py market --category "Pet Supplies > Dogs > Feeding & Watering" --topn 10
 ```
 
 ---
@@ -33,7 +33,7 @@ python3 scripts/zoodata.py market --keyword "new category keyword" --topn 10
 ## 7.3 Trend Discovery
 
 ```bash
-python3 scripts/zoodata.py products --keyword "pet supplies" --growth-min 0.2 --listing-age 180 --page-size 20
+python3 scripts/zoodata.py products --keyword "pet supplies" --growth-min 0.2 --listing-age 180d --page-size 20
 ```
 
 ---

--- a/amazon-analysis/references/scenarios-ops.md
+++ b/amazon-analysis/references/scenarios-ops.md
@@ -14,10 +14,10 @@
 
 ```bash
 # Step 1: Market overview
-python3 scripts/zoodata.py market --category "Pet Supplies,Dogs" --topn 10
+python3 scripts/zoodata.py market --category "Pet Supplies > Dogs" --topn 10
 
 # Step 2: New products in last 90 days
-python3 scripts/zoodata.py products --keyword "dog toys" --listing-age 90 --page-size 20
+python3 scripts/zoodata.py products --keyword "dog toys" --listing-age 90d --page-size 20
 ```
 
 ---
@@ -33,7 +33,7 @@ python3 scripts/zoodata.py competitors --brand "CompetitorBrand" --sort listingD
 ## 6.3 Top Products Changes
 
 ```bash
-python3 scripts/zoodata.py products --category "Pet Supplies,Dogs,Toys" --page-size 20
+python3 scripts/zoodata.py products --category "Pet Supplies > Dogs > Toys" --page-size 20
 ```
 
 ---
@@ -42,13 +42,13 @@ python3 scripts/zoodata.py products --category "Pet Supplies,Dogs,Toys" --page-s
 
 ```bash
 # Step 1: Market indicators
-python3 scripts/zoodata.py market --category "Pet Supplies,Dogs,Toys" --topn 10
+python3 scripts/zoodata.py market --category "Pet Supplies > Dogs > Toys" --topn 10
 
 # Step 2: Current top products
-python3 scripts/zoodata.py products --category "Pet Supplies,Dogs,Toys" --page-size 20
+python3 scripts/zoodata.py products --category "Pet Supplies > Dogs > Toys" --page-size 20
 
 # Step 3: High-growth new products (potential threats)
-python3 scripts/zoodata.py products --category "Pet Supplies,Dogs,Toys" --listing-age 90 --growth-min 0.2 --page-size 10
+python3 scripts/zoodata.py products --category "Pet Supplies > Dogs > Toys" --listing-age 90d --growth-min 0.2 --page-size 10
 ```
 
 **Alert Signal Detection**:

--- a/amazon-analysis/references/scenarios-pricing.md
+++ b/amazon-analysis/references/scenarios-pricing.md
@@ -12,7 +12,7 @@
 
 ```bash
 # Step 1: Category pricing
-python3 scripts/zoodata.py market --category "Electronics,Headphones" --topn 10
+python3 scripts/zoodata.py market --category "Electronics > Headphones" --topn 10
 
 # Step 2: Top 50 price distribution
 python3 scripts/zoodata.py products --keyword "wireless earbuds" --page-size 50

--- a/amazon-analysis/scripts/zoodata.py
+++ b/amazon-analysis/scripts/zoodata.py
@@ -2802,7 +2802,7 @@ def main():
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
-  %(prog)s market --category "Pet Supplies,Dogs" --topn 10
+  %(prog)s market --category "Pet Supplies > Dogs" --topn 10
   %(prog)s products --keyword "yoga mat" --mode emerging
   %(prog)s products --keyword "yoga mat" --sales-min 300 --ratings-max 50
   %(prog)s competitors --keyword "wireless earbuds" --brand Anker
@@ -2835,7 +2835,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_mkt.add_argument("--sort", choices=['totalSkuCount', 'sampleSkuCount', 'sampleAvgPrice', 'sampleAvgMonthlySales', 'sampleAvgMonthlyRevenue', 'sampleTotalMonthlySales', 'sampleAvgBsr', 'sampleAvgRating', 'sampleAvgRatingCount', 'sampleBrandCount', 'sampleSellerCount', 'sampleFbaRate', 'sampleNewSkuRate', 'topAvgMonthlySales', 'topAvgMonthlyRevenue', 'topSalesRate', 'topBrandSalesRate', 'topSellerSalesRate'], metavar="FIELD", help="Sort field (markets enum), e.g. sampleAvgMonthlySales, topBrandSalesRate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2860,7 +2860,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_prod.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2874,7 +2874,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_comp.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-analysis/scripts/zoodata.py
+++ b/amazon-analysis/scripts/zoodata.py
@@ -54,6 +54,16 @@ KEYWORD_TIMELINE_MAX_DAYS = 61
 def _resolve_base_url():
     """Resolve API base URL, allowing local test hosts via ZOODATA_BASE_URL."""
     configured = os.environ.get("ZOODATA_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/")
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(configured if "://" in configured else f"https://{configured}").hostname or ""
+    except Exception:
+        host = ""
+    trusted = host == "zoodata.ai" or host.endswith(".zoodata.ai") or host in ("localhost", "127.0.0.1")
+    if configured.rstrip("/") != DEFAULT_BASE_URL.rstrip("/") and not trusted:
+        print(f"WARNING: ZOODATA_BASE_URL points at non-default host '{host}'. "
+              "Your API key will be sent there as a Bearer token — only proceed if you trust this host.",
+              file=sys.stderr)
     if configured.endswith(API_BASE_PATH):
         return configured
     return f"{configured}{API_BASE_PATH}"
@@ -142,12 +152,12 @@ def get_api_key():
     print("", file=sys.stderr)
     print("Please configure your API Key using one of these methods:", file=sys.stderr)
     print("", file=sys.stderr)
-    print("  Method 1: User-home config (recommended — shared across all skills)", file=sys.stderr)
+    print("  Method 1: Environment variable (recommended — no file written)", file=sys.stderr)
+    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 2: User-home config (persistent, shared across all skills)", file=sys.stderr)
     print("    mkdir -p ~/.zoodata", file=sys.stderr)
     print('    echo \'{"api_key":"hms_live_yourkey"}\' > ~/.zoodata/config.json', file=sys.stderr)
-    print("", file=sys.stderr)
-    print("  Method 2: Environment variable (session only)", file=sys.stderr)
-    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
     print("", file=sys.stderr)
     print("Get a free key at https://zoodata.ai/en/api-keys", file=sys.stderr)
     sys.exit(1)

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -44,7 +44,7 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
 - **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `categories`, `market`, `competitors`, `products`, `product`, `history`, `analyze`, `competitor-analysis`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
 - **Local files**: a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
 - **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
-- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans. The composite `competitor-analysis` command executes ~17+ API calls (Full Scan, ~28-35 credits documented) in ONE invocation and has NO skip/trim flags — under a credit cap, use the granular commands instead.
 
 ## Input
 

--- a/amazon-competitor-intelligence-monitor/SKILL.md
+++ b/amazon-competitor-intelligence-monitor/SKILL.md
@@ -16,7 +16,7 @@ description: >
   3 competitors, ongoing watch on a defined competitor set.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.4"
+  version: "1.1.5"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}
@@ -37,6 +37,14 @@ metadata:
 ## Credential
 
 Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zoodata.ai/en/api-keys).
+
+## Capabilities & Data Flow
+
+- **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `categories`, `market`, `competitors`, `products`, `product`, `history`, `analyze`, `competitor-analysis`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
+- **Local files**: a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
+- **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
 
 ## Input
 

--- a/amazon-competitor-intelligence-monitor/scripts/zoodata.py
+++ b/amazon-competitor-intelligence-monitor/scripts/zoodata.py
@@ -2802,7 +2802,7 @@ def main():
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
-  %(prog)s market --category "Pet Supplies,Dogs" --topn 10
+  %(prog)s market --category "Pet Supplies > Dogs" --topn 10
   %(prog)s products --keyword "yoga mat" --mode emerging
   %(prog)s products --keyword "yoga mat" --sales-min 300 --ratings-max 50
   %(prog)s competitors --keyword "wireless earbuds" --brand Anker
@@ -2835,7 +2835,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_mkt.add_argument("--sort", choices=['totalSkuCount', 'sampleSkuCount', 'sampleAvgPrice', 'sampleAvgMonthlySales', 'sampleAvgMonthlyRevenue', 'sampleTotalMonthlySales', 'sampleAvgBsr', 'sampleAvgRating', 'sampleAvgRatingCount', 'sampleBrandCount', 'sampleSellerCount', 'sampleFbaRate', 'sampleNewSkuRate', 'topAvgMonthlySales', 'topAvgMonthlyRevenue', 'topSalesRate', 'topBrandSalesRate', 'topSellerSalesRate'], metavar="FIELD", help="Sort field (markets enum), e.g. sampleAvgMonthlySales, topBrandSalesRate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2860,7 +2860,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_prod.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2874,7 +2874,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_comp.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-competitor-intelligence-monitor/scripts/zoodata.py
+++ b/amazon-competitor-intelligence-monitor/scripts/zoodata.py
@@ -54,6 +54,16 @@ KEYWORD_TIMELINE_MAX_DAYS = 61
 def _resolve_base_url():
     """Resolve API base URL, allowing local test hosts via ZOODATA_BASE_URL."""
     configured = os.environ.get("ZOODATA_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/")
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(configured if "://" in configured else f"https://{configured}").hostname or ""
+    except Exception:
+        host = ""
+    trusted = host == "zoodata.ai" or host.endswith(".zoodata.ai") or host in ("localhost", "127.0.0.1")
+    if configured.rstrip("/") != DEFAULT_BASE_URL.rstrip("/") and not trusted:
+        print(f"WARNING: ZOODATA_BASE_URL points at non-default host '{host}'. "
+              "Your API key will be sent there as a Bearer token — only proceed if you trust this host.",
+              file=sys.stderr)
     if configured.endswith(API_BASE_PATH):
         return configured
     return f"{configured}{API_BASE_PATH}"
@@ -142,12 +152,12 @@ def get_api_key():
     print("", file=sys.stderr)
     print("Please configure your API Key using one of these methods:", file=sys.stderr)
     print("", file=sys.stderr)
-    print("  Method 1: User-home config (recommended — shared across all skills)", file=sys.stderr)
+    print("  Method 1: Environment variable (recommended — no file written)", file=sys.stderr)
+    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 2: User-home config (persistent, shared across all skills)", file=sys.stderr)
     print("    mkdir -p ~/.zoodata", file=sys.stderr)
     print('    echo \'{"api_key":"hms_live_yourkey"}\' > ~/.zoodata/config.json', file=sys.stderr)
-    print("", file=sys.stderr)
-    print("  Method 2: Environment variable (session only)", file=sys.stderr)
-    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
     print("", file=sys.stderr)
     print("Get a free key at https://zoodata.ai/en/api-keys", file=sys.stderr)
     sys.exit(1)

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -42,10 +42,10 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
 ## Capabilities & Data Flow
 
 - **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
-- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `daily-radar`, `market`, `products`, `competitors`, `product`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `daily-radar`, `market`, `products`, `competitors`, `product`, `price-band-overview`, `history`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
 - **Local files**: baseline snapshots `{skill_base_dir}/data/last-run.json` and `{skill_base_dir}/data/watchlist.json`; a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
 - **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
-- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans. The composite `daily-radar` command executes ~14+ API calls (~15-30 credits) in ONE invocation and has NO skip/trim flags — under a credit cap, use the granular commands instead.
 
 ## Input (First Run)
 

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -17,7 +17,7 @@ description: >
   daily, stockout signals, set-it-and-forget-it market watch.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.4"
+  version: "1.0.5"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}
@@ -38,6 +38,14 @@ metadata:
 ## Credential
 
 Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zoodata.ai/en/api-keys).
+
+## Capabilities & Data Flow
+
+- **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `daily-radar`, `market`, `products`, `competitors`, `product`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
+- **Local files**: baseline snapshots `{skill_base_dir}/data/last-run.json` and `{skill_base_dir}/data/watchlist.json`; a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
+- **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
 
 ## Input (First Run)
 

--- a/amazon-daily-market-radar/scripts/zoodata.py
+++ b/amazon-daily-market-radar/scripts/zoodata.py
@@ -2802,7 +2802,7 @@ def main():
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
-  %(prog)s market --category "Pet Supplies,Dogs" --topn 10
+  %(prog)s market --category "Pet Supplies > Dogs" --topn 10
   %(prog)s products --keyword "yoga mat" --mode emerging
   %(prog)s products --keyword "yoga mat" --sales-min 300 --ratings-max 50
   %(prog)s competitors --keyword "wireless earbuds" --brand Anker
@@ -2835,7 +2835,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_mkt.add_argument("--sort", choices=['totalSkuCount', 'sampleSkuCount', 'sampleAvgPrice', 'sampleAvgMonthlySales', 'sampleAvgMonthlyRevenue', 'sampleTotalMonthlySales', 'sampleAvgBsr', 'sampleAvgRating', 'sampleAvgRatingCount', 'sampleBrandCount', 'sampleSellerCount', 'sampleFbaRate', 'sampleNewSkuRate', 'topAvgMonthlySales', 'topAvgMonthlyRevenue', 'topSalesRate', 'topBrandSalesRate', 'topSellerSalesRate'], metavar="FIELD", help="Sort field (markets enum), e.g. sampleAvgMonthlySales, topBrandSalesRate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2860,7 +2860,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_prod.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2874,7 +2874,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_comp.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-daily-market-radar/scripts/zoodata.py
+++ b/amazon-daily-market-radar/scripts/zoodata.py
@@ -54,6 +54,16 @@ KEYWORD_TIMELINE_MAX_DAYS = 61
 def _resolve_base_url():
     """Resolve API base URL, allowing local test hosts via ZOODATA_BASE_URL."""
     configured = os.environ.get("ZOODATA_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/")
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(configured if "://" in configured else f"https://{configured}").hostname or ""
+    except Exception:
+        host = ""
+    trusted = host == "zoodata.ai" or host.endswith(".zoodata.ai") or host in ("localhost", "127.0.0.1")
+    if configured.rstrip("/") != DEFAULT_BASE_URL.rstrip("/") and not trusted:
+        print(f"WARNING: ZOODATA_BASE_URL points at non-default host '{host}'. "
+              "Your API key will be sent there as a Bearer token — only proceed if you trust this host.",
+              file=sys.stderr)
     if configured.endswith(API_BASE_PATH):
         return configured
     return f"{configured}{API_BASE_PATH}"
@@ -142,12 +152,12 @@ def get_api_key():
     print("", file=sys.stderr)
     print("Please configure your API Key using one of these methods:", file=sys.stderr)
     print("", file=sys.stderr)
-    print("  Method 1: User-home config (recommended — shared across all skills)", file=sys.stderr)
+    print("  Method 1: Environment variable (recommended — no file written)", file=sys.stderr)
+    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 2: User-home config (persistent, shared across all skills)", file=sys.stderr)
     print("    mkdir -p ~/.zoodata", file=sys.stderr)
     print('    echo \'{"api_key":"hms_live_yourkey"}\' > ~/.zoodata/config.json', file=sys.stderr)
-    print("", file=sys.stderr)
-    print("  Method 2: Environment variable (session only)", file=sys.stderr)
-    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
     print("", file=sys.stderr)
     print("Get a free key at https://zoodata.ai/en/api-keys", file=sys.stderr)
     sys.exit(1)

--- a/amazon-keyword-traffic-analysis/SKILL.md
+++ b/amazon-keyword-traffic-analysis/SKILL.md
@@ -7,7 +7,7 @@ description: >
   batch keyword snapshot, multidimensional market profile, trend, and ASIN-keyword timeline
   workflows. Requires ZOODATA_API_KEY.
 metadata:
-  version: "0.1.2"
+  version: "0.1.3"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}
@@ -31,6 +31,14 @@ metadata:
 ## Credential
 
 Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zoodata.ai/en/api-keys).
+
+## Capabilities & Data Flow
+
+- **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `keyword-detail`, `keyword-market-profile`, `keyword-trend`, `keyword-trend-profile`, `keyword-extends`, `keyword-search-results`, `keyword-competitor-product-keywords`, `keyword-product-traffic-terms`, `product-traffic-terms-overview`, `product-traffic-terms-timeline`, `check`. Do not invoke unrelated subcommands for this skill's tasks.
+- **Local files**: none; reads the optional credential store `~/.zoodata/config.json`.
+- **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
 
 ## Input
 

--- a/amazon-keyword-traffic-analysis/scripts/zoodata.py
+++ b/amazon-keyword-traffic-analysis/scripts/zoodata.py
@@ -2802,7 +2802,7 @@ def main():
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
-  %(prog)s market --category "Pet Supplies,Dogs" --topn 10
+  %(prog)s market --category "Pet Supplies > Dogs" --topn 10
   %(prog)s products --keyword "yoga mat" --mode emerging
   %(prog)s products --keyword "yoga mat" --sales-min 300 --ratings-max 50
   %(prog)s competitors --keyword "wireless earbuds" --brand Anker
@@ -2835,7 +2835,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_mkt.add_argument("--sort", choices=['totalSkuCount', 'sampleSkuCount', 'sampleAvgPrice', 'sampleAvgMonthlySales', 'sampleAvgMonthlyRevenue', 'sampleTotalMonthlySales', 'sampleAvgBsr', 'sampleAvgRating', 'sampleAvgRatingCount', 'sampleBrandCount', 'sampleSellerCount', 'sampleFbaRate', 'sampleNewSkuRate', 'topAvgMonthlySales', 'topAvgMonthlyRevenue', 'topSalesRate', 'topBrandSalesRate', 'topSellerSalesRate'], metavar="FIELD", help="Sort field (markets enum), e.g. sampleAvgMonthlySales, topBrandSalesRate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2860,7 +2860,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_prod.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2874,7 +2874,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_comp.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-keyword-traffic-analysis/scripts/zoodata.py
+++ b/amazon-keyword-traffic-analysis/scripts/zoodata.py
@@ -54,6 +54,16 @@ KEYWORD_TIMELINE_MAX_DAYS = 61
 def _resolve_base_url():
     """Resolve API base URL, allowing local test hosts via ZOODATA_BASE_URL."""
     configured = os.environ.get("ZOODATA_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/")
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(configured if "://" in configured else f"https://{configured}").hostname or ""
+    except Exception:
+        host = ""
+    trusted = host == "zoodata.ai" or host.endswith(".zoodata.ai") or host in ("localhost", "127.0.0.1")
+    if configured.rstrip("/") != DEFAULT_BASE_URL.rstrip("/") and not trusted:
+        print(f"WARNING: ZOODATA_BASE_URL points at non-default host '{host}'. "
+              "Your API key will be sent there as a Bearer token — only proceed if you trust this host.",
+              file=sys.stderr)
     if configured.endswith(API_BASE_PATH):
         return configured
     return f"{configured}{API_BASE_PATH}"
@@ -142,12 +152,12 @@ def get_api_key():
     print("", file=sys.stderr)
     print("Please configure your API Key using one of these methods:", file=sys.stderr)
     print("", file=sys.stderr)
-    print("  Method 1: User-home config (recommended — shared across all skills)", file=sys.stderr)
+    print("  Method 1: Environment variable (recommended — no file written)", file=sys.stderr)
+    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 2: User-home config (persistent, shared across all skills)", file=sys.stderr)
     print("    mkdir -p ~/.zoodata", file=sys.stderr)
     print('    echo \'{"api_key":"hms_live_yourkey"}\' > ~/.zoodata/config.json', file=sys.stderr)
-    print("", file=sys.stderr)
-    print("  Method 2: Environment variable (session only)", file=sys.stderr)
-    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
     print("", file=sys.stderr)
     print("Get a free key at https://zoodata.ai/en/api-keys", file=sys.stderr)
     sys.exit(1)

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -12,7 +12,7 @@ description: >
   A+ content, listing health check, listing comparison.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.4"
+  version: "1.0.5"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}
@@ -32,6 +32,14 @@ metadata:
 ## Credential
 
 Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zoodata.ai/en/api-keys).
+
+## Capabilities & Data Flow
+
+- **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `listing-audit`, `product`, `products`, `market`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
+- **Local files**: a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
+- **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
 
 ## Input
 

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -39,7 +39,7 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
 - **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `listing-audit`, `product`, `products`, `market`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
 - **Local files**: a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
 - **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
-- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans. The composite `listing-audit` command executes ~18 API calls (~15-20 credits) in ONE invocation and has NO skip/trim flags — under a credit cap, use the granular commands instead.
 
 ## Input
 

--- a/amazon-listing-audit-pro/scripts/zoodata.py
+++ b/amazon-listing-audit-pro/scripts/zoodata.py
@@ -2802,7 +2802,7 @@ def main():
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
-  %(prog)s market --category "Pet Supplies,Dogs" --topn 10
+  %(prog)s market --category "Pet Supplies > Dogs" --topn 10
   %(prog)s products --keyword "yoga mat" --mode emerging
   %(prog)s products --keyword "yoga mat" --sales-min 300 --ratings-max 50
   %(prog)s competitors --keyword "wireless earbuds" --brand Anker
@@ -2835,7 +2835,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_mkt.add_argument("--sort", choices=['totalSkuCount', 'sampleSkuCount', 'sampleAvgPrice', 'sampleAvgMonthlySales', 'sampleAvgMonthlyRevenue', 'sampleTotalMonthlySales', 'sampleAvgBsr', 'sampleAvgRating', 'sampleAvgRatingCount', 'sampleBrandCount', 'sampleSellerCount', 'sampleFbaRate', 'sampleNewSkuRate', 'topAvgMonthlySales', 'topAvgMonthlyRevenue', 'topSalesRate', 'topBrandSalesRate', 'topSellerSalesRate'], metavar="FIELD", help="Sort field (markets enum), e.g. sampleAvgMonthlySales, topBrandSalesRate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2860,7 +2860,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_prod.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2874,7 +2874,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_comp.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-listing-audit-pro/scripts/zoodata.py
+++ b/amazon-listing-audit-pro/scripts/zoodata.py
@@ -54,6 +54,16 @@ KEYWORD_TIMELINE_MAX_DAYS = 61
 def _resolve_base_url():
     """Resolve API base URL, allowing local test hosts via ZOODATA_BASE_URL."""
     configured = os.environ.get("ZOODATA_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/")
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(configured if "://" in configured else f"https://{configured}").hostname or ""
+    except Exception:
+        host = ""
+    trusted = host == "zoodata.ai" or host.endswith(".zoodata.ai") or host in ("localhost", "127.0.0.1")
+    if configured.rstrip("/") != DEFAULT_BASE_URL.rstrip("/") and not trusted:
+        print(f"WARNING: ZOODATA_BASE_URL points at non-default host '{host}'. "
+              "Your API key will be sent there as a Bearer token — only proceed if you trust this host.",
+              file=sys.stderr)
     if configured.endswith(API_BASE_PATH):
         return configured
     return f"{configured}{API_BASE_PATH}"
@@ -142,12 +152,12 @@ def get_api_key():
     print("", file=sys.stderr)
     print("Please configure your API Key using one of these methods:", file=sys.stderr)
     print("", file=sys.stderr)
-    print("  Method 1: User-home config (recommended — shared across all skills)", file=sys.stderr)
+    print("  Method 1: Environment variable (recommended — no file written)", file=sys.stderr)
+    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 2: User-home config (persistent, shared across all skills)", file=sys.stderr)
     print("    mkdir -p ~/.zoodata", file=sys.stderr)
     print('    echo \'{"api_key":"hms_live_yourkey"}\' > ~/.zoodata/config.json', file=sys.stderr)
-    print("", file=sys.stderr)
-    print("  Method 2: Environment variable (session only)", file=sys.stderr)
-    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
     print("", file=sys.stderr)
     print("Get a free key at https://zoodata.ai/en/api-keys", file=sys.stderr)
     sys.exit(1)

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -36,7 +36,7 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
 - **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `market-entry`, `categories`, `market`, `competitors`, `product`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
 - **Local files**: a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
 - **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
-- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans. The composite `market-entry` command executes ~17+ API calls (~15-25 credits) in ONE invocation and has NO skip/trim flags — under a credit cap, use the granular commands instead.
 
 ## Input
 - **Required**: keyword or categoryPath

--- a/amazon-market-entry-analyzer/SKILL.md
+++ b/amazon-market-entry-analyzer/SKILL.md
@@ -13,7 +13,7 @@ description: >
   to track how categories shift over time, use amazon-market-trend-scanner.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.4"
+  version: "1.0.5"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}
@@ -29,6 +29,14 @@ One input (keyword/category). Full market viability assessment with sub-market d
 
 ## Credential
 Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zoodata.ai/en/api-keys)
+
+## Capabilities & Data Flow
+
+- **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `market-entry`, `categories`, `market`, `competitors`, `product`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
+- **Local files**: a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
+- **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
 
 ## Input
 - **Required**: keyword or categoryPath

--- a/amazon-market-entry-analyzer/scripts/zoodata.py
+++ b/amazon-market-entry-analyzer/scripts/zoodata.py
@@ -2802,7 +2802,7 @@ def main():
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
-  %(prog)s market --category "Pet Supplies,Dogs" --topn 10
+  %(prog)s market --category "Pet Supplies > Dogs" --topn 10
   %(prog)s products --keyword "yoga mat" --mode emerging
   %(prog)s products --keyword "yoga mat" --sales-min 300 --ratings-max 50
   %(prog)s competitors --keyword "wireless earbuds" --brand Anker
@@ -2835,7 +2835,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_mkt.add_argument("--sort", choices=['totalSkuCount', 'sampleSkuCount', 'sampleAvgPrice', 'sampleAvgMonthlySales', 'sampleAvgMonthlyRevenue', 'sampleTotalMonthlySales', 'sampleAvgBsr', 'sampleAvgRating', 'sampleAvgRatingCount', 'sampleBrandCount', 'sampleSellerCount', 'sampleFbaRate', 'sampleNewSkuRate', 'topAvgMonthlySales', 'topAvgMonthlyRevenue', 'topSalesRate', 'topBrandSalesRate', 'topSellerSalesRate'], metavar="FIELD", help="Sort field (markets enum), e.g. sampleAvgMonthlySales, topBrandSalesRate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2860,7 +2860,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_prod.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2874,7 +2874,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_comp.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-market-entry-analyzer/scripts/zoodata.py
+++ b/amazon-market-entry-analyzer/scripts/zoodata.py
@@ -54,6 +54,16 @@ KEYWORD_TIMELINE_MAX_DAYS = 61
 def _resolve_base_url():
     """Resolve API base URL, allowing local test hosts via ZOODATA_BASE_URL."""
     configured = os.environ.get("ZOODATA_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/")
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(configured if "://" in configured else f"https://{configured}").hostname or ""
+    except Exception:
+        host = ""
+    trusted = host == "zoodata.ai" or host.endswith(".zoodata.ai") or host in ("localhost", "127.0.0.1")
+    if configured.rstrip("/") != DEFAULT_BASE_URL.rstrip("/") and not trusted:
+        print(f"WARNING: ZOODATA_BASE_URL points at non-default host '{host}'. "
+              "Your API key will be sent there as a Bearer token — only proceed if you trust this host.",
+              file=sys.stderr)
     if configured.endswith(API_BASE_PATH):
         return configured
     return f"{configured}{API_BASE_PATH}"
@@ -142,12 +152,12 @@ def get_api_key():
     print("", file=sys.stderr)
     print("Please configure your API Key using one of these methods:", file=sys.stderr)
     print("", file=sys.stderr)
-    print("  Method 1: User-home config (recommended — shared across all skills)", file=sys.stderr)
+    print("  Method 1: Environment variable (recommended — no file written)", file=sys.stderr)
+    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 2: User-home config (persistent, shared across all skills)", file=sys.stderr)
     print("    mkdir -p ~/.zoodata", file=sys.stderr)
     print('    echo \'{"api_key":"hms_live_yourkey"}\' > ~/.zoodata/config.json', file=sys.stderr)
-    print("", file=sys.stderr)
-    print("  Method 2: Environment variable (session only)", file=sys.stderr)
-    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
     print("", file=sys.stderr)
     print("Get a free key at https://zoodata.ai/en/api-keys", file=sys.stderr)
     sys.exit(1)

--- a/amazon-market-trend-scanner/SKILL.md
+++ b/amazon-market-trend-scanner/SKILL.md
@@ -13,7 +13,7 @@ description: >
   to sell, use amazon-opportunity-discoverer.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.3"
+  version: "1.0.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}
@@ -34,6 +34,14 @@ metadata:
 ## Credential
 
 Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zoodata.ai/en/api-keys).
+
+## Capabilities & Data Flow
+
+- **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `categories`, `market`, `products`, `check`. Do not invoke unrelated subcommands for this skill's tasks.
+- **Local files**: scan state under `{skill_base_dir}/scan-data/` (`baseline.json`, `watchlist.json`, `history/*.json`); reads the optional credential store `~/.zoodata/config.json`.
+- **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
 
 ## Input
 

--- a/amazon-market-trend-scanner/scripts/zoodata.py
+++ b/amazon-market-trend-scanner/scripts/zoodata.py
@@ -2802,7 +2802,7 @@ def main():
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
-  %(prog)s market --category "Pet Supplies,Dogs" --topn 10
+  %(prog)s market --category "Pet Supplies > Dogs" --topn 10
   %(prog)s products --keyword "yoga mat" --mode emerging
   %(prog)s products --keyword "yoga mat" --sales-min 300 --ratings-max 50
   %(prog)s competitors --keyword "wireless earbuds" --brand Anker
@@ -2835,7 +2835,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_mkt.add_argument("--sort", choices=['totalSkuCount', 'sampleSkuCount', 'sampleAvgPrice', 'sampleAvgMonthlySales', 'sampleAvgMonthlyRevenue', 'sampleTotalMonthlySales', 'sampleAvgBsr', 'sampleAvgRating', 'sampleAvgRatingCount', 'sampleBrandCount', 'sampleSellerCount', 'sampleFbaRate', 'sampleNewSkuRate', 'topAvgMonthlySales', 'topAvgMonthlyRevenue', 'topSalesRate', 'topBrandSalesRate', 'topSellerSalesRate'], metavar="FIELD", help="Sort field (markets enum), e.g. sampleAvgMonthlySales, topBrandSalesRate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2860,7 +2860,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_prod.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2874,7 +2874,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_comp.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-market-trend-scanner/scripts/zoodata.py
+++ b/amazon-market-trend-scanner/scripts/zoodata.py
@@ -54,6 +54,16 @@ KEYWORD_TIMELINE_MAX_DAYS = 61
 def _resolve_base_url():
     """Resolve API base URL, allowing local test hosts via ZOODATA_BASE_URL."""
     configured = os.environ.get("ZOODATA_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/")
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(configured if "://" in configured else f"https://{configured}").hostname or ""
+    except Exception:
+        host = ""
+    trusted = host == "zoodata.ai" or host.endswith(".zoodata.ai") or host in ("localhost", "127.0.0.1")
+    if configured.rstrip("/") != DEFAULT_BASE_URL.rstrip("/") and not trusted:
+        print(f"WARNING: ZOODATA_BASE_URL points at non-default host '{host}'. "
+              "Your API key will be sent there as a Bearer token — only proceed if you trust this host.",
+              file=sys.stderr)
     if configured.endswith(API_BASE_PATH):
         return configured
     return f"{configured}{API_BASE_PATH}"
@@ -142,12 +152,12 @@ def get_api_key():
     print("", file=sys.stderr)
     print("Please configure your API Key using one of these methods:", file=sys.stderr)
     print("", file=sys.stderr)
-    print("  Method 1: User-home config (recommended — shared across all skills)", file=sys.stderr)
+    print("  Method 1: Environment variable (recommended — no file written)", file=sys.stderr)
+    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 2: User-home config (persistent, shared across all skills)", file=sys.stderr)
     print("    mkdir -p ~/.zoodata", file=sys.stderr)
     print('    echo \'{"api_key":"hms_live_yourkey"}\' > ~/.zoodata/config.json', file=sys.stderr)
-    print("", file=sys.stderr)
-    print("  Method 2: Environment variable (session only)", file=sys.stderr)
-    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
     print("", file=sys.stderr)
     print("Get a free key at https://zoodata.ai/en/api-keys", file=sys.stderr)
     sys.exit(1)

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -36,7 +36,7 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
 - **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `opportunity-scan`, `categories`, `market`, `products`, `product`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
 - **Local files**: a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
 - **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
-- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans. The composite `opportunity-scan` command executes ~15+ API calls across up to 9 loops (~25-30 credits observed) in ONE invocation and has NO skip/trim flags — under a credit cap, use the granular commands instead.
 
 ## Input
 - **Required**: keyword or category + budget (Low/Med/High) + experience (Beginner/Intermediate/Advanced)

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -13,7 +13,7 @@ description: >
   category trends over time, use amazon-market-trend-scanner.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.4"
+  version: "1.0.5"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}
@@ -29,6 +29,14 @@ Tell me your budget and experience. I find opportunities, score them, and rank.
 
 ## Credential
 Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zoodata.ai/en/api-keys)
+
+## Capabilities & Data Flow
+
+- **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `opportunity-scan`, `categories`, `market`, `products`, `product`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
+- **Local files**: a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
+- **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
 
 ## Input
 - **Required**: keyword or category + budget (Low/Med/High) + experience (Beginner/Intermediate/Advanced)

--- a/amazon-opportunity-discoverer/scripts/zoodata.py
+++ b/amazon-opportunity-discoverer/scripts/zoodata.py
@@ -2802,7 +2802,7 @@ def main():
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
-  %(prog)s market --category "Pet Supplies,Dogs" --topn 10
+  %(prog)s market --category "Pet Supplies > Dogs" --topn 10
   %(prog)s products --keyword "yoga mat" --mode emerging
   %(prog)s products --keyword "yoga mat" --sales-min 300 --ratings-max 50
   %(prog)s competitors --keyword "wireless earbuds" --brand Anker
@@ -2835,7 +2835,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_mkt.add_argument("--sort", choices=['totalSkuCount', 'sampleSkuCount', 'sampleAvgPrice', 'sampleAvgMonthlySales', 'sampleAvgMonthlyRevenue', 'sampleTotalMonthlySales', 'sampleAvgBsr', 'sampleAvgRating', 'sampleAvgRatingCount', 'sampleBrandCount', 'sampleSellerCount', 'sampleFbaRate', 'sampleNewSkuRate', 'topAvgMonthlySales', 'topAvgMonthlyRevenue', 'topSalesRate', 'topBrandSalesRate', 'topSellerSalesRate'], metavar="FIELD", help="Sort field (markets enum), e.g. sampleAvgMonthlySales, topBrandSalesRate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2860,7 +2860,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_prod.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2874,7 +2874,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_comp.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-opportunity-discoverer/scripts/zoodata.py
+++ b/amazon-opportunity-discoverer/scripts/zoodata.py
@@ -54,6 +54,16 @@ KEYWORD_TIMELINE_MAX_DAYS = 61
 def _resolve_base_url():
     """Resolve API base URL, allowing local test hosts via ZOODATA_BASE_URL."""
     configured = os.environ.get("ZOODATA_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/")
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(configured if "://" in configured else f"https://{configured}").hostname or ""
+    except Exception:
+        host = ""
+    trusted = host == "zoodata.ai" or host.endswith(".zoodata.ai") or host in ("localhost", "127.0.0.1")
+    if configured.rstrip("/") != DEFAULT_BASE_URL.rstrip("/") and not trusted:
+        print(f"WARNING: ZOODATA_BASE_URL points at non-default host '{host}'. "
+              "Your API key will be sent there as a Bearer token — only proceed if you trust this host.",
+              file=sys.stderr)
     if configured.endswith(API_BASE_PATH):
         return configured
     return f"{configured}{API_BASE_PATH}"
@@ -142,12 +152,12 @@ def get_api_key():
     print("", file=sys.stderr)
     print("Please configure your API Key using one of these methods:", file=sys.stderr)
     print("", file=sys.stderr)
-    print("  Method 1: User-home config (recommended — shared across all skills)", file=sys.stderr)
+    print("  Method 1: Environment variable (recommended — no file written)", file=sys.stderr)
+    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 2: User-home config (persistent, shared across all skills)", file=sys.stderr)
     print("    mkdir -p ~/.zoodata", file=sys.stderr)
     print('    echo \'{"api_key":"hms_live_yourkey"}\' > ~/.zoodata/config.json', file=sys.stderr)
-    print("", file=sys.stderr)
-    print("  Method 2: Environment variable (session only)", file=sys.stderr)
-    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
     print("", file=sys.stderr)
     print("Get a free key at https://zoodata.ai/en/api-keys", file=sys.stderr)
     sys.exit(1)

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -12,7 +12,7 @@ description: >
   price comparison, price positioning, repricing, should I raise or lower price.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.3"
+  version: "1.1.4"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}
@@ -28,6 +28,14 @@ Give me your ASIN(s). I'll tell you whether to raise, hold, or lower — with da
 
 ## Credential
 Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zoodata.ai/en/api-keys)
+
+## Capabilities & Data Flow
+
+- **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `categories`, `product`, `products`, `competitors`, `market`, `price-band-overview`, `price-band-detail`, `history`, `analyze`, `check`. Do not invoke unrelated subcommands for this skill's tasks.
+- **Local files**: none; reads the optional credential store `~/.zoodata/config.json`.
+- **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
 
 ## Input
 - **Required**: one or more ASINs (your products). No keyword needed — category is auto-detected.

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -35,7 +35,7 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
 - **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `categories`, `product`, `products`, `competitors`, `market`, `price-band-overview`, `price-band-detail`, `history`, `analyze`, `check`. Do not invoke unrelated subcommands for this skill's tasks.
 - **Local files**: none; reads the optional credential store `~/.zoodata/config.json`.
 - **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
-- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans. The composite `pricing-analysis` command executes ~20 API calls (~15-25 credits) in ONE invocation and has NO skip/trim flags — under a credit cap, use the granular commands instead.
 
 ## Input
 - **Required**: one or more ASINs (your products). No keyword needed — category is auto-detected.

--- a/amazon-pricing-command-center/SKILL.md
+++ b/amazon-pricing-command-center/SKILL.md
@@ -32,10 +32,10 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
 ## Capabilities & Data Flow
 
 - **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
-- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `categories`, `product`, `products`, `competitors`, `market`, `price-band-overview`, `price-band-detail`, `history`, `analyze`, `check`. Do not invoke unrelated subcommands for this skill's tasks.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `categories`, `product`, `products`, `competitors`, `market`, `price-band-overview`, `price-band-detail`, `brand-overview`, `brand-detail`, `history`, `analyze`, `check`. Do not invoke unrelated subcommands for this skill's tasks.
 - **Local files**: none; reads the optional credential store `~/.zoodata/config.json`.
 - **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
-- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans. The composite `pricing-analysis` command executes ~20 API calls (~15-25 credits) in ONE invocation and has NO skip/trim flags — under a credit cap, use the granular commands instead.
+- **Credits**: every API call consumes account credits. This skill drives the endpoints granularly (no single composite command); a per-ASIN pricing analysis orchestrates ~11 endpoints for ~20-25 credits, and batch runs scale by unique category (see API Budget below). For batch or broad requests, state the estimated credit cost and confirm with the user before running.
 
 ## Input
 - **Required**: one or more ASINs (your products). No keyword needed — category is auto-detected.

--- a/amazon-pricing-command-center/scripts/zoodata.py
+++ b/amazon-pricing-command-center/scripts/zoodata.py
@@ -2802,7 +2802,7 @@ def main():
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
-  %(prog)s market --category "Pet Supplies,Dogs" --topn 10
+  %(prog)s market --category "Pet Supplies > Dogs" --topn 10
   %(prog)s products --keyword "yoga mat" --mode emerging
   %(prog)s products --keyword "yoga mat" --sales-min 300 --ratings-max 50
   %(prog)s competitors --keyword "wireless earbuds" --brand Anker
@@ -2835,7 +2835,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_mkt.add_argument("--sort", choices=['totalSkuCount', 'sampleSkuCount', 'sampleAvgPrice', 'sampleAvgMonthlySales', 'sampleAvgMonthlyRevenue', 'sampleTotalMonthlySales', 'sampleAvgBsr', 'sampleAvgRating', 'sampleAvgRatingCount', 'sampleBrandCount', 'sampleSellerCount', 'sampleFbaRate', 'sampleNewSkuRate', 'topAvgMonthlySales', 'topAvgMonthlyRevenue', 'topSalesRate', 'topBrandSalesRate', 'topSellerSalesRate'], metavar="FIELD", help="Sort field (markets enum), e.g. sampleAvgMonthlySales, topBrandSalesRate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2860,7 +2860,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_prod.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2874,7 +2874,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_comp.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-pricing-command-center/scripts/zoodata.py
+++ b/amazon-pricing-command-center/scripts/zoodata.py
@@ -54,6 +54,16 @@ KEYWORD_TIMELINE_MAX_DAYS = 61
 def _resolve_base_url():
     """Resolve API base URL, allowing local test hosts via ZOODATA_BASE_URL."""
     configured = os.environ.get("ZOODATA_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/")
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(configured if "://" in configured else f"https://{configured}").hostname or ""
+    except Exception:
+        host = ""
+    trusted = host == "zoodata.ai" or host.endswith(".zoodata.ai") or host in ("localhost", "127.0.0.1")
+    if configured.rstrip("/") != DEFAULT_BASE_URL.rstrip("/") and not trusted:
+        print(f"WARNING: ZOODATA_BASE_URL points at non-default host '{host}'. "
+              "Your API key will be sent there as a Bearer token — only proceed if you trust this host.",
+              file=sys.stderr)
     if configured.endswith(API_BASE_PATH):
         return configured
     return f"{configured}{API_BASE_PATH}"
@@ -142,12 +152,12 @@ def get_api_key():
     print("", file=sys.stderr)
     print("Please configure your API Key using one of these methods:", file=sys.stderr)
     print("", file=sys.stderr)
-    print("  Method 1: User-home config (recommended — shared across all skills)", file=sys.stderr)
+    print("  Method 1: Environment variable (recommended — no file written)", file=sys.stderr)
+    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 2: User-home config (persistent, shared across all skills)", file=sys.stderr)
     print("    mkdir -p ~/.zoodata", file=sys.stderr)
     print('    echo \'{"api_key":"hms_live_yourkey"}\' > ~/.zoodata/config.json', file=sys.stderr)
-    print("", file=sys.stderr)
-    print("  Method 2: Environment variable (session only)", file=sys.stderr)
-    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
     print("", file=sys.stderr)
     print("Get a free key at https://zoodata.ai/en/api-keys", file=sys.stderr)
     sys.exit(1)

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -34,7 +34,7 @@ Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zooda
 - **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `analyze`, `review-deepdive`, `product`, `categories`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
 - **Local files**: a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
 - **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
-- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans. The composite `review-deepdive` command executes ~14+ API calls (~10-20 credits) in ONE invocation and has NO skip/trim flags — under a credit cap, use the granular commands instead.
 
 ## Input (one of)
 - **Single ASIN**: "Analyze reviews for B09V3KXJPB"

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -11,7 +11,7 @@ description: >
   review comparison, negative reviews, customer complaints, buying factors, user profile.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.4"
+  version: "1.0.5"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}
@@ -27,6 +27,14 @@ Pre-analyzed consumer insights. Pain points, buying factors, user profiles, diff
 
 ## Credential
 Required: `ZOODATA_API_KEY`. Get free key at [zoodata.ai/api-keys](https://zoodata.ai/en/api-keys)
+
+## Capabilities & Data Flow
+
+- **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: `analyze`, `review-deepdive`, `product`, `categories`, `check`, plus the review fallback toolkit (`reviews-raw` / `review-tag-prompt` / `review-reduce-prompt` / `review-aggregate`). Do not invoke unrelated subcommands for this skill's tasks.
+- **Local files**: a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback; reads the optional credential store `~/.zoodata/config.json`.
+- **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
 
 ## Input (one of)
 - **Single ASIN**: "Analyze reviews for B09V3KXJPB"

--- a/amazon-review-intelligence-extractor/scripts/zoodata.py
+++ b/amazon-review-intelligence-extractor/scripts/zoodata.py
@@ -2802,7 +2802,7 @@ def main():
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
-  %(prog)s market --category "Pet Supplies,Dogs" --topn 10
+  %(prog)s market --category "Pet Supplies > Dogs" --topn 10
   %(prog)s products --keyword "yoga mat" --mode emerging
   %(prog)s products --keyword "yoga mat" --sales-min 300 --ratings-max 50
   %(prog)s competitors --keyword "wireless earbuds" --brand Anker
@@ -2835,7 +2835,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_mkt.add_argument("--sort", choices=['totalSkuCount', 'sampleSkuCount', 'sampleAvgPrice', 'sampleAvgMonthlySales', 'sampleAvgMonthlyRevenue', 'sampleTotalMonthlySales', 'sampleAvgBsr', 'sampleAvgRating', 'sampleAvgRatingCount', 'sampleBrandCount', 'sampleSellerCount', 'sampleFbaRate', 'sampleNewSkuRate', 'topAvgMonthlySales', 'topAvgMonthlyRevenue', 'topSalesRate', 'topBrandSalesRate', 'topSellerSalesRate'], metavar="FIELD", help="Sort field (markets enum), e.g. sampleAvgMonthlySales, topBrandSalesRate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2860,7 +2860,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_prod.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2874,7 +2874,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_comp.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/amazon-review-intelligence-extractor/scripts/zoodata.py
+++ b/amazon-review-intelligence-extractor/scripts/zoodata.py
@@ -54,6 +54,16 @@ KEYWORD_TIMELINE_MAX_DAYS = 61
 def _resolve_base_url():
     """Resolve API base URL, allowing local test hosts via ZOODATA_BASE_URL."""
     configured = os.environ.get("ZOODATA_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/")
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(configured if "://" in configured else f"https://{configured}").hostname or ""
+    except Exception:
+        host = ""
+    trusted = host == "zoodata.ai" or host.endswith(".zoodata.ai") or host in ("localhost", "127.0.0.1")
+    if configured.rstrip("/") != DEFAULT_BASE_URL.rstrip("/") and not trusted:
+        print(f"WARNING: ZOODATA_BASE_URL points at non-default host '{host}'. "
+              "Your API key will be sent there as a Bearer token — only proceed if you trust this host.",
+              file=sys.stderr)
     if configured.endswith(API_BASE_PATH):
         return configured
     return f"{configured}{API_BASE_PATH}"
@@ -142,12 +152,12 @@ def get_api_key():
     print("", file=sys.stderr)
     print("Please configure your API Key using one of these methods:", file=sys.stderr)
     print("", file=sys.stderr)
-    print("  Method 1: User-home config (recommended — shared across all skills)", file=sys.stderr)
+    print("  Method 1: Environment variable (recommended — no file written)", file=sys.stderr)
+    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 2: User-home config (persistent, shared across all skills)", file=sys.stderr)
     print("    mkdir -p ~/.zoodata", file=sys.stderr)
     print('    echo \'{"api_key":"hms_live_yourkey"}\' > ~/.zoodata/config.json', file=sys.stderr)
-    print("", file=sys.stderr)
-    print("  Method 2: Environment variable (session only)", file=sys.stderr)
-    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
     print("", file=sys.stderr)
     print("Get a free key at https://zoodata.ai/en/api-keys", file=sys.stderr)
     sys.exit(1)

--- a/tests/test_zoodata.py
+++ b/tests/test_zoodata.py
@@ -683,6 +683,32 @@ class TestBaseUrlResolution(unittest.TestCase):
                 "http://localhost:8080/openapi/v2",
             )
 
+    def _stderr_of_resolve(self, env):
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with patch.dict("os.environ", env, clear=True), \
+             contextlib.redirect_stderr(buf):
+            zoodata._resolve_base_url()
+        return buf.getvalue()
+
+    def test_untrusted_host_warns_about_bearer_token(self):
+        stderr = self._stderr_of_resolve({"ZOODATA_BASE_URL": "https://evil.example.com"})
+        self.assertIn("WARNING", stderr)
+        self.assertIn("evil.example.com", stderr)
+        self.assertIn("Bearer", stderr)
+
+    def test_default_host_is_silent(self):
+        self.assertEqual(self._stderr_of_resolve({}), "")
+
+    def test_zoodata_subdomain_is_trusted_and_silent(self):
+        stderr = self._stderr_of_resolve({"ZOODATA_BASE_URL": "https://staging.zoodata.ai"})
+        self.assertEqual(stderr, "")
+
+    def test_localhost_is_trusted_and_silent(self):
+        stderr = self._stderr_of_resolve({"ZOODATA_BASE_URL": "http://localhost:8080"})
+        self.assertEqual(stderr, "")
+
 
 class TestCheckCommand(unittest.TestCase):
     def test_check_defaults_to_credentials_only_without_api_call(self):

--- a/web-extract/SKILL.md
+++ b/web-extract/SKILL.md
@@ -20,7 +20,7 @@ description: >
 
   Requires ZOODATA_API_KEY (free key: https://zoodata.ai/en/api-keys).
 metadata:
-  version: "0.2.1"
+  version: "0.2.2"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}
@@ -59,6 +59,14 @@ export ZOODATA_API_KEY='hms_live_xxx'
 # OR persist to disk:
 mkdir -p ~/.zoodata && echo '{"api_key":"hms_live_xxx"}' > ~/.zoodata/config.json
 ```
+
+## Capabilities & Data Flow
+
+- **Network**: only `https://api.zoodata.ai` WebTools endpoints (Bearer `ZOODATA_API_KEY`). Target pages are fetched server-side by ZooData, not from this machine.
+- **Execution**: bundled CLI `{skill_base_dir}/scripts/webtools.py` (Python 3, stdlib-only) with exactly the documented subcommands (`scrape`, `interactive`, `search`, `map`, `crawl`, `crawl-status`, `crawl-wait`, `check`) — the full surface is the declared surface.
+- **Local files**: none; reads the optional credential store `~/.zoodata/config.json`.
+- **Sent to the API**: the target URLs, search queries, and crawl options you request.
+- **Credits**: every call consumes credits (crawl bills per page). For large crawls or deep-scrapes, state the estimated cost and confirm before submitting.
 
 ## Two ways to drive it
 

--- a/zoodata/SKILL.md
+++ b/zoodata/SKILL.md
@@ -18,7 +18,7 @@ description: >
   credit usage, how the Local Review Toolkit works, how to get started.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.4"
+  version: "1.1.5"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}
@@ -37,6 +37,14 @@ metadata:
 3. Base URL: `https://api.zoodata.ai/openapi/v2` — all POST with JSON body
 4. Auth: `Authorization: Bearer YOUR_API_KEY`
 5. New keys need 3-5s to activate. If 403, wait and retry.
+
+## Capabilities & Data Flow
+
+- **Network**: only `https://api.zoodata.ai` (Bearer `ZOODATA_API_KEY`). Setting `ZOODATA_BASE_URL` to any other host triggers a CLI warning — do not point it at hosts you don't trust.
+- **Execution**: bundled shared ZooData CLI `{skill_base_dir}/scripts/zoodata.py` (Python 3, stdlib-only). The shared CLI exposes ALL ZooData endpoints as subcommands; this skill's workflows use: all subcommands — this is the data-layer reference skill, so the full CLI surface is the declared surface. Do not invoke unrelated subcommands for this skill's tasks.
+- **Local files**: none by default; reads the optional credential store `~/.zoodata/config.json`; the Local Review Toolkit uses a temporary `/tmp/review_<ASIN>_<timestamp>/` working dir during the review fallback.
+- **Sent to the API**: keywords, category paths, ASINs, marketplace/date and numeric filter values only. **Never sent**: budget, experience level, risk tolerance, or any other user-profile text — profile inputs map client-side to numeric filters.
+- **Credits**: every API call consumes account credits. For broad or ambiguous requests, state the estimated credit cost and confirm with the user before running multi-call scans.
 
 ## ⚠️ Critical API Pitfalls (ALL skills must follow)
 1. **Keyword search is broad** → MUST lock `categoryPath` first via `categories` endpoint

--- a/zoodata/scripts/zoodata.py
+++ b/zoodata/scripts/zoodata.py
@@ -2802,7 +2802,7 @@ def main():
         epilog="""
 Examples:
   %(prog)s categories --keyword "pet supplies"
-  %(prog)s market --category "Pet Supplies,Dogs" --topn 10
+  %(prog)s market --category "Pet Supplies > Dogs" --topn 10
   %(prog)s products --keyword "yoga mat" --mode emerging
   %(prog)s products --keyword "yoga mat" --sales-min 300 --ratings-max 50
   %(prog)s competitors --keyword "wireless earbuds" --brand Anker
@@ -2835,7 +2835,7 @@ Examples:
     p_mkt.add_argument("--topn", type=int, default=10, help="Top N for concentration analysis (default: 10)")
     p_mkt.add_argument("--page-size", type=int, default=20)
     p_mkt.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_mkt.add_argument("--sort", help="Sort field: monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_mkt.add_argument("--sort", choices=['totalSkuCount', 'sampleSkuCount', 'sampleAvgPrice', 'sampleAvgMonthlySales', 'sampleAvgMonthlyRevenue', 'sampleTotalMonthlySales', 'sampleAvgBsr', 'sampleAvgRating', 'sampleAvgRatingCount', 'sampleBrandCount', 'sampleSellerCount', 'sampleFbaRate', 'sampleNewSkuRate', 'topAvgMonthlySales', 'topAvgMonthlyRevenue', 'topSalesRate', 'topBrandSalesRate', 'topSellerSalesRate'], metavar="FIELD", help="Sort field (markets enum), e.g. sampleAvgMonthlySales, topBrandSalesRate")
     p_mkt.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_mkt.set_defaults(func=cmd_market)
 
@@ -2860,7 +2860,7 @@ Examples:
     p_prod.add_argument("--exclude-brands", help="Exclude brands (comma-separated)")
     p_prod.add_argument("--page-size", type=int, default=20)
     p_prod.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    p_prod.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_prod.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_prod.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_prod.set_defaults(func=cmd_products)
 
@@ -2874,7 +2874,7 @@ Examples:
     p_comp.add_argument("--marketplace", default="US", help="Marketplace (default: US)")
     p_comp.add_argument("--page", type=int, default=1, help="Page number")
     p_comp.add_argument("--page-size", type=int, default=20)
-    p_comp.add_argument("--sort", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
+    p_comp.add_argument("--sort", choices=['monthlySalesFloor', 'monthlyRevenueFloor', 'bsr', 'price', 'rating', 'ratingCount', 'listingDate'], metavar="FIELD", help="Sort field (default: monthlySalesFloor): monthlySalesFloor, monthlyRevenueFloor, bsr, price, rating, ratingCount, listingDate")
     p_comp.add_argument("--order", choices=["asc", "desc"], default="desc")
     p_comp.set_defaults(func=cmd_competitors)
 

--- a/zoodata/scripts/zoodata.py
+++ b/zoodata/scripts/zoodata.py
@@ -54,6 +54,16 @@ KEYWORD_TIMELINE_MAX_DAYS = 61
 def _resolve_base_url():
     """Resolve API base URL, allowing local test hosts via ZOODATA_BASE_URL."""
     configured = os.environ.get("ZOODATA_BASE_URL", DEFAULT_BASE_URL).strip().rstrip("/")
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(configured if "://" in configured else f"https://{configured}").hostname or ""
+    except Exception:
+        host = ""
+    trusted = host == "zoodata.ai" or host.endswith(".zoodata.ai") or host in ("localhost", "127.0.0.1")
+    if configured.rstrip("/") != DEFAULT_BASE_URL.rstrip("/") and not trusted:
+        print(f"WARNING: ZOODATA_BASE_URL points at non-default host '{host}'. "
+              "Your API key will be sent there as a Bearer token — only proceed if you trust this host.",
+              file=sys.stderr)
     if configured.endswith(API_BASE_PATH):
         return configured
     return f"{configured}{API_BASE_PATH}"
@@ -142,12 +152,12 @@ def get_api_key():
     print("", file=sys.stderr)
     print("Please configure your API Key using one of these methods:", file=sys.stderr)
     print("", file=sys.stderr)
-    print("  Method 1: User-home config (recommended — shared across all skills)", file=sys.stderr)
+    print("  Method 1: Environment variable (recommended — no file written)", file=sys.stderr)
+    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  Method 2: User-home config (persistent, shared across all skills)", file=sys.stderr)
     print("    mkdir -p ~/.zoodata", file=sys.stderr)
     print('    echo \'{"api_key":"hms_live_yourkey"}\' > ~/.zoodata/config.json', file=sys.stderr)
-    print("", file=sys.stderr)
-    print("  Method 2: Environment variable (session only)", file=sys.stderr)
-    print("    export ZOODATA_API_KEY='hms_live_yourkey'", file=sys.stderr)
     print("", file=sys.stderr)
     print("Get a free key at https://zoodata.ai/en/api-keys", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
## Why

ClawHub's SkillSpector audit flagged all 12 skills (CRITICAL×9 / HIGH×2 / MEDIUM×1). Recurring findings: **MCP Least Privilege** (env-only declaration vs actual execute/network/file behavior), **description-behavior mismatch** (bundled full shared CLI), **missing user warnings** (data-flow transparency), **vague triggers** (credit consumption without confirmation), plus credential-config and base-url ergonomics.

## What

**A. Declarations (12 × SKILL.md)** — standardized per-skill "Capabilities & Data Flow" section:
- Network: only api.zoodata.ai; base-url override warning noted
- Execution: bundled shared CLI disclosed + the exact subcommands this skill's workflows use, with a don't-invoke-unrelated instruction
- Local files: per-skill accurate list (radar/trend baselines, review-toolkit tmp dir, optional ~/.zoodata/config.json)
- Sent vs never-sent: corrects the audit's inaccuracy — budget/experience/risk-tolerance never leave the machine (client-side mapping to numeric filters)
- Credits: estimate + confirm before multi-call scans on broad requests

**B. CLI hardening (canonical + 11 synced copies)**
- `ZOODATA_BASE_URL` → non-trusted host prints a Bearer-token warning (behavior-verified)
- Missing-key hint: env var first, home config as alternative

Patch bump ×12 for republish. 106 tests pass.

## Not addressed (deliberate)
- Per-skill trimmed CLI builds (would fully resolve the mismatch class but overturns the single-source sync architecture) — revisit if LLM re-review doesn't clear after this
- External-transmission findings on api.zoodata.ai itself — by design, appeal path

🤖 Generated with [Claude Code](https://claude.com/claude-code)