### PR TITLE
fix(cli): composite robustness — empty-target guard, category self-heal, terminal fail-fast, realtime retry + offline fallback

### DIFF
--- a/amazon-analysis/references/cli-contract.md
+++ b/amazon-analysis/references/cli-contract.md
@@ -66,6 +66,10 @@ The shared CLI owns transport retries. Once the execution-environment permission
 - If all failures are documented non-terminal business/coverage failures, a local skill may use its explicit fallback and the compatible successful sections. Label coverage precisely and never present the composite as fully successful.
 - Process exit status and JSON status must agree for a single-result command. A partial pagination failure must return `success=false` while preserving already collected rows under `data`.
 
+## Realtime unavailable — offline fallback
+
+`realtime/product` is a live scrape endpoint that can return a transient 200-success with an empty payload. Composites retry it a few times; if it is still empty, that item's result carries `_realtimeStatus="empty_after_retries"`, and the composite `meta` carries `realtimeUnavailable` (count) plus `realtimeFallbackHint`. When `realtimeFallbackHint` is present, tell the user realtime lookup is temporarily unavailable for those items, then continue the analysis using the offline snapshot data already gathered (products/search fields, history, price/BSR/rating). Do not stall, silently re-run, or fabricate the missing realtime detail.
+
 ## Partial review pagination
 
 When `reviews-raw` fails after one or more successful pages, it returns `success=false`, preserves collected reviews and page count under `data`, and exposes the failed page request through `_failedQuery`. Never treat that payload as a complete review sample.

--- a/amazon-analysis/scripts/zoodata.py
+++ b/amazon-analysis/scripts/zoodata.py
@@ -533,7 +533,8 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     Priority:
       1. keyword → categories API
       2. asin → realtime/product → categoryPath or bestsellersRank leaf
-      3. keyword → products/search → first result → realtime/product
+      3. keyword → products/search → top row's categoryPath (else its bsrCategory);
+         no realtime call — the search row already carries the category.
     """
     category_path = None
     category_source = "user"
@@ -1304,9 +1305,9 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword like "yoga mat" with no direct category match still
-    # resolves a categoryPath — otherwise the market step below returns empty).
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword like "yoga mat" with no direct category match
+    # still resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
     _log = lambda m: print(m, file=sys.stderr)
@@ -1361,8 +1362,8 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword with no direct category match still resolves a
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword with no direct category match still resolves a
     # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
@@ -2135,6 +2136,10 @@ def cmd_daily_radar(args):
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
     log(f"Step 1/7: Realtime snapshot ({len(tracked_asins)} ASINs)...")
+    # Note: unlike search-sourced composites, these ASINs are USER-SUPPLIED, so a
+    # persistent 200-empty may be a dead/typo ASIN rather than a transient miss. The
+    # empty-retry is still bounded (≤REALTIME_EMPTY_RETRIES fast calls per ASIN) and the
+    # offline-fallback hint surfaces it — a wrong ASIN costs a few extra credits, not a hang.
     realtime_snapshots = []
     for asin in tracked_asins:
         log(f"  → {asin}")

--- a/amazon-analysis/scripts/zoodata.py
+++ b/amazon-analysis/scripts/zoodata.py
@@ -88,6 +88,7 @@ API_DOCS = "https://api.zoodata.ai/api-docs"   # API documentation URL
 MAX_RETRIES = 3       # Total attempt budget for ordinary failed requests
 RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
 RATE_LIMIT_RETRIES = 4  # Total attempt budget for 429 rate limits
+REALTIME_EMPTY_RETRIES = 3  # Total attempts when realtime/product returns a transient 200-empty (scrape miss)
 RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
 MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
@@ -570,7 +571,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_source = "asin_bsr"
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
-    # Priority 3: keyword → search → first product → realtime
+    # Priority 3: keyword → search → read categoryPath straight from the top product.
+    # products/search rows already carry categoryPath, so no extra realtime probe is
+    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
+    # bsrCategory, then to a realtime probe only as a last resort.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -578,23 +582,26 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
         }, "products (category probe)")
         prod_data = prod_result.get("data", [])
         if isinstance(prod_data, list) and prod_data:
-            probe_asin = prod_data[0].get("asin")
-            if probe_asin:
-                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+            top = prod_data[0]
+            if top.get("categoryPath"):
+                category_path = top["categoryPath"]
+                category_source = "inferred_from_search"
+                log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+            elif top.get("bsrCategory"):
+                cat_result = api_caller("categories", {"categoryKeyword": top["bsrCategory"]}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
+            elif top.get("asin"):
+                # Last resort only: realtime probe (flaky) with transient-empty retry.
+                rt = _fetch_realtime(api_caller, top["asin"])
                 rt_data = rt.get("data", {}) or {}
                 if rt_data.get("categoryPath"):
                     category_path = rt_data["categoryPath"]
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
-                elif rt_data.get("bestsellersRank"):
-                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
-                    if leaf:
-                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
-                        cat_data = cat_result.get("data", [])
-                        if cat_data:
-                            category_path = cat_data[0].get("categoryPath")
-                            category_source = "inferred_from_search"
-                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 
@@ -630,6 +637,50 @@ def _skipped_after_abort():
             "message": "skipped: an earlier call in this composite hit a terminal interface failure",
         },
     }
+
+
+REALTIME_FALLBACK_HINT = (
+    "Realtime data collection failed for one or more items after retries. Tell the "
+    "user realtime lookup is temporarily unavailable, then continue the analysis "
+    "using the offline snapshot data already gathered (products/search fields, "
+    "history, price/BSR/rating) — do not stall or fabricate the missing realtime detail."
+)
+
+
+def _is_empty_realtime(result):
+    """True when realtime/product returned a 200-success but empty payload
+    (`data.asin` blank) — a transient scrape miss, not a hard error."""
+    if not isinstance(result, dict):
+        return False
+    data = result.get("data")
+    return isinstance(data, dict) and not data.get("asin")
+
+
+def _fetch_realtime(caller, asin, marketplace="US", label=None, attempts=REALTIME_EMPTY_RETRIES):
+    """Fetch realtime/product for a known-good ASIN (it came from a search result),
+    retrying a transient 200-empty up to `attempts` total. `caller(endpoint, params,
+    label)` is the composite's safe_call or an api_call adapter. If still empty after
+    all attempts, stamps result['_realtimeStatus']='empty_after_retries' so callers
+    can surface the offline-fallback hint. Does NOT retry a terminal failure."""
+    params = {"asin": asin, "marketplace": marketplace}
+    lbl = label or f"realtime {asin}"
+    r = caller("realtime/product", params, lbl)
+    n = 1
+    while n < attempts and _is_empty_realtime(r) and not _is_terminal_failure(r):
+        n += 1
+        r = caller("realtime/product", params, lbl)
+    if _is_empty_realtime(r):
+        r["_realtimeStatus"] = "empty_after_retries"
+    return r
+
+
+def _note_realtime_fallback(results, result):
+    """If a realtime result came back empty after retries, bump the composite-level
+    counter and set the user-facing offline-fallback hint on results['meta']."""
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        m = results.setdefault("meta", {})
+        m["realtimeUnavailable"] = m.get("realtimeUnavailable", 0) + 1
+        m["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
 
 
 def _mark_cli_error():
@@ -1295,7 +1346,8 @@ def cmd_report(args):
         top_asin = product_data[0].get("asin")
         if top_asin:
             print(f"Step 4/4: Getting details for top ASIN {top_asin}...", file=sys.stderr)
-            detail_result = api_call("realtime/product", {"asin": top_asin, "marketplace": "US"})
+            detail_result = _fetch_realtime(_caller, top_asin)
+            _note_realtime_fallback(results, detail_result)
             results["topProductDetail"] = detail_result
     else:
         print("Step 4/4: No products found, skipping detail.", file=sys.stderr)
@@ -1356,7 +1408,9 @@ def cmd_opportunity(args):
         asin = p.get("asin")
         if asin:
             print(f"Step 4/4: Getting details for {asin}...", file=sys.stderr)
-            details.append(api_call("realtime/product", {"asin": asin, "marketplace": "US"}))
+            r = _fetch_realtime(_caller, asin)
+            _note_realtime_fallback(results, r)
+            details.append(r)
     results["topProductDetails"] = details
 
     print("Done.", file=sys.stderr)
@@ -1396,6 +1450,16 @@ def cmd_market_entry(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1653,6 +1717,16 @@ def cmd_competitor_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1829,6 +1903,16 @@ def cmd_pricing_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2032,6 +2116,16 @@ def cmd_daily_radar(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2193,6 +2287,16 @@ def cmd_listing_audit(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2420,6 +2524,16 @@ def cmd_opportunity_scan(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2623,6 +2737,16 @@ def cmd_review_deepdive(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):

--- a/amazon-analysis/scripts/zoodata.py
+++ b/amazon-analysis/scripts/zoodata.py
@@ -1283,11 +1283,17 @@ def cmd_product(args):
     if not args.asin:
         print("ERROR: --asin is required for product command.", file=sys.stderr)
         sys.exit(1)
-    params = {"asin": args.asin}
-    if args.marketplace:
-        params["marketplace"] = args.marketplace
-
-    result = api_call("realtime/product", params)
+    marketplace = args.marketplace or "US"
+    # realtime/product can return a transient 200-empty; retry like the composites do
+    # and, if still empty, surface the offline-fallback hint on the result's own meta so
+    # a per-ASIN poller (e.g. a Quick Check loop) gets the same signal to fall back to
+    # offline snapshot data instead of treating the empty payload as a real answer.
+    caller = lambda ep, p, label=None: api_call(ep, p)
+    result = _fetch_realtime(caller, args.asin, marketplace=marketplace)
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        meta = result.setdefault("meta", {})
+        meta["realtimeUnavailable"] = (meta.get("realtimeUnavailable") or 0) + 1
+        meta["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
     output(result, args.format)
 
 

--- a/amazon-analysis/scripts/zoodata.py
+++ b/amazon-analysis/scripts/zoodata.py
@@ -599,6 +599,39 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     return category_path, category_source
 
 
+def _has_scope(keyword, category_path):
+    """A category-scoped discovery call (products/search, products/competitors,
+    markets/search for leaders) needs at least one filter. With neither keyword
+    nor categoryPath the API returns unfiltered global top-sellers — a real bug
+    that benchmarks a listing against random products. Callers MUST gate such
+    calls on this."""
+    return bool(keyword or category_path)
+
+
+def _is_terminal_failure(result):
+    """True when a call returned an exhausted terminal interface failure
+    (transport retries used up). Once one happens inside a composite, the
+    remaining fan-out calls will almost certainly hit the same wall, so the
+    composite should stop rather than stack retry x timeout for every endpoint."""
+    if not isinstance(result, dict):
+        return False
+    err = result.get("error")
+    return isinstance(err, dict) and bool(err.get("retryExhausted"))
+
+
+def _skipped_after_abort():
+    """Envelope a composite's safe_call returns once the command has aborted
+    after a terminal failure — no network call, no credits consumed."""
+    return {
+        "success": False,
+        "data": None,
+        "error": {
+            "code": "ABORTED_AFTER_TERMINAL_FAILURE",
+            "message": "skipped: an earlier call in this composite hit a terminal interface failure",
+        },
+    }
+
+
 def _mark_cli_error():
     """Remember an API failure without interrupting a composite command."""
     global _cli_had_error
@@ -1227,16 +1260,14 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword like "yoga mat" with no direct category match still
+    # resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-
-    # Use the first matching category path
-    category_path = None
-    if cat_data:
-        category_path = cat_data[0].get("categoryPath")
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market data
     print("Step 2/4: Pulling market data...", file=sys.stderr)
@@ -1285,12 +1316,14 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword with no direct category match still resolves a
+    # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-    category_path = cat_data[0].get("categoryPath") if cat_data else None
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market validation
     print("Step 2/4: Validating market...", file=sys.stderr)
@@ -1358,9 +1391,16 @@ def cmd_market_entry(args):
 
     def safe_call(endpoint, params, label=""):
         """Call API and return result. Never exit on error."""
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # ── Step 0.5: Category Resolution ──
@@ -1608,9 +1648,16 @@ def cmd_competitor_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -1777,9 +1824,16 @@ def cmd_pricing_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 1: Current Price Snapshot
@@ -1973,9 +2027,16 @@ def cmd_daily_radar(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2127,9 +2188,16 @@ def cmd_listing_audit(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2144,22 +2212,50 @@ def cmd_listing_audit(args):
     results["target_realtime"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
     results["meta"]["steps_completed"].append("audit_target")
 
-    # Step 2: Category Leaders
-    log("Step 2/7: Finding category leaders...")
-    prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        prod_params["keyword"] = keyword
-    if category_path:
-        prod_params["categoryPath"] = category_path
-    results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+    # Step 1.5: Empty-target guard. If the target ASIN has no realtime data and no
+    # category resolved, the leader search below would run UNFILTERED and benchmark
+    # the listing against random global top-sellers. A missing target is not
+    # auditable — stop here rather than fabricate an audit against garbage peers.
+    _tgt = results["target_realtime"].get("data")
+    _tgt = _tgt if isinstance(_tgt, dict) else {}
+    if not _tgt.get("asin"):
+        results["meta"]["target_status"] = "empty"
+        results["meta"]["audit_status"] = "not_auditable"
+        results["meta"]["reason"] = (
+            "Target ASIN returned no realtime data (not indexed by ZooData or a "
+            "transient upstream failure). A listing audit cannot benchmark a missing "
+            "target; re-check the ASIN or retry later."
+        )
+        _mark_cli_error()
+        output(results, args.format)
+        return
+    results["meta"]["target_status"] = "ok"
 
-    comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
-                   "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        comp_params["keyword"] = keyword
-    if category_path:
-        comp_params["categoryPath"] = category_path
-    results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    # Step 2: Category Leaders — only with a scope, else the search is unfiltered.
+    log("Step 2/7: Finding category leaders...")
+    if _has_scope(keyword, category_path):
+        prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            prod_params["keyword"] = keyword
+        if category_path:
+            prod_params["categoryPath"] = category_path
+        results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+
+        comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
+                       "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            comp_params["keyword"] = keyword
+        if category_path:
+            comp_params["categoryPath"] = category_path
+        results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    else:
+        _no_scope = {"success": False, "data": [], "error": {
+            "code": "NO_CATEGORY_SCOPE",
+            "message": "skipped: no keyword or category to scope discovery (would return unfiltered global results)"}}
+        results["leader_products"] = _no_scope
+        results["competitors"] = _no_scope
+        results["meta"].setdefault("warnings", []).append(
+            "leader/competitor discovery skipped — target had no category and no keyword to scope on")
     results["meta"]["steps_completed"].append("category_leaders")
 
     # Step 3: Benchmark Realtime (Top 5 leaders, deduplicated)
@@ -2319,9 +2415,16 @@ def cmd_opportunity_scan(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -2515,9 +2618,16 @@ def cmd_review_deepdive(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution

--- a/amazon-analysis/scripts/zoodata.py
+++ b/amazon-analysis/scripts/zoodata.py
@@ -572,9 +572,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
     # Priority 3: keyword → search → read categoryPath straight from the top product.
-    # products/search rows already carry categoryPath, so no extra realtime probe is
-    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
-    # bsrCategory, then to a realtime probe only as a last resort.
+    # products/search rows already carry categoryPath, so category resolution needs NO
+    # realtime call here (realtime is a flaky scrape endpoint). Fall back to the
+    # product's bsrCategory; if even that is absent (a data anomaly), leave the category
+    # unresolved rather than gamble on a flaky realtime probe for one field we can't get.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -594,14 +595,6 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_path = cat_data[0].get("categoryPath")
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
-            elif top.get("asin"):
-                # Last resort only: realtime probe (flaky) with transient-empty retry.
-                rt = _fetch_realtime(api_caller, top["asin"])
-                rt_data = rt.get("data", {}) or {}
-                if rt_data.get("categoryPath"):
-                    category_path = rt_data["categoryPath"]
-                    category_source = "inferred_from_search"
-                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 

--- a/amazon-competitor-intelligence-monitor/references/cli-contract.md
+++ b/amazon-competitor-intelligence-monitor/references/cli-contract.md
@@ -66,6 +66,10 @@ The shared CLI owns transport retries. Once the execution-environment permission
 - If all failures are documented non-terminal business/coverage failures, a local skill may use its explicit fallback and the compatible successful sections. Label coverage precisely and never present the composite as fully successful.
 - Process exit status and JSON status must agree for a single-result command. A partial pagination failure must return `success=false` while preserving already collected rows under `data`.
 
+## Realtime unavailable — offline fallback
+
+`realtime/product` is a live scrape endpoint that can return a transient 200-success with an empty payload. Composites retry it a few times; if it is still empty, that item's result carries `_realtimeStatus="empty_after_retries"`, and the composite `meta` carries `realtimeUnavailable` (count) plus `realtimeFallbackHint`. When `realtimeFallbackHint` is present, tell the user realtime lookup is temporarily unavailable for those items, then continue the analysis using the offline snapshot data already gathered (products/search fields, history, price/BSR/rating). Do not stall, silently re-run, or fabricate the missing realtime detail.
+
 ## Partial review pagination
 
 When `reviews-raw` fails after one or more successful pages, it returns `success=false`, preserves collected reviews and page count under `data`, and exposes the failed page request through `_failedQuery`. Never treat that payload as a complete review sample.

--- a/amazon-competitor-intelligence-monitor/scripts/zoodata.py
+++ b/amazon-competitor-intelligence-monitor/scripts/zoodata.py
@@ -533,7 +533,8 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     Priority:
       1. keyword → categories API
       2. asin → realtime/product → categoryPath or bestsellersRank leaf
-      3. keyword → products/search → first result → realtime/product
+      3. keyword → products/search → top row's categoryPath (else its bsrCategory);
+         no realtime call — the search row already carries the category.
     """
     category_path = None
     category_source = "user"
@@ -1304,9 +1305,9 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword like "yoga mat" with no direct category match still
-    # resolves a categoryPath — otherwise the market step below returns empty).
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword like "yoga mat" with no direct category match
+    # still resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
     _log = lambda m: print(m, file=sys.stderr)
@@ -1361,8 +1362,8 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword with no direct category match still resolves a
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword with no direct category match still resolves a
     # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
@@ -2135,6 +2136,10 @@ def cmd_daily_radar(args):
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
     log(f"Step 1/7: Realtime snapshot ({len(tracked_asins)} ASINs)...")
+    # Note: unlike search-sourced composites, these ASINs are USER-SUPPLIED, so a
+    # persistent 200-empty may be a dead/typo ASIN rather than a transient miss. The
+    # empty-retry is still bounded (≤REALTIME_EMPTY_RETRIES fast calls per ASIN) and the
+    # offline-fallback hint surfaces it — a wrong ASIN costs a few extra credits, not a hang.
     realtime_snapshots = []
     for asin in tracked_asins:
         log(f"  → {asin}")

--- a/amazon-competitor-intelligence-monitor/scripts/zoodata.py
+++ b/amazon-competitor-intelligence-monitor/scripts/zoodata.py
@@ -88,6 +88,7 @@ API_DOCS = "https://api.zoodata.ai/api-docs"   # API documentation URL
 MAX_RETRIES = 3       # Total attempt budget for ordinary failed requests
 RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
 RATE_LIMIT_RETRIES = 4  # Total attempt budget for 429 rate limits
+REALTIME_EMPTY_RETRIES = 3  # Total attempts when realtime/product returns a transient 200-empty (scrape miss)
 RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
 MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
@@ -570,7 +571,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_source = "asin_bsr"
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
-    # Priority 3: keyword → search → first product → realtime
+    # Priority 3: keyword → search → read categoryPath straight from the top product.
+    # products/search rows already carry categoryPath, so no extra realtime probe is
+    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
+    # bsrCategory, then to a realtime probe only as a last resort.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -578,23 +582,26 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
         }, "products (category probe)")
         prod_data = prod_result.get("data", [])
         if isinstance(prod_data, list) and prod_data:
-            probe_asin = prod_data[0].get("asin")
-            if probe_asin:
-                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+            top = prod_data[0]
+            if top.get("categoryPath"):
+                category_path = top["categoryPath"]
+                category_source = "inferred_from_search"
+                log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+            elif top.get("bsrCategory"):
+                cat_result = api_caller("categories", {"categoryKeyword": top["bsrCategory"]}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
+            elif top.get("asin"):
+                # Last resort only: realtime probe (flaky) with transient-empty retry.
+                rt = _fetch_realtime(api_caller, top["asin"])
                 rt_data = rt.get("data", {}) or {}
                 if rt_data.get("categoryPath"):
                     category_path = rt_data["categoryPath"]
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
-                elif rt_data.get("bestsellersRank"):
-                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
-                    if leaf:
-                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
-                        cat_data = cat_result.get("data", [])
-                        if cat_data:
-                            category_path = cat_data[0].get("categoryPath")
-                            category_source = "inferred_from_search"
-                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 
@@ -630,6 +637,50 @@ def _skipped_after_abort():
             "message": "skipped: an earlier call in this composite hit a terminal interface failure",
         },
     }
+
+
+REALTIME_FALLBACK_HINT = (
+    "Realtime data collection failed for one or more items after retries. Tell the "
+    "user realtime lookup is temporarily unavailable, then continue the analysis "
+    "using the offline snapshot data already gathered (products/search fields, "
+    "history, price/BSR/rating) — do not stall or fabricate the missing realtime detail."
+)
+
+
+def _is_empty_realtime(result):
+    """True when realtime/product returned a 200-success but empty payload
+    (`data.asin` blank) — a transient scrape miss, not a hard error."""
+    if not isinstance(result, dict):
+        return False
+    data = result.get("data")
+    return isinstance(data, dict) and not data.get("asin")
+
+
+def _fetch_realtime(caller, asin, marketplace="US", label=None, attempts=REALTIME_EMPTY_RETRIES):
+    """Fetch realtime/product for a known-good ASIN (it came from a search result),
+    retrying a transient 200-empty up to `attempts` total. `caller(endpoint, params,
+    label)` is the composite's safe_call or an api_call adapter. If still empty after
+    all attempts, stamps result['_realtimeStatus']='empty_after_retries' so callers
+    can surface the offline-fallback hint. Does NOT retry a terminal failure."""
+    params = {"asin": asin, "marketplace": marketplace}
+    lbl = label or f"realtime {asin}"
+    r = caller("realtime/product", params, lbl)
+    n = 1
+    while n < attempts and _is_empty_realtime(r) and not _is_terminal_failure(r):
+        n += 1
+        r = caller("realtime/product", params, lbl)
+    if _is_empty_realtime(r):
+        r["_realtimeStatus"] = "empty_after_retries"
+    return r
+
+
+def _note_realtime_fallback(results, result):
+    """If a realtime result came back empty after retries, bump the composite-level
+    counter and set the user-facing offline-fallback hint on results['meta']."""
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        m = results.setdefault("meta", {})
+        m["realtimeUnavailable"] = m.get("realtimeUnavailable", 0) + 1
+        m["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
 
 
 def _mark_cli_error():
@@ -1295,7 +1346,8 @@ def cmd_report(args):
         top_asin = product_data[0].get("asin")
         if top_asin:
             print(f"Step 4/4: Getting details for top ASIN {top_asin}...", file=sys.stderr)
-            detail_result = api_call("realtime/product", {"asin": top_asin, "marketplace": "US"})
+            detail_result = _fetch_realtime(_caller, top_asin)
+            _note_realtime_fallback(results, detail_result)
             results["topProductDetail"] = detail_result
     else:
         print("Step 4/4: No products found, skipping detail.", file=sys.stderr)
@@ -1356,7 +1408,9 @@ def cmd_opportunity(args):
         asin = p.get("asin")
         if asin:
             print(f"Step 4/4: Getting details for {asin}...", file=sys.stderr)
-            details.append(api_call("realtime/product", {"asin": asin, "marketplace": "US"}))
+            r = _fetch_realtime(_caller, asin)
+            _note_realtime_fallback(results, r)
+            details.append(r)
     results["topProductDetails"] = details
 
     print("Done.", file=sys.stderr)
@@ -1396,6 +1450,16 @@ def cmd_market_entry(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1653,6 +1717,16 @@ def cmd_competitor_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1829,6 +1903,16 @@ def cmd_pricing_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2032,6 +2116,16 @@ def cmd_daily_radar(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2193,6 +2287,16 @@ def cmd_listing_audit(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2420,6 +2524,16 @@ def cmd_opportunity_scan(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2623,6 +2737,16 @@ def cmd_review_deepdive(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):

--- a/amazon-competitor-intelligence-monitor/scripts/zoodata.py
+++ b/amazon-competitor-intelligence-monitor/scripts/zoodata.py
@@ -1283,11 +1283,17 @@ def cmd_product(args):
     if not args.asin:
         print("ERROR: --asin is required for product command.", file=sys.stderr)
         sys.exit(1)
-    params = {"asin": args.asin}
-    if args.marketplace:
-        params["marketplace"] = args.marketplace
-
-    result = api_call("realtime/product", params)
+    marketplace = args.marketplace or "US"
+    # realtime/product can return a transient 200-empty; retry like the composites do
+    # and, if still empty, surface the offline-fallback hint on the result's own meta so
+    # a per-ASIN poller (e.g. a Quick Check loop) gets the same signal to fall back to
+    # offline snapshot data instead of treating the empty payload as a real answer.
+    caller = lambda ep, p, label=None: api_call(ep, p)
+    result = _fetch_realtime(caller, args.asin, marketplace=marketplace)
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        meta = result.setdefault("meta", {})
+        meta["realtimeUnavailable"] = (meta.get("realtimeUnavailable") or 0) + 1
+        meta["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
     output(result, args.format)
 
 

--- a/amazon-competitor-intelligence-monitor/scripts/zoodata.py
+++ b/amazon-competitor-intelligence-monitor/scripts/zoodata.py
@@ -599,6 +599,39 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     return category_path, category_source
 
 
+def _has_scope(keyword, category_path):
+    """A category-scoped discovery call (products/search, products/competitors,
+    markets/search for leaders) needs at least one filter. With neither keyword
+    nor categoryPath the API returns unfiltered global top-sellers — a real bug
+    that benchmarks a listing against random products. Callers MUST gate such
+    calls on this."""
+    return bool(keyword or category_path)
+
+
+def _is_terminal_failure(result):
+    """True when a call returned an exhausted terminal interface failure
+    (transport retries used up). Once one happens inside a composite, the
+    remaining fan-out calls will almost certainly hit the same wall, so the
+    composite should stop rather than stack retry x timeout for every endpoint."""
+    if not isinstance(result, dict):
+        return False
+    err = result.get("error")
+    return isinstance(err, dict) and bool(err.get("retryExhausted"))
+
+
+def _skipped_after_abort():
+    """Envelope a composite's safe_call returns once the command has aborted
+    after a terminal failure — no network call, no credits consumed."""
+    return {
+        "success": False,
+        "data": None,
+        "error": {
+            "code": "ABORTED_AFTER_TERMINAL_FAILURE",
+            "message": "skipped: an earlier call in this composite hit a terminal interface failure",
+        },
+    }
+
+
 def _mark_cli_error():
     """Remember an API failure without interrupting a composite command."""
     global _cli_had_error
@@ -1227,16 +1260,14 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword like "yoga mat" with no direct category match still
+    # resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-
-    # Use the first matching category path
-    category_path = None
-    if cat_data:
-        category_path = cat_data[0].get("categoryPath")
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market data
     print("Step 2/4: Pulling market data...", file=sys.stderr)
@@ -1285,12 +1316,14 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword with no direct category match still resolves a
+    # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-    category_path = cat_data[0].get("categoryPath") if cat_data else None
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market validation
     print("Step 2/4: Validating market...", file=sys.stderr)
@@ -1358,9 +1391,16 @@ def cmd_market_entry(args):
 
     def safe_call(endpoint, params, label=""):
         """Call API and return result. Never exit on error."""
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # ── Step 0.5: Category Resolution ──
@@ -1608,9 +1648,16 @@ def cmd_competitor_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -1777,9 +1824,16 @@ def cmd_pricing_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 1: Current Price Snapshot
@@ -1973,9 +2027,16 @@ def cmd_daily_radar(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2127,9 +2188,16 @@ def cmd_listing_audit(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2144,22 +2212,50 @@ def cmd_listing_audit(args):
     results["target_realtime"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
     results["meta"]["steps_completed"].append("audit_target")
 
-    # Step 2: Category Leaders
-    log("Step 2/7: Finding category leaders...")
-    prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        prod_params["keyword"] = keyword
-    if category_path:
-        prod_params["categoryPath"] = category_path
-    results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+    # Step 1.5: Empty-target guard. If the target ASIN has no realtime data and no
+    # category resolved, the leader search below would run UNFILTERED and benchmark
+    # the listing against random global top-sellers. A missing target is not
+    # auditable — stop here rather than fabricate an audit against garbage peers.
+    _tgt = results["target_realtime"].get("data")
+    _tgt = _tgt if isinstance(_tgt, dict) else {}
+    if not _tgt.get("asin"):
+        results["meta"]["target_status"] = "empty"
+        results["meta"]["audit_status"] = "not_auditable"
+        results["meta"]["reason"] = (
+            "Target ASIN returned no realtime data (not indexed by ZooData or a "
+            "transient upstream failure). A listing audit cannot benchmark a missing "
+            "target; re-check the ASIN or retry later."
+        )
+        _mark_cli_error()
+        output(results, args.format)
+        return
+    results["meta"]["target_status"] = "ok"
 
-    comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
-                   "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        comp_params["keyword"] = keyword
-    if category_path:
-        comp_params["categoryPath"] = category_path
-    results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    # Step 2: Category Leaders — only with a scope, else the search is unfiltered.
+    log("Step 2/7: Finding category leaders...")
+    if _has_scope(keyword, category_path):
+        prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            prod_params["keyword"] = keyword
+        if category_path:
+            prod_params["categoryPath"] = category_path
+        results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+
+        comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
+                       "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            comp_params["keyword"] = keyword
+        if category_path:
+            comp_params["categoryPath"] = category_path
+        results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    else:
+        _no_scope = {"success": False, "data": [], "error": {
+            "code": "NO_CATEGORY_SCOPE",
+            "message": "skipped: no keyword or category to scope discovery (would return unfiltered global results)"}}
+        results["leader_products"] = _no_scope
+        results["competitors"] = _no_scope
+        results["meta"].setdefault("warnings", []).append(
+            "leader/competitor discovery skipped — target had no category and no keyword to scope on")
     results["meta"]["steps_completed"].append("category_leaders")
 
     # Step 3: Benchmark Realtime (Top 5 leaders, deduplicated)
@@ -2319,9 +2415,16 @@ def cmd_opportunity_scan(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -2515,9 +2618,16 @@ def cmd_review_deepdive(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution

--- a/amazon-competitor-intelligence-monitor/scripts/zoodata.py
+++ b/amazon-competitor-intelligence-monitor/scripts/zoodata.py
@@ -572,9 +572,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
     # Priority 3: keyword → search → read categoryPath straight from the top product.
-    # products/search rows already carry categoryPath, so no extra realtime probe is
-    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
-    # bsrCategory, then to a realtime probe only as a last resort.
+    # products/search rows already carry categoryPath, so category resolution needs NO
+    # realtime call here (realtime is a flaky scrape endpoint). Fall back to the
+    # product's bsrCategory; if even that is absent (a data anomaly), leave the category
+    # unresolved rather than gamble on a flaky realtime probe for one field we can't get.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -594,14 +595,6 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_path = cat_data[0].get("categoryPath")
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
-            elif top.get("asin"):
-                # Last resort only: realtime probe (flaky) with transient-empty retry.
-                rt = _fetch_realtime(api_caller, top["asin"])
-                rt_data = rt.get("data", {}) or {}
-                if rt_data.get("categoryPath"):
-                    category_path = rt_data["categoryPath"]
-                    category_source = "inferred_from_search"
-                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 

--- a/amazon-daily-market-radar/references/cli-contract.md
+++ b/amazon-daily-market-radar/references/cli-contract.md
@@ -66,6 +66,10 @@ The shared CLI owns transport retries. Once the execution-environment permission
 - If all failures are documented non-terminal business/coverage failures, a local skill may use its explicit fallback and the compatible successful sections. Label coverage precisely and never present the composite as fully successful.
 - Process exit status and JSON status must agree for a single-result command. A partial pagination failure must return `success=false` while preserving already collected rows under `data`.
 
+## Realtime unavailable — offline fallback
+
+`realtime/product` is a live scrape endpoint that can return a transient 200-success with an empty payload. Composites retry it a few times; if it is still empty, that item's result carries `_realtimeStatus="empty_after_retries"`, and the composite `meta` carries `realtimeUnavailable` (count) plus `realtimeFallbackHint`. When `realtimeFallbackHint` is present, tell the user realtime lookup is temporarily unavailable for those items, then continue the analysis using the offline snapshot data already gathered (products/search fields, history, price/BSR/rating). Do not stall, silently re-run, or fabricate the missing realtime detail.
+
 ## Partial review pagination
 
 When `reviews-raw` fails after one or more successful pages, it returns `success=false`, preserves collected reviews and page count under `data`, and exposes the failed page request through `_failedQuery`. Never treat that payload as a complete review sample.

--- a/amazon-daily-market-radar/scripts/zoodata.py
+++ b/amazon-daily-market-radar/scripts/zoodata.py
@@ -533,7 +533,8 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     Priority:
       1. keyword → categories API
       2. asin → realtime/product → categoryPath or bestsellersRank leaf
-      3. keyword → products/search → first result → realtime/product
+      3. keyword → products/search → top row's categoryPath (else its bsrCategory);
+         no realtime call — the search row already carries the category.
     """
     category_path = None
     category_source = "user"
@@ -1304,9 +1305,9 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword like "yoga mat" with no direct category match still
-    # resolves a categoryPath — otherwise the market step below returns empty).
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword like "yoga mat" with no direct category match
+    # still resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
     _log = lambda m: print(m, file=sys.stderr)
@@ -1361,8 +1362,8 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword with no direct category match still resolves a
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword with no direct category match still resolves a
     # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
@@ -2135,6 +2136,10 @@ def cmd_daily_radar(args):
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
     log(f"Step 1/7: Realtime snapshot ({len(tracked_asins)} ASINs)...")
+    # Note: unlike search-sourced composites, these ASINs are USER-SUPPLIED, so a
+    # persistent 200-empty may be a dead/typo ASIN rather than a transient miss. The
+    # empty-retry is still bounded (≤REALTIME_EMPTY_RETRIES fast calls per ASIN) and the
+    # offline-fallback hint surfaces it — a wrong ASIN costs a few extra credits, not a hang.
     realtime_snapshots = []
     for asin in tracked_asins:
         log(f"  → {asin}")

--- a/amazon-daily-market-radar/scripts/zoodata.py
+++ b/amazon-daily-market-radar/scripts/zoodata.py
@@ -88,6 +88,7 @@ API_DOCS = "https://api.zoodata.ai/api-docs"   # API documentation URL
 MAX_RETRIES = 3       # Total attempt budget for ordinary failed requests
 RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
 RATE_LIMIT_RETRIES = 4  # Total attempt budget for 429 rate limits
+REALTIME_EMPTY_RETRIES = 3  # Total attempts when realtime/product returns a transient 200-empty (scrape miss)
 RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
 MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
@@ -570,7 +571,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_source = "asin_bsr"
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
-    # Priority 3: keyword → search → first product → realtime
+    # Priority 3: keyword → search → read categoryPath straight from the top product.
+    # products/search rows already carry categoryPath, so no extra realtime probe is
+    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
+    # bsrCategory, then to a realtime probe only as a last resort.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -578,23 +582,26 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
         }, "products (category probe)")
         prod_data = prod_result.get("data", [])
         if isinstance(prod_data, list) and prod_data:
-            probe_asin = prod_data[0].get("asin")
-            if probe_asin:
-                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+            top = prod_data[0]
+            if top.get("categoryPath"):
+                category_path = top["categoryPath"]
+                category_source = "inferred_from_search"
+                log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+            elif top.get("bsrCategory"):
+                cat_result = api_caller("categories", {"categoryKeyword": top["bsrCategory"]}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
+            elif top.get("asin"):
+                # Last resort only: realtime probe (flaky) with transient-empty retry.
+                rt = _fetch_realtime(api_caller, top["asin"])
                 rt_data = rt.get("data", {}) or {}
                 if rt_data.get("categoryPath"):
                     category_path = rt_data["categoryPath"]
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
-                elif rt_data.get("bestsellersRank"):
-                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
-                    if leaf:
-                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
-                        cat_data = cat_result.get("data", [])
-                        if cat_data:
-                            category_path = cat_data[0].get("categoryPath")
-                            category_source = "inferred_from_search"
-                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 
@@ -630,6 +637,50 @@ def _skipped_after_abort():
             "message": "skipped: an earlier call in this composite hit a terminal interface failure",
         },
     }
+
+
+REALTIME_FALLBACK_HINT = (
+    "Realtime data collection failed for one or more items after retries. Tell the "
+    "user realtime lookup is temporarily unavailable, then continue the analysis "
+    "using the offline snapshot data already gathered (products/search fields, "
+    "history, price/BSR/rating) — do not stall or fabricate the missing realtime detail."
+)
+
+
+def _is_empty_realtime(result):
+    """True when realtime/product returned a 200-success but empty payload
+    (`data.asin` blank) — a transient scrape miss, not a hard error."""
+    if not isinstance(result, dict):
+        return False
+    data = result.get("data")
+    return isinstance(data, dict) and not data.get("asin")
+
+
+def _fetch_realtime(caller, asin, marketplace="US", label=None, attempts=REALTIME_EMPTY_RETRIES):
+    """Fetch realtime/product for a known-good ASIN (it came from a search result),
+    retrying a transient 200-empty up to `attempts` total. `caller(endpoint, params,
+    label)` is the composite's safe_call or an api_call adapter. If still empty after
+    all attempts, stamps result['_realtimeStatus']='empty_after_retries' so callers
+    can surface the offline-fallback hint. Does NOT retry a terminal failure."""
+    params = {"asin": asin, "marketplace": marketplace}
+    lbl = label or f"realtime {asin}"
+    r = caller("realtime/product", params, lbl)
+    n = 1
+    while n < attempts and _is_empty_realtime(r) and not _is_terminal_failure(r):
+        n += 1
+        r = caller("realtime/product", params, lbl)
+    if _is_empty_realtime(r):
+        r["_realtimeStatus"] = "empty_after_retries"
+    return r
+
+
+def _note_realtime_fallback(results, result):
+    """If a realtime result came back empty after retries, bump the composite-level
+    counter and set the user-facing offline-fallback hint on results['meta']."""
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        m = results.setdefault("meta", {})
+        m["realtimeUnavailable"] = m.get("realtimeUnavailable", 0) + 1
+        m["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
 
 
 def _mark_cli_error():
@@ -1295,7 +1346,8 @@ def cmd_report(args):
         top_asin = product_data[0].get("asin")
         if top_asin:
             print(f"Step 4/4: Getting details for top ASIN {top_asin}...", file=sys.stderr)
-            detail_result = api_call("realtime/product", {"asin": top_asin, "marketplace": "US"})
+            detail_result = _fetch_realtime(_caller, top_asin)
+            _note_realtime_fallback(results, detail_result)
             results["topProductDetail"] = detail_result
     else:
         print("Step 4/4: No products found, skipping detail.", file=sys.stderr)
@@ -1356,7 +1408,9 @@ def cmd_opportunity(args):
         asin = p.get("asin")
         if asin:
             print(f"Step 4/4: Getting details for {asin}...", file=sys.stderr)
-            details.append(api_call("realtime/product", {"asin": asin, "marketplace": "US"}))
+            r = _fetch_realtime(_caller, asin)
+            _note_realtime_fallback(results, r)
+            details.append(r)
     results["topProductDetails"] = details
 
     print("Done.", file=sys.stderr)
@@ -1396,6 +1450,16 @@ def cmd_market_entry(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1653,6 +1717,16 @@ def cmd_competitor_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1829,6 +1903,16 @@ def cmd_pricing_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2032,6 +2116,16 @@ def cmd_daily_radar(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2193,6 +2287,16 @@ def cmd_listing_audit(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2420,6 +2524,16 @@ def cmd_opportunity_scan(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2623,6 +2737,16 @@ def cmd_review_deepdive(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):

--- a/amazon-daily-market-radar/scripts/zoodata.py
+++ b/amazon-daily-market-radar/scripts/zoodata.py
@@ -1283,11 +1283,17 @@ def cmd_product(args):
     if not args.asin:
         print("ERROR: --asin is required for product command.", file=sys.stderr)
         sys.exit(1)
-    params = {"asin": args.asin}
-    if args.marketplace:
-        params["marketplace"] = args.marketplace
-
-    result = api_call("realtime/product", params)
+    marketplace = args.marketplace or "US"
+    # realtime/product can return a transient 200-empty; retry like the composites do
+    # and, if still empty, surface the offline-fallback hint on the result's own meta so
+    # a per-ASIN poller (e.g. a Quick Check loop) gets the same signal to fall back to
+    # offline snapshot data instead of treating the empty payload as a real answer.
+    caller = lambda ep, p, label=None: api_call(ep, p)
+    result = _fetch_realtime(caller, args.asin, marketplace=marketplace)
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        meta = result.setdefault("meta", {})
+        meta["realtimeUnavailable"] = (meta.get("realtimeUnavailable") or 0) + 1
+        meta["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
     output(result, args.format)
 
 

--- a/amazon-daily-market-radar/scripts/zoodata.py
+++ b/amazon-daily-market-radar/scripts/zoodata.py
@@ -599,6 +599,39 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     return category_path, category_source
 
 
+def _has_scope(keyword, category_path):
+    """A category-scoped discovery call (products/search, products/competitors,
+    markets/search for leaders) needs at least one filter. With neither keyword
+    nor categoryPath the API returns unfiltered global top-sellers — a real bug
+    that benchmarks a listing against random products. Callers MUST gate such
+    calls on this."""
+    return bool(keyword or category_path)
+
+
+def _is_terminal_failure(result):
+    """True when a call returned an exhausted terminal interface failure
+    (transport retries used up). Once one happens inside a composite, the
+    remaining fan-out calls will almost certainly hit the same wall, so the
+    composite should stop rather than stack retry x timeout for every endpoint."""
+    if not isinstance(result, dict):
+        return False
+    err = result.get("error")
+    return isinstance(err, dict) and bool(err.get("retryExhausted"))
+
+
+def _skipped_after_abort():
+    """Envelope a composite's safe_call returns once the command has aborted
+    after a terminal failure — no network call, no credits consumed."""
+    return {
+        "success": False,
+        "data": None,
+        "error": {
+            "code": "ABORTED_AFTER_TERMINAL_FAILURE",
+            "message": "skipped: an earlier call in this composite hit a terminal interface failure",
+        },
+    }
+
+
 def _mark_cli_error():
     """Remember an API failure without interrupting a composite command."""
     global _cli_had_error
@@ -1227,16 +1260,14 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword like "yoga mat" with no direct category match still
+    # resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-
-    # Use the first matching category path
-    category_path = None
-    if cat_data:
-        category_path = cat_data[0].get("categoryPath")
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market data
     print("Step 2/4: Pulling market data...", file=sys.stderr)
@@ -1285,12 +1316,14 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword with no direct category match still resolves a
+    # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-    category_path = cat_data[0].get("categoryPath") if cat_data else None
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market validation
     print("Step 2/4: Validating market...", file=sys.stderr)
@@ -1358,9 +1391,16 @@ def cmd_market_entry(args):
 
     def safe_call(endpoint, params, label=""):
         """Call API and return result. Never exit on error."""
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # ── Step 0.5: Category Resolution ──
@@ -1608,9 +1648,16 @@ def cmd_competitor_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -1777,9 +1824,16 @@ def cmd_pricing_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 1: Current Price Snapshot
@@ -1973,9 +2027,16 @@ def cmd_daily_radar(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2127,9 +2188,16 @@ def cmd_listing_audit(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2144,22 +2212,50 @@ def cmd_listing_audit(args):
     results["target_realtime"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
     results["meta"]["steps_completed"].append("audit_target")
 
-    # Step 2: Category Leaders
-    log("Step 2/7: Finding category leaders...")
-    prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        prod_params["keyword"] = keyword
-    if category_path:
-        prod_params["categoryPath"] = category_path
-    results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+    # Step 1.5: Empty-target guard. If the target ASIN has no realtime data and no
+    # category resolved, the leader search below would run UNFILTERED and benchmark
+    # the listing against random global top-sellers. A missing target is not
+    # auditable — stop here rather than fabricate an audit against garbage peers.
+    _tgt = results["target_realtime"].get("data")
+    _tgt = _tgt if isinstance(_tgt, dict) else {}
+    if not _tgt.get("asin"):
+        results["meta"]["target_status"] = "empty"
+        results["meta"]["audit_status"] = "not_auditable"
+        results["meta"]["reason"] = (
+            "Target ASIN returned no realtime data (not indexed by ZooData or a "
+            "transient upstream failure). A listing audit cannot benchmark a missing "
+            "target; re-check the ASIN or retry later."
+        )
+        _mark_cli_error()
+        output(results, args.format)
+        return
+    results["meta"]["target_status"] = "ok"
 
-    comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
-                   "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        comp_params["keyword"] = keyword
-    if category_path:
-        comp_params["categoryPath"] = category_path
-    results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    # Step 2: Category Leaders — only with a scope, else the search is unfiltered.
+    log("Step 2/7: Finding category leaders...")
+    if _has_scope(keyword, category_path):
+        prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            prod_params["keyword"] = keyword
+        if category_path:
+            prod_params["categoryPath"] = category_path
+        results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+
+        comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
+                       "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            comp_params["keyword"] = keyword
+        if category_path:
+            comp_params["categoryPath"] = category_path
+        results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    else:
+        _no_scope = {"success": False, "data": [], "error": {
+            "code": "NO_CATEGORY_SCOPE",
+            "message": "skipped: no keyword or category to scope discovery (would return unfiltered global results)"}}
+        results["leader_products"] = _no_scope
+        results["competitors"] = _no_scope
+        results["meta"].setdefault("warnings", []).append(
+            "leader/competitor discovery skipped — target had no category and no keyword to scope on")
     results["meta"]["steps_completed"].append("category_leaders")
 
     # Step 3: Benchmark Realtime (Top 5 leaders, deduplicated)
@@ -2319,9 +2415,16 @@ def cmd_opportunity_scan(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -2515,9 +2618,16 @@ def cmd_review_deepdive(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution

--- a/amazon-daily-market-radar/scripts/zoodata.py
+++ b/amazon-daily-market-radar/scripts/zoodata.py
@@ -572,9 +572,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
     # Priority 3: keyword → search → read categoryPath straight from the top product.
-    # products/search rows already carry categoryPath, so no extra realtime probe is
-    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
-    # bsrCategory, then to a realtime probe only as a last resort.
+    # products/search rows already carry categoryPath, so category resolution needs NO
+    # realtime call here (realtime is a flaky scrape endpoint). Fall back to the
+    # product's bsrCategory; if even that is absent (a data anomaly), leave the category
+    # unresolved rather than gamble on a flaky realtime probe for one field we can't get.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -594,14 +595,6 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_path = cat_data[0].get("categoryPath")
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
-            elif top.get("asin"):
-                # Last resort only: realtime probe (flaky) with transient-empty retry.
-                rt = _fetch_realtime(api_caller, top["asin"])
-                rt_data = rt.get("data", {}) or {}
-                if rt_data.get("categoryPath"):
-                    category_path = rt_data["categoryPath"]
-                    category_source = "inferred_from_search"
-                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 

--- a/amazon-keyword-traffic-analysis/references/cli-contract.md
+++ b/amazon-keyword-traffic-analysis/references/cli-contract.md
@@ -66,6 +66,10 @@ The shared CLI owns transport retries. Once the execution-environment permission
 - If all failures are documented non-terminal business/coverage failures, a local skill may use its explicit fallback and the compatible successful sections. Label coverage precisely and never present the composite as fully successful.
 - Process exit status and JSON status must agree for a single-result command. A partial pagination failure must return `success=false` while preserving already collected rows under `data`.
 
+## Realtime unavailable — offline fallback
+
+`realtime/product` is a live scrape endpoint that can return a transient 200-success with an empty payload. Composites retry it a few times; if it is still empty, that item's result carries `_realtimeStatus="empty_after_retries"`, and the composite `meta` carries `realtimeUnavailable` (count) plus `realtimeFallbackHint`. When `realtimeFallbackHint` is present, tell the user realtime lookup is temporarily unavailable for those items, then continue the analysis using the offline snapshot data already gathered (products/search fields, history, price/BSR/rating). Do not stall, silently re-run, or fabricate the missing realtime detail.
+
 ## Partial review pagination
 
 When `reviews-raw` fails after one or more successful pages, it returns `success=false`, preserves collected reviews and page count under `data`, and exposes the failed page request through `_failedQuery`. Never treat that payload as a complete review sample.

--- a/amazon-keyword-traffic-analysis/scripts/zoodata.py
+++ b/amazon-keyword-traffic-analysis/scripts/zoodata.py
@@ -533,7 +533,8 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     Priority:
       1. keyword → categories API
       2. asin → realtime/product → categoryPath or bestsellersRank leaf
-      3. keyword → products/search → first result → realtime/product
+      3. keyword → products/search → top row's categoryPath (else its bsrCategory);
+         no realtime call — the search row already carries the category.
     """
     category_path = None
     category_source = "user"
@@ -1304,9 +1305,9 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword like "yoga mat" with no direct category match still
-    # resolves a categoryPath — otherwise the market step below returns empty).
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword like "yoga mat" with no direct category match
+    # still resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
     _log = lambda m: print(m, file=sys.stderr)
@@ -1361,8 +1362,8 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword with no direct category match still resolves a
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword with no direct category match still resolves a
     # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
@@ -2135,6 +2136,10 @@ def cmd_daily_radar(args):
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
     log(f"Step 1/7: Realtime snapshot ({len(tracked_asins)} ASINs)...")
+    # Note: unlike search-sourced composites, these ASINs are USER-SUPPLIED, so a
+    # persistent 200-empty may be a dead/typo ASIN rather than a transient miss. The
+    # empty-retry is still bounded (≤REALTIME_EMPTY_RETRIES fast calls per ASIN) and the
+    # offline-fallback hint surfaces it — a wrong ASIN costs a few extra credits, not a hang.
     realtime_snapshots = []
     for asin in tracked_asins:
         log(f"  → {asin}")

--- a/amazon-keyword-traffic-analysis/scripts/zoodata.py
+++ b/amazon-keyword-traffic-analysis/scripts/zoodata.py
@@ -88,6 +88,7 @@ API_DOCS = "https://api.zoodata.ai/api-docs"   # API documentation URL
 MAX_RETRIES = 3       # Total attempt budget for ordinary failed requests
 RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
 RATE_LIMIT_RETRIES = 4  # Total attempt budget for 429 rate limits
+REALTIME_EMPTY_RETRIES = 3  # Total attempts when realtime/product returns a transient 200-empty (scrape miss)
 RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
 MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
@@ -570,7 +571,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_source = "asin_bsr"
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
-    # Priority 3: keyword → search → first product → realtime
+    # Priority 3: keyword → search → read categoryPath straight from the top product.
+    # products/search rows already carry categoryPath, so no extra realtime probe is
+    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
+    # bsrCategory, then to a realtime probe only as a last resort.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -578,23 +582,26 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
         }, "products (category probe)")
         prod_data = prod_result.get("data", [])
         if isinstance(prod_data, list) and prod_data:
-            probe_asin = prod_data[0].get("asin")
-            if probe_asin:
-                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+            top = prod_data[0]
+            if top.get("categoryPath"):
+                category_path = top["categoryPath"]
+                category_source = "inferred_from_search"
+                log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+            elif top.get("bsrCategory"):
+                cat_result = api_caller("categories", {"categoryKeyword": top["bsrCategory"]}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
+            elif top.get("asin"):
+                # Last resort only: realtime probe (flaky) with transient-empty retry.
+                rt = _fetch_realtime(api_caller, top["asin"])
                 rt_data = rt.get("data", {}) or {}
                 if rt_data.get("categoryPath"):
                     category_path = rt_data["categoryPath"]
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
-                elif rt_data.get("bestsellersRank"):
-                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
-                    if leaf:
-                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
-                        cat_data = cat_result.get("data", [])
-                        if cat_data:
-                            category_path = cat_data[0].get("categoryPath")
-                            category_source = "inferred_from_search"
-                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 
@@ -630,6 +637,50 @@ def _skipped_after_abort():
             "message": "skipped: an earlier call in this composite hit a terminal interface failure",
         },
     }
+
+
+REALTIME_FALLBACK_HINT = (
+    "Realtime data collection failed for one or more items after retries. Tell the "
+    "user realtime lookup is temporarily unavailable, then continue the analysis "
+    "using the offline snapshot data already gathered (products/search fields, "
+    "history, price/BSR/rating) — do not stall or fabricate the missing realtime detail."
+)
+
+
+def _is_empty_realtime(result):
+    """True when realtime/product returned a 200-success but empty payload
+    (`data.asin` blank) — a transient scrape miss, not a hard error."""
+    if not isinstance(result, dict):
+        return False
+    data = result.get("data")
+    return isinstance(data, dict) and not data.get("asin")
+
+
+def _fetch_realtime(caller, asin, marketplace="US", label=None, attempts=REALTIME_EMPTY_RETRIES):
+    """Fetch realtime/product for a known-good ASIN (it came from a search result),
+    retrying a transient 200-empty up to `attempts` total. `caller(endpoint, params,
+    label)` is the composite's safe_call or an api_call adapter. If still empty after
+    all attempts, stamps result['_realtimeStatus']='empty_after_retries' so callers
+    can surface the offline-fallback hint. Does NOT retry a terminal failure."""
+    params = {"asin": asin, "marketplace": marketplace}
+    lbl = label or f"realtime {asin}"
+    r = caller("realtime/product", params, lbl)
+    n = 1
+    while n < attempts and _is_empty_realtime(r) and not _is_terminal_failure(r):
+        n += 1
+        r = caller("realtime/product", params, lbl)
+    if _is_empty_realtime(r):
+        r["_realtimeStatus"] = "empty_after_retries"
+    return r
+
+
+def _note_realtime_fallback(results, result):
+    """If a realtime result came back empty after retries, bump the composite-level
+    counter and set the user-facing offline-fallback hint on results['meta']."""
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        m = results.setdefault("meta", {})
+        m["realtimeUnavailable"] = m.get("realtimeUnavailable", 0) + 1
+        m["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
 
 
 def _mark_cli_error():
@@ -1295,7 +1346,8 @@ def cmd_report(args):
         top_asin = product_data[0].get("asin")
         if top_asin:
             print(f"Step 4/4: Getting details for top ASIN {top_asin}...", file=sys.stderr)
-            detail_result = api_call("realtime/product", {"asin": top_asin, "marketplace": "US"})
+            detail_result = _fetch_realtime(_caller, top_asin)
+            _note_realtime_fallback(results, detail_result)
             results["topProductDetail"] = detail_result
     else:
         print("Step 4/4: No products found, skipping detail.", file=sys.stderr)
@@ -1356,7 +1408,9 @@ def cmd_opportunity(args):
         asin = p.get("asin")
         if asin:
             print(f"Step 4/4: Getting details for {asin}...", file=sys.stderr)
-            details.append(api_call("realtime/product", {"asin": asin, "marketplace": "US"}))
+            r = _fetch_realtime(_caller, asin)
+            _note_realtime_fallback(results, r)
+            details.append(r)
     results["topProductDetails"] = details
 
     print("Done.", file=sys.stderr)
@@ -1396,6 +1450,16 @@ def cmd_market_entry(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1653,6 +1717,16 @@ def cmd_competitor_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1829,6 +1903,16 @@ def cmd_pricing_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2032,6 +2116,16 @@ def cmd_daily_radar(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2193,6 +2287,16 @@ def cmd_listing_audit(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2420,6 +2524,16 @@ def cmd_opportunity_scan(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2623,6 +2737,16 @@ def cmd_review_deepdive(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):

--- a/amazon-keyword-traffic-analysis/scripts/zoodata.py
+++ b/amazon-keyword-traffic-analysis/scripts/zoodata.py
@@ -1283,11 +1283,17 @@ def cmd_product(args):
     if not args.asin:
         print("ERROR: --asin is required for product command.", file=sys.stderr)
         sys.exit(1)
-    params = {"asin": args.asin}
-    if args.marketplace:
-        params["marketplace"] = args.marketplace
-
-    result = api_call("realtime/product", params)
+    marketplace = args.marketplace or "US"
+    # realtime/product can return a transient 200-empty; retry like the composites do
+    # and, if still empty, surface the offline-fallback hint on the result's own meta so
+    # a per-ASIN poller (e.g. a Quick Check loop) gets the same signal to fall back to
+    # offline snapshot data instead of treating the empty payload as a real answer.
+    caller = lambda ep, p, label=None: api_call(ep, p)
+    result = _fetch_realtime(caller, args.asin, marketplace=marketplace)
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        meta = result.setdefault("meta", {})
+        meta["realtimeUnavailable"] = (meta.get("realtimeUnavailable") or 0) + 1
+        meta["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
     output(result, args.format)
 
 

--- a/amazon-keyword-traffic-analysis/scripts/zoodata.py
+++ b/amazon-keyword-traffic-analysis/scripts/zoodata.py
@@ -599,6 +599,39 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     return category_path, category_source
 
 
+def _has_scope(keyword, category_path):
+    """A category-scoped discovery call (products/search, products/competitors,
+    markets/search for leaders) needs at least one filter. With neither keyword
+    nor categoryPath the API returns unfiltered global top-sellers — a real bug
+    that benchmarks a listing against random products. Callers MUST gate such
+    calls on this."""
+    return bool(keyword or category_path)
+
+
+def _is_terminal_failure(result):
+    """True when a call returned an exhausted terminal interface failure
+    (transport retries used up). Once one happens inside a composite, the
+    remaining fan-out calls will almost certainly hit the same wall, so the
+    composite should stop rather than stack retry x timeout for every endpoint."""
+    if not isinstance(result, dict):
+        return False
+    err = result.get("error")
+    return isinstance(err, dict) and bool(err.get("retryExhausted"))
+
+
+def _skipped_after_abort():
+    """Envelope a composite's safe_call returns once the command has aborted
+    after a terminal failure — no network call, no credits consumed."""
+    return {
+        "success": False,
+        "data": None,
+        "error": {
+            "code": "ABORTED_AFTER_TERMINAL_FAILURE",
+            "message": "skipped: an earlier call in this composite hit a terminal interface failure",
+        },
+    }
+
+
 def _mark_cli_error():
     """Remember an API failure without interrupting a composite command."""
     global _cli_had_error
@@ -1227,16 +1260,14 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword like "yoga mat" with no direct category match still
+    # resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-
-    # Use the first matching category path
-    category_path = None
-    if cat_data:
-        category_path = cat_data[0].get("categoryPath")
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market data
     print("Step 2/4: Pulling market data...", file=sys.stderr)
@@ -1285,12 +1316,14 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword with no direct category match still resolves a
+    # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-    category_path = cat_data[0].get("categoryPath") if cat_data else None
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market validation
     print("Step 2/4: Validating market...", file=sys.stderr)
@@ -1358,9 +1391,16 @@ def cmd_market_entry(args):
 
     def safe_call(endpoint, params, label=""):
         """Call API and return result. Never exit on error."""
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # ── Step 0.5: Category Resolution ──
@@ -1608,9 +1648,16 @@ def cmd_competitor_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -1777,9 +1824,16 @@ def cmd_pricing_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 1: Current Price Snapshot
@@ -1973,9 +2027,16 @@ def cmd_daily_radar(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2127,9 +2188,16 @@ def cmd_listing_audit(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2144,22 +2212,50 @@ def cmd_listing_audit(args):
     results["target_realtime"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
     results["meta"]["steps_completed"].append("audit_target")
 
-    # Step 2: Category Leaders
-    log("Step 2/7: Finding category leaders...")
-    prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        prod_params["keyword"] = keyword
-    if category_path:
-        prod_params["categoryPath"] = category_path
-    results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+    # Step 1.5: Empty-target guard. If the target ASIN has no realtime data and no
+    # category resolved, the leader search below would run UNFILTERED and benchmark
+    # the listing against random global top-sellers. A missing target is not
+    # auditable — stop here rather than fabricate an audit against garbage peers.
+    _tgt = results["target_realtime"].get("data")
+    _tgt = _tgt if isinstance(_tgt, dict) else {}
+    if not _tgt.get("asin"):
+        results["meta"]["target_status"] = "empty"
+        results["meta"]["audit_status"] = "not_auditable"
+        results["meta"]["reason"] = (
+            "Target ASIN returned no realtime data (not indexed by ZooData or a "
+            "transient upstream failure). A listing audit cannot benchmark a missing "
+            "target; re-check the ASIN or retry later."
+        )
+        _mark_cli_error()
+        output(results, args.format)
+        return
+    results["meta"]["target_status"] = "ok"
 
-    comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
-                   "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        comp_params["keyword"] = keyword
-    if category_path:
-        comp_params["categoryPath"] = category_path
-    results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    # Step 2: Category Leaders — only with a scope, else the search is unfiltered.
+    log("Step 2/7: Finding category leaders...")
+    if _has_scope(keyword, category_path):
+        prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            prod_params["keyword"] = keyword
+        if category_path:
+            prod_params["categoryPath"] = category_path
+        results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+
+        comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
+                       "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            comp_params["keyword"] = keyword
+        if category_path:
+            comp_params["categoryPath"] = category_path
+        results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    else:
+        _no_scope = {"success": False, "data": [], "error": {
+            "code": "NO_CATEGORY_SCOPE",
+            "message": "skipped: no keyword or category to scope discovery (would return unfiltered global results)"}}
+        results["leader_products"] = _no_scope
+        results["competitors"] = _no_scope
+        results["meta"].setdefault("warnings", []).append(
+            "leader/competitor discovery skipped — target had no category and no keyword to scope on")
     results["meta"]["steps_completed"].append("category_leaders")
 
     # Step 3: Benchmark Realtime (Top 5 leaders, deduplicated)
@@ -2319,9 +2415,16 @@ def cmd_opportunity_scan(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -2515,9 +2618,16 @@ def cmd_review_deepdive(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution

--- a/amazon-keyword-traffic-analysis/scripts/zoodata.py
+++ b/amazon-keyword-traffic-analysis/scripts/zoodata.py
@@ -572,9 +572,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
     # Priority 3: keyword → search → read categoryPath straight from the top product.
-    # products/search rows already carry categoryPath, so no extra realtime probe is
-    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
-    # bsrCategory, then to a realtime probe only as a last resort.
+    # products/search rows already carry categoryPath, so category resolution needs NO
+    # realtime call here (realtime is a flaky scrape endpoint). Fall back to the
+    # product's bsrCategory; if even that is absent (a data anomaly), leave the category
+    # unresolved rather than gamble on a flaky realtime probe for one field we can't get.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -594,14 +595,6 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_path = cat_data[0].get("categoryPath")
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
-            elif top.get("asin"):
-                # Last resort only: realtime probe (flaky) with transient-empty retry.
-                rt = _fetch_realtime(api_caller, top["asin"])
-                rt_data = rt.get("data", {}) or {}
-                if rt_data.get("categoryPath"):
-                    category_path = rt_data["categoryPath"]
-                    category_source = "inferred_from_search"
-                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -91,7 +91,7 @@ When `_transport.status=402`, stop further calls. Report where the workflow stop
 
 ## On Empty Target
 
-When the target ASIN's realtime lookup returns no data (`data.asin` empty) and no category can be resolved, the `listing-audit` command now stops and returns `meta.audit_status = "not_auditable"` with `meta.target_status = "empty"` instead of benchmarking against an unfiltered leader set. If you see this, tell the user the ASIN was not found / not indexed by ZooData (or a transient upstream failure), ask them to re-check the ASIN or retry, and do not present any competitor/benchmark comparison — there is none.
+When the target ASIN's realtime lookup returns no data (`data.asin` empty), the `listing-audit` command now stops and returns `meta.audit_status = "not_auditable"` with `meta.target_status = "empty"` instead of benchmarking against an unfiltered (or category-mismatched) leader set. If you see this, tell the user the ASIN was not found / not indexed by ZooData (or a transient upstream failure), ask them to re-check the ASIN or retry, and do not present any competitor/benchmark comparison — there is none.
 
 ## Execution
 

--- a/amazon-listing-audit-pro/SKILL.md
+++ b/amazon-listing-audit-pro/SKILL.md
@@ -89,6 +89,10 @@ When `_transport.status=401`, stop further calls, tell the user that the configu
 
 When `_transport.status=402`, stop further calls. Report where the workflow stopped, any compatible partial findings already gathered, and returned credit metadata when present; direct the user to https://zoodata.ai/en/pricing and do not fabricate missing data.
 
+## On Empty Target
+
+When the target ASIN's realtime lookup returns no data (`data.asin` empty) and no category can be resolved, the `listing-audit` command now stops and returns `meta.audit_status = "not_auditable"` with `meta.target_status = "empty"` instead of benchmarking against an unfiltered leader set. If you see this, tell the user the ASIN was not found / not indexed by ZooData (or a transient upstream failure), ask them to re-check the ASIN or retry, and do not present any competitor/benchmark comparison — there is none.
+
 ## Execution
 
 1. `listing-audit --my-asin X [--keyword Y] [--category Z]` (composite, auto-detects category from ASIN)

--- a/amazon-listing-audit-pro/references/cli-contract.md
+++ b/amazon-listing-audit-pro/references/cli-contract.md
@@ -66,6 +66,10 @@ The shared CLI owns transport retries. Once the execution-environment permission
 - If all failures are documented non-terminal business/coverage failures, a local skill may use its explicit fallback and the compatible successful sections. Label coverage precisely and never present the composite as fully successful.
 - Process exit status and JSON status must agree for a single-result command. A partial pagination failure must return `success=false` while preserving already collected rows under `data`.
 
+## Realtime unavailable — offline fallback
+
+`realtime/product` is a live scrape endpoint that can return a transient 200-success with an empty payload. Composites retry it a few times; if it is still empty, that item's result carries `_realtimeStatus="empty_after_retries"`, and the composite `meta` carries `realtimeUnavailable` (count) plus `realtimeFallbackHint`. When `realtimeFallbackHint` is present, tell the user realtime lookup is temporarily unavailable for those items, then continue the analysis using the offline snapshot data already gathered (products/search fields, history, price/BSR/rating). Do not stall, silently re-run, or fabricate the missing realtime detail.
+
 ## Partial review pagination
 
 When `reviews-raw` fails after one or more successful pages, it returns `success=false`, preserves collected reviews and page count under `data`, and exposes the failed page request through `_failedQuery`. Never treat that payload as a complete review sample.

--- a/amazon-listing-audit-pro/scripts/zoodata.py
+++ b/amazon-listing-audit-pro/scripts/zoodata.py
@@ -533,7 +533,8 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     Priority:
       1. keyword → categories API
       2. asin → realtime/product → categoryPath or bestsellersRank leaf
-      3. keyword → products/search → first result → realtime/product
+      3. keyword → products/search → top row's categoryPath (else its bsrCategory);
+         no realtime call — the search row already carries the category.
     """
     category_path = None
     category_source = "user"
@@ -1304,9 +1305,9 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword like "yoga mat" with no direct category match still
-    # resolves a categoryPath — otherwise the market step below returns empty).
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword like "yoga mat" with no direct category match
+    # still resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
     _log = lambda m: print(m, file=sys.stderr)
@@ -1361,8 +1362,8 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword with no direct category match still resolves a
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword with no direct category match still resolves a
     # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
@@ -2135,6 +2136,10 @@ def cmd_daily_radar(args):
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
     log(f"Step 1/7: Realtime snapshot ({len(tracked_asins)} ASINs)...")
+    # Note: unlike search-sourced composites, these ASINs are USER-SUPPLIED, so a
+    # persistent 200-empty may be a dead/typo ASIN rather than a transient miss. The
+    # empty-retry is still bounded (≤REALTIME_EMPTY_RETRIES fast calls per ASIN) and the
+    # offline-fallback hint surfaces it — a wrong ASIN costs a few extra credits, not a hang.
     realtime_snapshots = []
     for asin in tracked_asins:
         log(f"  → {asin}")

--- a/amazon-listing-audit-pro/scripts/zoodata.py
+++ b/amazon-listing-audit-pro/scripts/zoodata.py
@@ -88,6 +88,7 @@ API_DOCS = "https://api.zoodata.ai/api-docs"   # API documentation URL
 MAX_RETRIES = 3       # Total attempt budget for ordinary failed requests
 RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
 RATE_LIMIT_RETRIES = 4  # Total attempt budget for 429 rate limits
+REALTIME_EMPTY_RETRIES = 3  # Total attempts when realtime/product returns a transient 200-empty (scrape miss)
 RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
 MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
@@ -570,7 +571,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_source = "asin_bsr"
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
-    # Priority 3: keyword → search → first product → realtime
+    # Priority 3: keyword → search → read categoryPath straight from the top product.
+    # products/search rows already carry categoryPath, so no extra realtime probe is
+    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
+    # bsrCategory, then to a realtime probe only as a last resort.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -578,23 +582,26 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
         }, "products (category probe)")
         prod_data = prod_result.get("data", [])
         if isinstance(prod_data, list) and prod_data:
-            probe_asin = prod_data[0].get("asin")
-            if probe_asin:
-                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+            top = prod_data[0]
+            if top.get("categoryPath"):
+                category_path = top["categoryPath"]
+                category_source = "inferred_from_search"
+                log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+            elif top.get("bsrCategory"):
+                cat_result = api_caller("categories", {"categoryKeyword": top["bsrCategory"]}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
+            elif top.get("asin"):
+                # Last resort only: realtime probe (flaky) with transient-empty retry.
+                rt = _fetch_realtime(api_caller, top["asin"])
                 rt_data = rt.get("data", {}) or {}
                 if rt_data.get("categoryPath"):
                     category_path = rt_data["categoryPath"]
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
-                elif rt_data.get("bestsellersRank"):
-                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
-                    if leaf:
-                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
-                        cat_data = cat_result.get("data", [])
-                        if cat_data:
-                            category_path = cat_data[0].get("categoryPath")
-                            category_source = "inferred_from_search"
-                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 
@@ -630,6 +637,50 @@ def _skipped_after_abort():
             "message": "skipped: an earlier call in this composite hit a terminal interface failure",
         },
     }
+
+
+REALTIME_FALLBACK_HINT = (
+    "Realtime data collection failed for one or more items after retries. Tell the "
+    "user realtime lookup is temporarily unavailable, then continue the analysis "
+    "using the offline snapshot data already gathered (products/search fields, "
+    "history, price/BSR/rating) — do not stall or fabricate the missing realtime detail."
+)
+
+
+def _is_empty_realtime(result):
+    """True when realtime/product returned a 200-success but empty payload
+    (`data.asin` blank) — a transient scrape miss, not a hard error."""
+    if not isinstance(result, dict):
+        return False
+    data = result.get("data")
+    return isinstance(data, dict) and not data.get("asin")
+
+
+def _fetch_realtime(caller, asin, marketplace="US", label=None, attempts=REALTIME_EMPTY_RETRIES):
+    """Fetch realtime/product for a known-good ASIN (it came from a search result),
+    retrying a transient 200-empty up to `attempts` total. `caller(endpoint, params,
+    label)` is the composite's safe_call or an api_call adapter. If still empty after
+    all attempts, stamps result['_realtimeStatus']='empty_after_retries' so callers
+    can surface the offline-fallback hint. Does NOT retry a terminal failure."""
+    params = {"asin": asin, "marketplace": marketplace}
+    lbl = label or f"realtime {asin}"
+    r = caller("realtime/product", params, lbl)
+    n = 1
+    while n < attempts and _is_empty_realtime(r) and not _is_terminal_failure(r):
+        n += 1
+        r = caller("realtime/product", params, lbl)
+    if _is_empty_realtime(r):
+        r["_realtimeStatus"] = "empty_after_retries"
+    return r
+
+
+def _note_realtime_fallback(results, result):
+    """If a realtime result came back empty after retries, bump the composite-level
+    counter and set the user-facing offline-fallback hint on results['meta']."""
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        m = results.setdefault("meta", {})
+        m["realtimeUnavailable"] = m.get("realtimeUnavailable", 0) + 1
+        m["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
 
 
 def _mark_cli_error():
@@ -1295,7 +1346,8 @@ def cmd_report(args):
         top_asin = product_data[0].get("asin")
         if top_asin:
             print(f"Step 4/4: Getting details for top ASIN {top_asin}...", file=sys.stderr)
-            detail_result = api_call("realtime/product", {"asin": top_asin, "marketplace": "US"})
+            detail_result = _fetch_realtime(_caller, top_asin)
+            _note_realtime_fallback(results, detail_result)
             results["topProductDetail"] = detail_result
     else:
         print("Step 4/4: No products found, skipping detail.", file=sys.stderr)
@@ -1356,7 +1408,9 @@ def cmd_opportunity(args):
         asin = p.get("asin")
         if asin:
             print(f"Step 4/4: Getting details for {asin}...", file=sys.stderr)
-            details.append(api_call("realtime/product", {"asin": asin, "marketplace": "US"}))
+            r = _fetch_realtime(_caller, asin)
+            _note_realtime_fallback(results, r)
+            details.append(r)
     results["topProductDetails"] = details
 
     print("Done.", file=sys.stderr)
@@ -1396,6 +1450,16 @@ def cmd_market_entry(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1653,6 +1717,16 @@ def cmd_competitor_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1829,6 +1903,16 @@ def cmd_pricing_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2032,6 +2116,16 @@ def cmd_daily_radar(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2193,6 +2287,16 @@ def cmd_listing_audit(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2420,6 +2524,16 @@ def cmd_opportunity_scan(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2623,6 +2737,16 @@ def cmd_review_deepdive(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):

--- a/amazon-listing-audit-pro/scripts/zoodata.py
+++ b/amazon-listing-audit-pro/scripts/zoodata.py
@@ -1283,11 +1283,17 @@ def cmd_product(args):
     if not args.asin:
         print("ERROR: --asin is required for product command.", file=sys.stderr)
         sys.exit(1)
-    params = {"asin": args.asin}
-    if args.marketplace:
-        params["marketplace"] = args.marketplace
-
-    result = api_call("realtime/product", params)
+    marketplace = args.marketplace or "US"
+    # realtime/product can return a transient 200-empty; retry like the composites do
+    # and, if still empty, surface the offline-fallback hint on the result's own meta so
+    # a per-ASIN poller (e.g. a Quick Check loop) gets the same signal to fall back to
+    # offline snapshot data instead of treating the empty payload as a real answer.
+    caller = lambda ep, p, label=None: api_call(ep, p)
+    result = _fetch_realtime(caller, args.asin, marketplace=marketplace)
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        meta = result.setdefault("meta", {})
+        meta["realtimeUnavailable"] = (meta.get("realtimeUnavailable") or 0) + 1
+        meta["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
     output(result, args.format)
 
 

--- a/amazon-listing-audit-pro/scripts/zoodata.py
+++ b/amazon-listing-audit-pro/scripts/zoodata.py
@@ -599,6 +599,39 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     return category_path, category_source
 
 
+def _has_scope(keyword, category_path):
+    """A category-scoped discovery call (products/search, products/competitors,
+    markets/search for leaders) needs at least one filter. With neither keyword
+    nor categoryPath the API returns unfiltered global top-sellers — a real bug
+    that benchmarks a listing against random products. Callers MUST gate such
+    calls on this."""
+    return bool(keyword or category_path)
+
+
+def _is_terminal_failure(result):
+    """True when a call returned an exhausted terminal interface failure
+    (transport retries used up). Once one happens inside a composite, the
+    remaining fan-out calls will almost certainly hit the same wall, so the
+    composite should stop rather than stack retry x timeout for every endpoint."""
+    if not isinstance(result, dict):
+        return False
+    err = result.get("error")
+    return isinstance(err, dict) and bool(err.get("retryExhausted"))
+
+
+def _skipped_after_abort():
+    """Envelope a composite's safe_call returns once the command has aborted
+    after a terminal failure — no network call, no credits consumed."""
+    return {
+        "success": False,
+        "data": None,
+        "error": {
+            "code": "ABORTED_AFTER_TERMINAL_FAILURE",
+            "message": "skipped: an earlier call in this composite hit a terminal interface failure",
+        },
+    }
+
+
 def _mark_cli_error():
     """Remember an API failure without interrupting a composite command."""
     global _cli_had_error
@@ -1227,16 +1260,14 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword like "yoga mat" with no direct category match still
+    # resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-
-    # Use the first matching category path
-    category_path = None
-    if cat_data:
-        category_path = cat_data[0].get("categoryPath")
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market data
     print("Step 2/4: Pulling market data...", file=sys.stderr)
@@ -1285,12 +1316,14 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword with no direct category match still resolves a
+    # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-    category_path = cat_data[0].get("categoryPath") if cat_data else None
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market validation
     print("Step 2/4: Validating market...", file=sys.stderr)
@@ -1358,9 +1391,16 @@ def cmd_market_entry(args):
 
     def safe_call(endpoint, params, label=""):
         """Call API and return result. Never exit on error."""
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # ── Step 0.5: Category Resolution ──
@@ -1608,9 +1648,16 @@ def cmd_competitor_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -1777,9 +1824,16 @@ def cmd_pricing_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 1: Current Price Snapshot
@@ -1973,9 +2027,16 @@ def cmd_daily_radar(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2127,9 +2188,16 @@ def cmd_listing_audit(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2144,22 +2212,50 @@ def cmd_listing_audit(args):
     results["target_realtime"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
     results["meta"]["steps_completed"].append("audit_target")
 
-    # Step 2: Category Leaders
-    log("Step 2/7: Finding category leaders...")
-    prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        prod_params["keyword"] = keyword
-    if category_path:
-        prod_params["categoryPath"] = category_path
-    results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+    # Step 1.5: Empty-target guard. If the target ASIN has no realtime data and no
+    # category resolved, the leader search below would run UNFILTERED and benchmark
+    # the listing against random global top-sellers. A missing target is not
+    # auditable — stop here rather than fabricate an audit against garbage peers.
+    _tgt = results["target_realtime"].get("data")
+    _tgt = _tgt if isinstance(_tgt, dict) else {}
+    if not _tgt.get("asin"):
+        results["meta"]["target_status"] = "empty"
+        results["meta"]["audit_status"] = "not_auditable"
+        results["meta"]["reason"] = (
+            "Target ASIN returned no realtime data (not indexed by ZooData or a "
+            "transient upstream failure). A listing audit cannot benchmark a missing "
+            "target; re-check the ASIN or retry later."
+        )
+        _mark_cli_error()
+        output(results, args.format)
+        return
+    results["meta"]["target_status"] = "ok"
 
-    comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
-                   "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        comp_params["keyword"] = keyword
-    if category_path:
-        comp_params["categoryPath"] = category_path
-    results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    # Step 2: Category Leaders — only with a scope, else the search is unfiltered.
+    log("Step 2/7: Finding category leaders...")
+    if _has_scope(keyword, category_path):
+        prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            prod_params["keyword"] = keyword
+        if category_path:
+            prod_params["categoryPath"] = category_path
+        results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+
+        comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
+                       "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            comp_params["keyword"] = keyword
+        if category_path:
+            comp_params["categoryPath"] = category_path
+        results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    else:
+        _no_scope = {"success": False, "data": [], "error": {
+            "code": "NO_CATEGORY_SCOPE",
+            "message": "skipped: no keyword or category to scope discovery (would return unfiltered global results)"}}
+        results["leader_products"] = _no_scope
+        results["competitors"] = _no_scope
+        results["meta"].setdefault("warnings", []).append(
+            "leader/competitor discovery skipped — target had no category and no keyword to scope on")
     results["meta"]["steps_completed"].append("category_leaders")
 
     # Step 3: Benchmark Realtime (Top 5 leaders, deduplicated)
@@ -2319,9 +2415,16 @@ def cmd_opportunity_scan(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -2515,9 +2618,16 @@ def cmd_review_deepdive(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution

--- a/amazon-listing-audit-pro/scripts/zoodata.py
+++ b/amazon-listing-audit-pro/scripts/zoodata.py
@@ -572,9 +572,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
     # Priority 3: keyword → search → read categoryPath straight from the top product.
-    # products/search rows already carry categoryPath, so no extra realtime probe is
-    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
-    # bsrCategory, then to a realtime probe only as a last resort.
+    # products/search rows already carry categoryPath, so category resolution needs NO
+    # realtime call here (realtime is a flaky scrape endpoint). Fall back to the
+    # product's bsrCategory; if even that is absent (a data anomaly), leave the category
+    # unresolved rather than gamble on a flaky realtime probe for one field we can't get.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -594,14 +595,6 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_path = cat_data[0].get("categoryPath")
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
-            elif top.get("asin"):
-                # Last resort only: realtime probe (flaky) with transient-empty retry.
-                rt = _fetch_realtime(api_caller, top["asin"])
-                rt_data = rt.get("data", {}) or {}
-                if rt_data.get("categoryPath"):
-                    category_path = rt_data["categoryPath"]
-                    category_source = "inferred_from_search"
-                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 

--- a/amazon-market-entry-analyzer/references/cli-contract.md
+++ b/amazon-market-entry-analyzer/references/cli-contract.md
@@ -66,6 +66,10 @@ The shared CLI owns transport retries. Once the execution-environment permission
 - If all failures are documented non-terminal business/coverage failures, a local skill may use its explicit fallback and the compatible successful sections. Label coverage precisely and never present the composite as fully successful.
 - Process exit status and JSON status must agree for a single-result command. A partial pagination failure must return `success=false` while preserving already collected rows under `data`.
 
+## Realtime unavailable — offline fallback
+
+`realtime/product` is a live scrape endpoint that can return a transient 200-success with an empty payload. Composites retry it a few times; if it is still empty, that item's result carries `_realtimeStatus="empty_after_retries"`, and the composite `meta` carries `realtimeUnavailable` (count) plus `realtimeFallbackHint`. When `realtimeFallbackHint` is present, tell the user realtime lookup is temporarily unavailable for those items, then continue the analysis using the offline snapshot data already gathered (products/search fields, history, price/BSR/rating). Do not stall, silently re-run, or fabricate the missing realtime detail.
+
 ## Partial review pagination
 
 When `reviews-raw` fails after one or more successful pages, it returns `success=false`, preserves collected reviews and page count under `data`, and exposes the failed page request through `_failedQuery`. Never treat that payload as a complete review sample.

--- a/amazon-market-entry-analyzer/scripts/zoodata.py
+++ b/amazon-market-entry-analyzer/scripts/zoodata.py
@@ -533,7 +533,8 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     Priority:
       1. keyword → categories API
       2. asin → realtime/product → categoryPath or bestsellersRank leaf
-      3. keyword → products/search → first result → realtime/product
+      3. keyword → products/search → top row's categoryPath (else its bsrCategory);
+         no realtime call — the search row already carries the category.
     """
     category_path = None
     category_source = "user"
@@ -1304,9 +1305,9 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword like "yoga mat" with no direct category match still
-    # resolves a categoryPath — otherwise the market step below returns empty).
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword like "yoga mat" with no direct category match
+    # still resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
     _log = lambda m: print(m, file=sys.stderr)
@@ -1361,8 +1362,8 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword with no direct category match still resolves a
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword with no direct category match still resolves a
     # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
@@ -2135,6 +2136,10 @@ def cmd_daily_radar(args):
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
     log(f"Step 1/7: Realtime snapshot ({len(tracked_asins)} ASINs)...")
+    # Note: unlike search-sourced composites, these ASINs are USER-SUPPLIED, so a
+    # persistent 200-empty may be a dead/typo ASIN rather than a transient miss. The
+    # empty-retry is still bounded (≤REALTIME_EMPTY_RETRIES fast calls per ASIN) and the
+    # offline-fallback hint surfaces it — a wrong ASIN costs a few extra credits, not a hang.
     realtime_snapshots = []
     for asin in tracked_asins:
         log(f"  → {asin}")

--- a/amazon-market-entry-analyzer/scripts/zoodata.py
+++ b/amazon-market-entry-analyzer/scripts/zoodata.py
@@ -88,6 +88,7 @@ API_DOCS = "https://api.zoodata.ai/api-docs"   # API documentation URL
 MAX_RETRIES = 3       # Total attempt budget for ordinary failed requests
 RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
 RATE_LIMIT_RETRIES = 4  # Total attempt budget for 429 rate limits
+REALTIME_EMPTY_RETRIES = 3  # Total attempts when realtime/product returns a transient 200-empty (scrape miss)
 RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
 MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
@@ -570,7 +571,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_source = "asin_bsr"
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
-    # Priority 3: keyword → search → first product → realtime
+    # Priority 3: keyword → search → read categoryPath straight from the top product.
+    # products/search rows already carry categoryPath, so no extra realtime probe is
+    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
+    # bsrCategory, then to a realtime probe only as a last resort.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -578,23 +582,26 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
         }, "products (category probe)")
         prod_data = prod_result.get("data", [])
         if isinstance(prod_data, list) and prod_data:
-            probe_asin = prod_data[0].get("asin")
-            if probe_asin:
-                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+            top = prod_data[0]
+            if top.get("categoryPath"):
+                category_path = top["categoryPath"]
+                category_source = "inferred_from_search"
+                log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+            elif top.get("bsrCategory"):
+                cat_result = api_caller("categories", {"categoryKeyword": top["bsrCategory"]}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
+            elif top.get("asin"):
+                # Last resort only: realtime probe (flaky) with transient-empty retry.
+                rt = _fetch_realtime(api_caller, top["asin"])
                 rt_data = rt.get("data", {}) or {}
                 if rt_data.get("categoryPath"):
                     category_path = rt_data["categoryPath"]
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
-                elif rt_data.get("bestsellersRank"):
-                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
-                    if leaf:
-                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
-                        cat_data = cat_result.get("data", [])
-                        if cat_data:
-                            category_path = cat_data[0].get("categoryPath")
-                            category_source = "inferred_from_search"
-                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 
@@ -630,6 +637,50 @@ def _skipped_after_abort():
             "message": "skipped: an earlier call in this composite hit a terminal interface failure",
         },
     }
+
+
+REALTIME_FALLBACK_HINT = (
+    "Realtime data collection failed for one or more items after retries. Tell the "
+    "user realtime lookup is temporarily unavailable, then continue the analysis "
+    "using the offline snapshot data already gathered (products/search fields, "
+    "history, price/BSR/rating) — do not stall or fabricate the missing realtime detail."
+)
+
+
+def _is_empty_realtime(result):
+    """True when realtime/product returned a 200-success but empty payload
+    (`data.asin` blank) — a transient scrape miss, not a hard error."""
+    if not isinstance(result, dict):
+        return False
+    data = result.get("data")
+    return isinstance(data, dict) and not data.get("asin")
+
+
+def _fetch_realtime(caller, asin, marketplace="US", label=None, attempts=REALTIME_EMPTY_RETRIES):
+    """Fetch realtime/product for a known-good ASIN (it came from a search result),
+    retrying a transient 200-empty up to `attempts` total. `caller(endpoint, params,
+    label)` is the composite's safe_call or an api_call adapter. If still empty after
+    all attempts, stamps result['_realtimeStatus']='empty_after_retries' so callers
+    can surface the offline-fallback hint. Does NOT retry a terminal failure."""
+    params = {"asin": asin, "marketplace": marketplace}
+    lbl = label or f"realtime {asin}"
+    r = caller("realtime/product", params, lbl)
+    n = 1
+    while n < attempts and _is_empty_realtime(r) and not _is_terminal_failure(r):
+        n += 1
+        r = caller("realtime/product", params, lbl)
+    if _is_empty_realtime(r):
+        r["_realtimeStatus"] = "empty_after_retries"
+    return r
+
+
+def _note_realtime_fallback(results, result):
+    """If a realtime result came back empty after retries, bump the composite-level
+    counter and set the user-facing offline-fallback hint on results['meta']."""
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        m = results.setdefault("meta", {})
+        m["realtimeUnavailable"] = m.get("realtimeUnavailable", 0) + 1
+        m["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
 
 
 def _mark_cli_error():
@@ -1295,7 +1346,8 @@ def cmd_report(args):
         top_asin = product_data[0].get("asin")
         if top_asin:
             print(f"Step 4/4: Getting details for top ASIN {top_asin}...", file=sys.stderr)
-            detail_result = api_call("realtime/product", {"asin": top_asin, "marketplace": "US"})
+            detail_result = _fetch_realtime(_caller, top_asin)
+            _note_realtime_fallback(results, detail_result)
             results["topProductDetail"] = detail_result
     else:
         print("Step 4/4: No products found, skipping detail.", file=sys.stderr)
@@ -1356,7 +1408,9 @@ def cmd_opportunity(args):
         asin = p.get("asin")
         if asin:
             print(f"Step 4/4: Getting details for {asin}...", file=sys.stderr)
-            details.append(api_call("realtime/product", {"asin": asin, "marketplace": "US"}))
+            r = _fetch_realtime(_caller, asin)
+            _note_realtime_fallback(results, r)
+            details.append(r)
     results["topProductDetails"] = details
 
     print("Done.", file=sys.stderr)
@@ -1396,6 +1450,16 @@ def cmd_market_entry(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1653,6 +1717,16 @@ def cmd_competitor_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1829,6 +1903,16 @@ def cmd_pricing_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2032,6 +2116,16 @@ def cmd_daily_radar(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2193,6 +2287,16 @@ def cmd_listing_audit(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2420,6 +2524,16 @@ def cmd_opportunity_scan(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2623,6 +2737,16 @@ def cmd_review_deepdive(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):

--- a/amazon-market-entry-analyzer/scripts/zoodata.py
+++ b/amazon-market-entry-analyzer/scripts/zoodata.py
@@ -1283,11 +1283,17 @@ def cmd_product(args):
     if not args.asin:
         print("ERROR: --asin is required for product command.", file=sys.stderr)
         sys.exit(1)
-    params = {"asin": args.asin}
-    if args.marketplace:
-        params["marketplace"] = args.marketplace
-
-    result = api_call("realtime/product", params)
+    marketplace = args.marketplace or "US"
+    # realtime/product can return a transient 200-empty; retry like the composites do
+    # and, if still empty, surface the offline-fallback hint on the result's own meta so
+    # a per-ASIN poller (e.g. a Quick Check loop) gets the same signal to fall back to
+    # offline snapshot data instead of treating the empty payload as a real answer.
+    caller = lambda ep, p, label=None: api_call(ep, p)
+    result = _fetch_realtime(caller, args.asin, marketplace=marketplace)
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        meta = result.setdefault("meta", {})
+        meta["realtimeUnavailable"] = (meta.get("realtimeUnavailable") or 0) + 1
+        meta["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
     output(result, args.format)
 
 

--- a/amazon-market-entry-analyzer/scripts/zoodata.py
+++ b/amazon-market-entry-analyzer/scripts/zoodata.py
@@ -599,6 +599,39 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     return category_path, category_source
 
 
+def _has_scope(keyword, category_path):
+    """A category-scoped discovery call (products/search, products/competitors,
+    markets/search for leaders) needs at least one filter. With neither keyword
+    nor categoryPath the API returns unfiltered global top-sellers — a real bug
+    that benchmarks a listing against random products. Callers MUST gate such
+    calls on this."""
+    return bool(keyword or category_path)
+
+
+def _is_terminal_failure(result):
+    """True when a call returned an exhausted terminal interface failure
+    (transport retries used up). Once one happens inside a composite, the
+    remaining fan-out calls will almost certainly hit the same wall, so the
+    composite should stop rather than stack retry x timeout for every endpoint."""
+    if not isinstance(result, dict):
+        return False
+    err = result.get("error")
+    return isinstance(err, dict) and bool(err.get("retryExhausted"))
+
+
+def _skipped_after_abort():
+    """Envelope a composite's safe_call returns once the command has aborted
+    after a terminal failure — no network call, no credits consumed."""
+    return {
+        "success": False,
+        "data": None,
+        "error": {
+            "code": "ABORTED_AFTER_TERMINAL_FAILURE",
+            "message": "skipped: an earlier call in this composite hit a terminal interface failure",
+        },
+    }
+
+
 def _mark_cli_error():
     """Remember an API failure without interrupting a composite command."""
     global _cli_had_error
@@ -1227,16 +1260,14 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword like "yoga mat" with no direct category match still
+    # resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-
-    # Use the first matching category path
-    category_path = None
-    if cat_data:
-        category_path = cat_data[0].get("categoryPath")
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market data
     print("Step 2/4: Pulling market data...", file=sys.stderr)
@@ -1285,12 +1316,14 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword with no direct category match still resolves a
+    # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-    category_path = cat_data[0].get("categoryPath") if cat_data else None
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market validation
     print("Step 2/4: Validating market...", file=sys.stderr)
@@ -1358,9 +1391,16 @@ def cmd_market_entry(args):
 
     def safe_call(endpoint, params, label=""):
         """Call API and return result. Never exit on error."""
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # ── Step 0.5: Category Resolution ──
@@ -1608,9 +1648,16 @@ def cmd_competitor_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -1777,9 +1824,16 @@ def cmd_pricing_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 1: Current Price Snapshot
@@ -1973,9 +2027,16 @@ def cmd_daily_radar(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2127,9 +2188,16 @@ def cmd_listing_audit(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2144,22 +2212,50 @@ def cmd_listing_audit(args):
     results["target_realtime"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
     results["meta"]["steps_completed"].append("audit_target")
 
-    # Step 2: Category Leaders
-    log("Step 2/7: Finding category leaders...")
-    prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        prod_params["keyword"] = keyword
-    if category_path:
-        prod_params["categoryPath"] = category_path
-    results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+    # Step 1.5: Empty-target guard. If the target ASIN has no realtime data and no
+    # category resolved, the leader search below would run UNFILTERED and benchmark
+    # the listing against random global top-sellers. A missing target is not
+    # auditable — stop here rather than fabricate an audit against garbage peers.
+    _tgt = results["target_realtime"].get("data")
+    _tgt = _tgt if isinstance(_tgt, dict) else {}
+    if not _tgt.get("asin"):
+        results["meta"]["target_status"] = "empty"
+        results["meta"]["audit_status"] = "not_auditable"
+        results["meta"]["reason"] = (
+            "Target ASIN returned no realtime data (not indexed by ZooData or a "
+            "transient upstream failure). A listing audit cannot benchmark a missing "
+            "target; re-check the ASIN or retry later."
+        )
+        _mark_cli_error()
+        output(results, args.format)
+        return
+    results["meta"]["target_status"] = "ok"
 
-    comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
-                   "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        comp_params["keyword"] = keyword
-    if category_path:
-        comp_params["categoryPath"] = category_path
-    results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    # Step 2: Category Leaders — only with a scope, else the search is unfiltered.
+    log("Step 2/7: Finding category leaders...")
+    if _has_scope(keyword, category_path):
+        prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            prod_params["keyword"] = keyword
+        if category_path:
+            prod_params["categoryPath"] = category_path
+        results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+
+        comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
+                       "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            comp_params["keyword"] = keyword
+        if category_path:
+            comp_params["categoryPath"] = category_path
+        results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    else:
+        _no_scope = {"success": False, "data": [], "error": {
+            "code": "NO_CATEGORY_SCOPE",
+            "message": "skipped: no keyword or category to scope discovery (would return unfiltered global results)"}}
+        results["leader_products"] = _no_scope
+        results["competitors"] = _no_scope
+        results["meta"].setdefault("warnings", []).append(
+            "leader/competitor discovery skipped — target had no category and no keyword to scope on")
     results["meta"]["steps_completed"].append("category_leaders")
 
     # Step 3: Benchmark Realtime (Top 5 leaders, deduplicated)
@@ -2319,9 +2415,16 @@ def cmd_opportunity_scan(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -2515,9 +2618,16 @@ def cmd_review_deepdive(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution

--- a/amazon-market-entry-analyzer/scripts/zoodata.py
+++ b/amazon-market-entry-analyzer/scripts/zoodata.py
@@ -572,9 +572,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
     # Priority 3: keyword → search → read categoryPath straight from the top product.
-    # products/search rows already carry categoryPath, so no extra realtime probe is
-    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
-    # bsrCategory, then to a realtime probe only as a last resort.
+    # products/search rows already carry categoryPath, so category resolution needs NO
+    # realtime call here (realtime is a flaky scrape endpoint). Fall back to the
+    # product's bsrCategory; if even that is absent (a data anomaly), leave the category
+    # unresolved rather than gamble on a flaky realtime probe for one field we can't get.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -594,14 +595,6 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_path = cat_data[0].get("categoryPath")
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
-            elif top.get("asin"):
-                # Last resort only: realtime probe (flaky) with transient-empty retry.
-                rt = _fetch_realtime(api_caller, top["asin"])
-                rt_data = rt.get("data", {}) or {}
-                if rt_data.get("categoryPath"):
-                    category_path = rt_data["categoryPath"]
-                    category_source = "inferred_from_search"
-                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 

--- a/amazon-market-trend-scanner/references/cli-contract.md
+++ b/amazon-market-trend-scanner/references/cli-contract.md
@@ -66,6 +66,10 @@ The shared CLI owns transport retries. Once the execution-environment permission
 - If all failures are documented non-terminal business/coverage failures, a local skill may use its explicit fallback and the compatible successful sections. Label coverage precisely and never present the composite as fully successful.
 - Process exit status and JSON status must agree for a single-result command. A partial pagination failure must return `success=false` while preserving already collected rows under `data`.
 
+## Realtime unavailable — offline fallback
+
+`realtime/product` is a live scrape endpoint that can return a transient 200-success with an empty payload. Composites retry it a few times; if it is still empty, that item's result carries `_realtimeStatus="empty_after_retries"`, and the composite `meta` carries `realtimeUnavailable` (count) plus `realtimeFallbackHint`. When `realtimeFallbackHint` is present, tell the user realtime lookup is temporarily unavailable for those items, then continue the analysis using the offline snapshot data already gathered (products/search fields, history, price/BSR/rating). Do not stall, silently re-run, or fabricate the missing realtime detail.
+
 ## Partial review pagination
 
 When `reviews-raw` fails after one or more successful pages, it returns `success=false`, preserves collected reviews and page count under `data`, and exposes the failed page request through `_failedQuery`. Never treat that payload as a complete review sample.

--- a/amazon-market-trend-scanner/scripts/zoodata.py
+++ b/amazon-market-trend-scanner/scripts/zoodata.py
@@ -533,7 +533,8 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     Priority:
       1. keyword → categories API
       2. asin → realtime/product → categoryPath or bestsellersRank leaf
-      3. keyword → products/search → first result → realtime/product
+      3. keyword → products/search → top row's categoryPath (else its bsrCategory);
+         no realtime call — the search row already carries the category.
     """
     category_path = None
     category_source = "user"
@@ -1304,9 +1305,9 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword like "yoga mat" with no direct category match still
-    # resolves a categoryPath — otherwise the market step below returns empty).
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword like "yoga mat" with no direct category match
+    # still resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
     _log = lambda m: print(m, file=sys.stderr)
@@ -1361,8 +1362,8 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword with no direct category match still resolves a
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword with no direct category match still resolves a
     # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
@@ -2135,6 +2136,10 @@ def cmd_daily_radar(args):
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
     log(f"Step 1/7: Realtime snapshot ({len(tracked_asins)} ASINs)...")
+    # Note: unlike search-sourced composites, these ASINs are USER-SUPPLIED, so a
+    # persistent 200-empty may be a dead/typo ASIN rather than a transient miss. The
+    # empty-retry is still bounded (≤REALTIME_EMPTY_RETRIES fast calls per ASIN) and the
+    # offline-fallback hint surfaces it — a wrong ASIN costs a few extra credits, not a hang.
     realtime_snapshots = []
     for asin in tracked_asins:
         log(f"  → {asin}")

--- a/amazon-market-trend-scanner/scripts/zoodata.py
+++ b/amazon-market-trend-scanner/scripts/zoodata.py
@@ -88,6 +88,7 @@ API_DOCS = "https://api.zoodata.ai/api-docs"   # API documentation URL
 MAX_RETRIES = 3       # Total attempt budget for ordinary failed requests
 RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
 RATE_LIMIT_RETRIES = 4  # Total attempt budget for 429 rate limits
+REALTIME_EMPTY_RETRIES = 3  # Total attempts when realtime/product returns a transient 200-empty (scrape miss)
 RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
 MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
@@ -570,7 +571,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_source = "asin_bsr"
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
-    # Priority 3: keyword → search → first product → realtime
+    # Priority 3: keyword → search → read categoryPath straight from the top product.
+    # products/search rows already carry categoryPath, so no extra realtime probe is
+    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
+    # bsrCategory, then to a realtime probe only as a last resort.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -578,23 +582,26 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
         }, "products (category probe)")
         prod_data = prod_result.get("data", [])
         if isinstance(prod_data, list) and prod_data:
-            probe_asin = prod_data[0].get("asin")
-            if probe_asin:
-                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+            top = prod_data[0]
+            if top.get("categoryPath"):
+                category_path = top["categoryPath"]
+                category_source = "inferred_from_search"
+                log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+            elif top.get("bsrCategory"):
+                cat_result = api_caller("categories", {"categoryKeyword": top["bsrCategory"]}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
+            elif top.get("asin"):
+                # Last resort only: realtime probe (flaky) with transient-empty retry.
+                rt = _fetch_realtime(api_caller, top["asin"])
                 rt_data = rt.get("data", {}) or {}
                 if rt_data.get("categoryPath"):
                     category_path = rt_data["categoryPath"]
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
-                elif rt_data.get("bestsellersRank"):
-                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
-                    if leaf:
-                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
-                        cat_data = cat_result.get("data", [])
-                        if cat_data:
-                            category_path = cat_data[0].get("categoryPath")
-                            category_source = "inferred_from_search"
-                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 
@@ -630,6 +637,50 @@ def _skipped_after_abort():
             "message": "skipped: an earlier call in this composite hit a terminal interface failure",
         },
     }
+
+
+REALTIME_FALLBACK_HINT = (
+    "Realtime data collection failed for one or more items after retries. Tell the "
+    "user realtime lookup is temporarily unavailable, then continue the analysis "
+    "using the offline snapshot data already gathered (products/search fields, "
+    "history, price/BSR/rating) — do not stall or fabricate the missing realtime detail."
+)
+
+
+def _is_empty_realtime(result):
+    """True when realtime/product returned a 200-success but empty payload
+    (`data.asin` blank) — a transient scrape miss, not a hard error."""
+    if not isinstance(result, dict):
+        return False
+    data = result.get("data")
+    return isinstance(data, dict) and not data.get("asin")
+
+
+def _fetch_realtime(caller, asin, marketplace="US", label=None, attempts=REALTIME_EMPTY_RETRIES):
+    """Fetch realtime/product for a known-good ASIN (it came from a search result),
+    retrying a transient 200-empty up to `attempts` total. `caller(endpoint, params,
+    label)` is the composite's safe_call or an api_call adapter. If still empty after
+    all attempts, stamps result['_realtimeStatus']='empty_after_retries' so callers
+    can surface the offline-fallback hint. Does NOT retry a terminal failure."""
+    params = {"asin": asin, "marketplace": marketplace}
+    lbl = label or f"realtime {asin}"
+    r = caller("realtime/product", params, lbl)
+    n = 1
+    while n < attempts and _is_empty_realtime(r) and not _is_terminal_failure(r):
+        n += 1
+        r = caller("realtime/product", params, lbl)
+    if _is_empty_realtime(r):
+        r["_realtimeStatus"] = "empty_after_retries"
+    return r
+
+
+def _note_realtime_fallback(results, result):
+    """If a realtime result came back empty after retries, bump the composite-level
+    counter and set the user-facing offline-fallback hint on results['meta']."""
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        m = results.setdefault("meta", {})
+        m["realtimeUnavailable"] = m.get("realtimeUnavailable", 0) + 1
+        m["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
 
 
 def _mark_cli_error():
@@ -1295,7 +1346,8 @@ def cmd_report(args):
         top_asin = product_data[0].get("asin")
         if top_asin:
             print(f"Step 4/4: Getting details for top ASIN {top_asin}...", file=sys.stderr)
-            detail_result = api_call("realtime/product", {"asin": top_asin, "marketplace": "US"})
+            detail_result = _fetch_realtime(_caller, top_asin)
+            _note_realtime_fallback(results, detail_result)
             results["topProductDetail"] = detail_result
     else:
         print("Step 4/4: No products found, skipping detail.", file=sys.stderr)
@@ -1356,7 +1408,9 @@ def cmd_opportunity(args):
         asin = p.get("asin")
         if asin:
             print(f"Step 4/4: Getting details for {asin}...", file=sys.stderr)
-            details.append(api_call("realtime/product", {"asin": asin, "marketplace": "US"}))
+            r = _fetch_realtime(_caller, asin)
+            _note_realtime_fallback(results, r)
+            details.append(r)
     results["topProductDetails"] = details
 
     print("Done.", file=sys.stderr)
@@ -1396,6 +1450,16 @@ def cmd_market_entry(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1653,6 +1717,16 @@ def cmd_competitor_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1829,6 +1903,16 @@ def cmd_pricing_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2032,6 +2116,16 @@ def cmd_daily_radar(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2193,6 +2287,16 @@ def cmd_listing_audit(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2420,6 +2524,16 @@ def cmd_opportunity_scan(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2623,6 +2737,16 @@ def cmd_review_deepdive(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):

--- a/amazon-market-trend-scanner/scripts/zoodata.py
+++ b/amazon-market-trend-scanner/scripts/zoodata.py
@@ -1283,11 +1283,17 @@ def cmd_product(args):
     if not args.asin:
         print("ERROR: --asin is required for product command.", file=sys.stderr)
         sys.exit(1)
-    params = {"asin": args.asin}
-    if args.marketplace:
-        params["marketplace"] = args.marketplace
-
-    result = api_call("realtime/product", params)
+    marketplace = args.marketplace or "US"
+    # realtime/product can return a transient 200-empty; retry like the composites do
+    # and, if still empty, surface the offline-fallback hint on the result's own meta so
+    # a per-ASIN poller (e.g. a Quick Check loop) gets the same signal to fall back to
+    # offline snapshot data instead of treating the empty payload as a real answer.
+    caller = lambda ep, p, label=None: api_call(ep, p)
+    result = _fetch_realtime(caller, args.asin, marketplace=marketplace)
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        meta = result.setdefault("meta", {})
+        meta["realtimeUnavailable"] = (meta.get("realtimeUnavailable") or 0) + 1
+        meta["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
     output(result, args.format)
 
 

--- a/amazon-market-trend-scanner/scripts/zoodata.py
+++ b/amazon-market-trend-scanner/scripts/zoodata.py
@@ -599,6 +599,39 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     return category_path, category_source
 
 
+def _has_scope(keyword, category_path):
+    """A category-scoped discovery call (products/search, products/competitors,
+    markets/search for leaders) needs at least one filter. With neither keyword
+    nor categoryPath the API returns unfiltered global top-sellers — a real bug
+    that benchmarks a listing against random products. Callers MUST gate such
+    calls on this."""
+    return bool(keyword or category_path)
+
+
+def _is_terminal_failure(result):
+    """True when a call returned an exhausted terminal interface failure
+    (transport retries used up). Once one happens inside a composite, the
+    remaining fan-out calls will almost certainly hit the same wall, so the
+    composite should stop rather than stack retry x timeout for every endpoint."""
+    if not isinstance(result, dict):
+        return False
+    err = result.get("error")
+    return isinstance(err, dict) and bool(err.get("retryExhausted"))
+
+
+def _skipped_after_abort():
+    """Envelope a composite's safe_call returns once the command has aborted
+    after a terminal failure — no network call, no credits consumed."""
+    return {
+        "success": False,
+        "data": None,
+        "error": {
+            "code": "ABORTED_AFTER_TERMINAL_FAILURE",
+            "message": "skipped: an earlier call in this composite hit a terminal interface failure",
+        },
+    }
+
+
 def _mark_cli_error():
     """Remember an API failure without interrupting a composite command."""
     global _cli_had_error
@@ -1227,16 +1260,14 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword like "yoga mat" with no direct category match still
+    # resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-
-    # Use the first matching category path
-    category_path = None
-    if cat_data:
-        category_path = cat_data[0].get("categoryPath")
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market data
     print("Step 2/4: Pulling market data...", file=sys.stderr)
@@ -1285,12 +1316,14 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword with no direct category match still resolves a
+    # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-    category_path = cat_data[0].get("categoryPath") if cat_data else None
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market validation
     print("Step 2/4: Validating market...", file=sys.stderr)
@@ -1358,9 +1391,16 @@ def cmd_market_entry(args):
 
     def safe_call(endpoint, params, label=""):
         """Call API and return result. Never exit on error."""
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # ── Step 0.5: Category Resolution ──
@@ -1608,9 +1648,16 @@ def cmd_competitor_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -1777,9 +1824,16 @@ def cmd_pricing_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 1: Current Price Snapshot
@@ -1973,9 +2027,16 @@ def cmd_daily_radar(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2127,9 +2188,16 @@ def cmd_listing_audit(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2144,22 +2212,50 @@ def cmd_listing_audit(args):
     results["target_realtime"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
     results["meta"]["steps_completed"].append("audit_target")
 
-    # Step 2: Category Leaders
-    log("Step 2/7: Finding category leaders...")
-    prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        prod_params["keyword"] = keyword
-    if category_path:
-        prod_params["categoryPath"] = category_path
-    results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+    # Step 1.5: Empty-target guard. If the target ASIN has no realtime data and no
+    # category resolved, the leader search below would run UNFILTERED and benchmark
+    # the listing against random global top-sellers. A missing target is not
+    # auditable — stop here rather than fabricate an audit against garbage peers.
+    _tgt = results["target_realtime"].get("data")
+    _tgt = _tgt if isinstance(_tgt, dict) else {}
+    if not _tgt.get("asin"):
+        results["meta"]["target_status"] = "empty"
+        results["meta"]["audit_status"] = "not_auditable"
+        results["meta"]["reason"] = (
+            "Target ASIN returned no realtime data (not indexed by ZooData or a "
+            "transient upstream failure). A listing audit cannot benchmark a missing "
+            "target; re-check the ASIN or retry later."
+        )
+        _mark_cli_error()
+        output(results, args.format)
+        return
+    results["meta"]["target_status"] = "ok"
 
-    comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
-                   "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        comp_params["keyword"] = keyword
-    if category_path:
-        comp_params["categoryPath"] = category_path
-    results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    # Step 2: Category Leaders — only with a scope, else the search is unfiltered.
+    log("Step 2/7: Finding category leaders...")
+    if _has_scope(keyword, category_path):
+        prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            prod_params["keyword"] = keyword
+        if category_path:
+            prod_params["categoryPath"] = category_path
+        results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+
+        comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
+                       "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            comp_params["keyword"] = keyword
+        if category_path:
+            comp_params["categoryPath"] = category_path
+        results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    else:
+        _no_scope = {"success": False, "data": [], "error": {
+            "code": "NO_CATEGORY_SCOPE",
+            "message": "skipped: no keyword or category to scope discovery (would return unfiltered global results)"}}
+        results["leader_products"] = _no_scope
+        results["competitors"] = _no_scope
+        results["meta"].setdefault("warnings", []).append(
+            "leader/competitor discovery skipped — target had no category and no keyword to scope on")
     results["meta"]["steps_completed"].append("category_leaders")
 
     # Step 3: Benchmark Realtime (Top 5 leaders, deduplicated)
@@ -2319,9 +2415,16 @@ def cmd_opportunity_scan(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -2515,9 +2618,16 @@ def cmd_review_deepdive(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution

--- a/amazon-market-trend-scanner/scripts/zoodata.py
+++ b/amazon-market-trend-scanner/scripts/zoodata.py
@@ -572,9 +572,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
     # Priority 3: keyword → search → read categoryPath straight from the top product.
-    # products/search rows already carry categoryPath, so no extra realtime probe is
-    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
-    # bsrCategory, then to a realtime probe only as a last resort.
+    # products/search rows already carry categoryPath, so category resolution needs NO
+    # realtime call here (realtime is a flaky scrape endpoint). Fall back to the
+    # product's bsrCategory; if even that is absent (a data anomaly), leave the category
+    # unresolved rather than gamble on a flaky realtime probe for one field we can't get.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -594,14 +595,6 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_path = cat_data[0].get("categoryPath")
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
-            elif top.get("asin"):
-                # Last resort only: realtime probe (flaky) with transient-empty retry.
-                rt = _fetch_realtime(api_caller, top["asin"])
-                rt_data = rt.get("data", {}) or {}
-                if rt_data.get("categoryPath"):
-                    category_path = rt_data["categoryPath"]
-                    category_source = "inferred_from_search"
-                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 

--- a/amazon-opportunity-discoverer/references/cli-contract.md
+++ b/amazon-opportunity-discoverer/references/cli-contract.md
@@ -66,6 +66,10 @@ The shared CLI owns transport retries. Once the execution-environment permission
 - If all failures are documented non-terminal business/coverage failures, a local skill may use its explicit fallback and the compatible successful sections. Label coverage precisely and never present the composite as fully successful.
 - Process exit status and JSON status must agree for a single-result command. A partial pagination failure must return `success=false` while preserving already collected rows under `data`.
 
+## Realtime unavailable — offline fallback
+
+`realtime/product` is a live scrape endpoint that can return a transient 200-success with an empty payload. Composites retry it a few times; if it is still empty, that item's result carries `_realtimeStatus="empty_after_retries"`, and the composite `meta` carries `realtimeUnavailable` (count) plus `realtimeFallbackHint`. When `realtimeFallbackHint` is present, tell the user realtime lookup is temporarily unavailable for those items, then continue the analysis using the offline snapshot data already gathered (products/search fields, history, price/BSR/rating). Do not stall, silently re-run, or fabricate the missing realtime detail.
+
 ## Partial review pagination
 
 When `reviews-raw` fails after one or more successful pages, it returns `success=false`, preserves collected reviews and page count under `data`, and exposes the failed page request through `_failedQuery`. Never treat that payload as a complete review sample.

--- a/amazon-opportunity-discoverer/scripts/zoodata.py
+++ b/amazon-opportunity-discoverer/scripts/zoodata.py
@@ -533,7 +533,8 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     Priority:
       1. keyword → categories API
       2. asin → realtime/product → categoryPath or bestsellersRank leaf
-      3. keyword → products/search → first result → realtime/product
+      3. keyword → products/search → top row's categoryPath (else its bsrCategory);
+         no realtime call — the search row already carries the category.
     """
     category_path = None
     category_source = "user"
@@ -1304,9 +1305,9 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword like "yoga mat" with no direct category match still
-    # resolves a categoryPath — otherwise the market step below returns empty).
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword like "yoga mat" with no direct category match
+    # still resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
     _log = lambda m: print(m, file=sys.stderr)
@@ -1361,8 +1362,8 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword with no direct category match still resolves a
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword with no direct category match still resolves a
     # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
@@ -2135,6 +2136,10 @@ def cmd_daily_radar(args):
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
     log(f"Step 1/7: Realtime snapshot ({len(tracked_asins)} ASINs)...")
+    # Note: unlike search-sourced composites, these ASINs are USER-SUPPLIED, so a
+    # persistent 200-empty may be a dead/typo ASIN rather than a transient miss. The
+    # empty-retry is still bounded (≤REALTIME_EMPTY_RETRIES fast calls per ASIN) and the
+    # offline-fallback hint surfaces it — a wrong ASIN costs a few extra credits, not a hang.
     realtime_snapshots = []
     for asin in tracked_asins:
         log(f"  → {asin}")

--- a/amazon-opportunity-discoverer/scripts/zoodata.py
+++ b/amazon-opportunity-discoverer/scripts/zoodata.py
@@ -88,6 +88,7 @@ API_DOCS = "https://api.zoodata.ai/api-docs"   # API documentation URL
 MAX_RETRIES = 3       # Total attempt budget for ordinary failed requests
 RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
 RATE_LIMIT_RETRIES = 4  # Total attempt budget for 429 rate limits
+REALTIME_EMPTY_RETRIES = 3  # Total attempts when realtime/product returns a transient 200-empty (scrape miss)
 RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
 MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
@@ -570,7 +571,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_source = "asin_bsr"
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
-    # Priority 3: keyword → search → first product → realtime
+    # Priority 3: keyword → search → read categoryPath straight from the top product.
+    # products/search rows already carry categoryPath, so no extra realtime probe is
+    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
+    # bsrCategory, then to a realtime probe only as a last resort.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -578,23 +582,26 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
         }, "products (category probe)")
         prod_data = prod_result.get("data", [])
         if isinstance(prod_data, list) and prod_data:
-            probe_asin = prod_data[0].get("asin")
-            if probe_asin:
-                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+            top = prod_data[0]
+            if top.get("categoryPath"):
+                category_path = top["categoryPath"]
+                category_source = "inferred_from_search"
+                log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+            elif top.get("bsrCategory"):
+                cat_result = api_caller("categories", {"categoryKeyword": top["bsrCategory"]}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
+            elif top.get("asin"):
+                # Last resort only: realtime probe (flaky) with transient-empty retry.
+                rt = _fetch_realtime(api_caller, top["asin"])
                 rt_data = rt.get("data", {}) or {}
                 if rt_data.get("categoryPath"):
                     category_path = rt_data["categoryPath"]
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
-                elif rt_data.get("bestsellersRank"):
-                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
-                    if leaf:
-                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
-                        cat_data = cat_result.get("data", [])
-                        if cat_data:
-                            category_path = cat_data[0].get("categoryPath")
-                            category_source = "inferred_from_search"
-                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 
@@ -630,6 +637,50 @@ def _skipped_after_abort():
             "message": "skipped: an earlier call in this composite hit a terminal interface failure",
         },
     }
+
+
+REALTIME_FALLBACK_HINT = (
+    "Realtime data collection failed for one or more items after retries. Tell the "
+    "user realtime lookup is temporarily unavailable, then continue the analysis "
+    "using the offline snapshot data already gathered (products/search fields, "
+    "history, price/BSR/rating) — do not stall or fabricate the missing realtime detail."
+)
+
+
+def _is_empty_realtime(result):
+    """True when realtime/product returned a 200-success but empty payload
+    (`data.asin` blank) — a transient scrape miss, not a hard error."""
+    if not isinstance(result, dict):
+        return False
+    data = result.get("data")
+    return isinstance(data, dict) and not data.get("asin")
+
+
+def _fetch_realtime(caller, asin, marketplace="US", label=None, attempts=REALTIME_EMPTY_RETRIES):
+    """Fetch realtime/product for a known-good ASIN (it came from a search result),
+    retrying a transient 200-empty up to `attempts` total. `caller(endpoint, params,
+    label)` is the composite's safe_call or an api_call adapter. If still empty after
+    all attempts, stamps result['_realtimeStatus']='empty_after_retries' so callers
+    can surface the offline-fallback hint. Does NOT retry a terminal failure."""
+    params = {"asin": asin, "marketplace": marketplace}
+    lbl = label or f"realtime {asin}"
+    r = caller("realtime/product", params, lbl)
+    n = 1
+    while n < attempts and _is_empty_realtime(r) and not _is_terminal_failure(r):
+        n += 1
+        r = caller("realtime/product", params, lbl)
+    if _is_empty_realtime(r):
+        r["_realtimeStatus"] = "empty_after_retries"
+    return r
+
+
+def _note_realtime_fallback(results, result):
+    """If a realtime result came back empty after retries, bump the composite-level
+    counter and set the user-facing offline-fallback hint on results['meta']."""
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        m = results.setdefault("meta", {})
+        m["realtimeUnavailable"] = m.get("realtimeUnavailable", 0) + 1
+        m["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
 
 
 def _mark_cli_error():
@@ -1295,7 +1346,8 @@ def cmd_report(args):
         top_asin = product_data[0].get("asin")
         if top_asin:
             print(f"Step 4/4: Getting details for top ASIN {top_asin}...", file=sys.stderr)
-            detail_result = api_call("realtime/product", {"asin": top_asin, "marketplace": "US"})
+            detail_result = _fetch_realtime(_caller, top_asin)
+            _note_realtime_fallback(results, detail_result)
             results["topProductDetail"] = detail_result
     else:
         print("Step 4/4: No products found, skipping detail.", file=sys.stderr)
@@ -1356,7 +1408,9 @@ def cmd_opportunity(args):
         asin = p.get("asin")
         if asin:
             print(f"Step 4/4: Getting details for {asin}...", file=sys.stderr)
-            details.append(api_call("realtime/product", {"asin": asin, "marketplace": "US"}))
+            r = _fetch_realtime(_caller, asin)
+            _note_realtime_fallback(results, r)
+            details.append(r)
     results["topProductDetails"] = details
 
     print("Done.", file=sys.stderr)
@@ -1396,6 +1450,16 @@ def cmd_market_entry(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1653,6 +1717,16 @@ def cmd_competitor_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1829,6 +1903,16 @@ def cmd_pricing_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2032,6 +2116,16 @@ def cmd_daily_radar(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2193,6 +2287,16 @@ def cmd_listing_audit(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2420,6 +2524,16 @@ def cmd_opportunity_scan(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2623,6 +2737,16 @@ def cmd_review_deepdive(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):

--- a/amazon-opportunity-discoverer/scripts/zoodata.py
+++ b/amazon-opportunity-discoverer/scripts/zoodata.py
@@ -1283,11 +1283,17 @@ def cmd_product(args):
     if not args.asin:
         print("ERROR: --asin is required for product command.", file=sys.stderr)
         sys.exit(1)
-    params = {"asin": args.asin}
-    if args.marketplace:
-        params["marketplace"] = args.marketplace
-
-    result = api_call("realtime/product", params)
+    marketplace = args.marketplace or "US"
+    # realtime/product can return a transient 200-empty; retry like the composites do
+    # and, if still empty, surface the offline-fallback hint on the result's own meta so
+    # a per-ASIN poller (e.g. a Quick Check loop) gets the same signal to fall back to
+    # offline snapshot data instead of treating the empty payload as a real answer.
+    caller = lambda ep, p, label=None: api_call(ep, p)
+    result = _fetch_realtime(caller, args.asin, marketplace=marketplace)
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        meta = result.setdefault("meta", {})
+        meta["realtimeUnavailable"] = (meta.get("realtimeUnavailable") or 0) + 1
+        meta["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
     output(result, args.format)
 
 

--- a/amazon-opportunity-discoverer/scripts/zoodata.py
+++ b/amazon-opportunity-discoverer/scripts/zoodata.py
@@ -599,6 +599,39 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     return category_path, category_source
 
 
+def _has_scope(keyword, category_path):
+    """A category-scoped discovery call (products/search, products/competitors,
+    markets/search for leaders) needs at least one filter. With neither keyword
+    nor categoryPath the API returns unfiltered global top-sellers — a real bug
+    that benchmarks a listing against random products. Callers MUST gate such
+    calls on this."""
+    return bool(keyword or category_path)
+
+
+def _is_terminal_failure(result):
+    """True when a call returned an exhausted terminal interface failure
+    (transport retries used up). Once one happens inside a composite, the
+    remaining fan-out calls will almost certainly hit the same wall, so the
+    composite should stop rather than stack retry x timeout for every endpoint."""
+    if not isinstance(result, dict):
+        return False
+    err = result.get("error")
+    return isinstance(err, dict) and bool(err.get("retryExhausted"))
+
+
+def _skipped_after_abort():
+    """Envelope a composite's safe_call returns once the command has aborted
+    after a terminal failure — no network call, no credits consumed."""
+    return {
+        "success": False,
+        "data": None,
+        "error": {
+            "code": "ABORTED_AFTER_TERMINAL_FAILURE",
+            "message": "skipped: an earlier call in this composite hit a terminal interface failure",
+        },
+    }
+
+
 def _mark_cli_error():
     """Remember an API failure without interrupting a composite command."""
     global _cli_had_error
@@ -1227,16 +1260,14 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword like "yoga mat" with no direct category match still
+    # resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-
-    # Use the first matching category path
-    category_path = None
-    if cat_data:
-        category_path = cat_data[0].get("categoryPath")
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market data
     print("Step 2/4: Pulling market data...", file=sys.stderr)
@@ -1285,12 +1316,14 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword with no direct category match still resolves a
+    # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-    category_path = cat_data[0].get("categoryPath") if cat_data else None
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market validation
     print("Step 2/4: Validating market...", file=sys.stderr)
@@ -1358,9 +1391,16 @@ def cmd_market_entry(args):
 
     def safe_call(endpoint, params, label=""):
         """Call API and return result. Never exit on error."""
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # ── Step 0.5: Category Resolution ──
@@ -1608,9 +1648,16 @@ def cmd_competitor_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -1777,9 +1824,16 @@ def cmd_pricing_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 1: Current Price Snapshot
@@ -1973,9 +2027,16 @@ def cmd_daily_radar(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2127,9 +2188,16 @@ def cmd_listing_audit(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2144,22 +2212,50 @@ def cmd_listing_audit(args):
     results["target_realtime"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
     results["meta"]["steps_completed"].append("audit_target")
 
-    # Step 2: Category Leaders
-    log("Step 2/7: Finding category leaders...")
-    prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        prod_params["keyword"] = keyword
-    if category_path:
-        prod_params["categoryPath"] = category_path
-    results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+    # Step 1.5: Empty-target guard. If the target ASIN has no realtime data and no
+    # category resolved, the leader search below would run UNFILTERED and benchmark
+    # the listing against random global top-sellers. A missing target is not
+    # auditable — stop here rather than fabricate an audit against garbage peers.
+    _tgt = results["target_realtime"].get("data")
+    _tgt = _tgt if isinstance(_tgt, dict) else {}
+    if not _tgt.get("asin"):
+        results["meta"]["target_status"] = "empty"
+        results["meta"]["audit_status"] = "not_auditable"
+        results["meta"]["reason"] = (
+            "Target ASIN returned no realtime data (not indexed by ZooData or a "
+            "transient upstream failure). A listing audit cannot benchmark a missing "
+            "target; re-check the ASIN or retry later."
+        )
+        _mark_cli_error()
+        output(results, args.format)
+        return
+    results["meta"]["target_status"] = "ok"
 
-    comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
-                   "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        comp_params["keyword"] = keyword
-    if category_path:
-        comp_params["categoryPath"] = category_path
-    results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    # Step 2: Category Leaders — only with a scope, else the search is unfiltered.
+    log("Step 2/7: Finding category leaders...")
+    if _has_scope(keyword, category_path):
+        prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            prod_params["keyword"] = keyword
+        if category_path:
+            prod_params["categoryPath"] = category_path
+        results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+
+        comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
+                       "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            comp_params["keyword"] = keyword
+        if category_path:
+            comp_params["categoryPath"] = category_path
+        results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    else:
+        _no_scope = {"success": False, "data": [], "error": {
+            "code": "NO_CATEGORY_SCOPE",
+            "message": "skipped: no keyword or category to scope discovery (would return unfiltered global results)"}}
+        results["leader_products"] = _no_scope
+        results["competitors"] = _no_scope
+        results["meta"].setdefault("warnings", []).append(
+            "leader/competitor discovery skipped — target had no category and no keyword to scope on")
     results["meta"]["steps_completed"].append("category_leaders")
 
     # Step 3: Benchmark Realtime (Top 5 leaders, deduplicated)
@@ -2319,9 +2415,16 @@ def cmd_opportunity_scan(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -2515,9 +2618,16 @@ def cmd_review_deepdive(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution

--- a/amazon-opportunity-discoverer/scripts/zoodata.py
+++ b/amazon-opportunity-discoverer/scripts/zoodata.py
@@ -572,9 +572,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
     # Priority 3: keyword → search → read categoryPath straight from the top product.
-    # products/search rows already carry categoryPath, so no extra realtime probe is
-    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
-    # bsrCategory, then to a realtime probe only as a last resort.
+    # products/search rows already carry categoryPath, so category resolution needs NO
+    # realtime call here (realtime is a flaky scrape endpoint). Fall back to the
+    # product's bsrCategory; if even that is absent (a data anomaly), leave the category
+    # unresolved rather than gamble on a flaky realtime probe for one field we can't get.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -594,14 +595,6 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_path = cat_data[0].get("categoryPath")
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
-            elif top.get("asin"):
-                # Last resort only: realtime probe (flaky) with transient-empty retry.
-                rt = _fetch_realtime(api_caller, top["asin"])
-                rt_data = rt.get("data", {}) or {}
-                if rt_data.get("categoryPath"):
-                    category_path = rt_data["categoryPath"]
-                    category_source = "inferred_from_search"
-                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 

--- a/amazon-pricing-command-center/references/cli-contract.md
+++ b/amazon-pricing-command-center/references/cli-contract.md
@@ -66,6 +66,10 @@ The shared CLI owns transport retries. Once the execution-environment permission
 - If all failures are documented non-terminal business/coverage failures, a local skill may use its explicit fallback and the compatible successful sections. Label coverage precisely and never present the composite as fully successful.
 - Process exit status and JSON status must agree for a single-result command. A partial pagination failure must return `success=false` while preserving already collected rows under `data`.
 
+## Realtime unavailable — offline fallback
+
+`realtime/product` is a live scrape endpoint that can return a transient 200-success with an empty payload. Composites retry it a few times; if it is still empty, that item's result carries `_realtimeStatus="empty_after_retries"`, and the composite `meta` carries `realtimeUnavailable` (count) plus `realtimeFallbackHint`. When `realtimeFallbackHint` is present, tell the user realtime lookup is temporarily unavailable for those items, then continue the analysis using the offline snapshot data already gathered (products/search fields, history, price/BSR/rating). Do not stall, silently re-run, or fabricate the missing realtime detail.
+
 ## Partial review pagination
 
 When `reviews-raw` fails after one or more successful pages, it returns `success=false`, preserves collected reviews and page count under `data`, and exposes the failed page request through `_failedQuery`. Never treat that payload as a complete review sample.

--- a/amazon-pricing-command-center/scripts/zoodata.py
+++ b/amazon-pricing-command-center/scripts/zoodata.py
@@ -533,7 +533,8 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     Priority:
       1. keyword → categories API
       2. asin → realtime/product → categoryPath or bestsellersRank leaf
-      3. keyword → products/search → first result → realtime/product
+      3. keyword → products/search → top row's categoryPath (else its bsrCategory);
+         no realtime call — the search row already carries the category.
     """
     category_path = None
     category_source = "user"
@@ -1304,9 +1305,9 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword like "yoga mat" with no direct category match still
-    # resolves a categoryPath — otherwise the market step below returns empty).
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword like "yoga mat" with no direct category match
+    # still resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
     _log = lambda m: print(m, file=sys.stderr)
@@ -1361,8 +1362,8 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword with no direct category match still resolves a
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword with no direct category match still resolves a
     # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
@@ -2135,6 +2136,10 @@ def cmd_daily_radar(args):
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
     log(f"Step 1/7: Realtime snapshot ({len(tracked_asins)} ASINs)...")
+    # Note: unlike search-sourced composites, these ASINs are USER-SUPPLIED, so a
+    # persistent 200-empty may be a dead/typo ASIN rather than a transient miss. The
+    # empty-retry is still bounded (≤REALTIME_EMPTY_RETRIES fast calls per ASIN) and the
+    # offline-fallback hint surfaces it — a wrong ASIN costs a few extra credits, not a hang.
     realtime_snapshots = []
     for asin in tracked_asins:
         log(f"  → {asin}")

--- a/amazon-pricing-command-center/scripts/zoodata.py
+++ b/amazon-pricing-command-center/scripts/zoodata.py
@@ -88,6 +88,7 @@ API_DOCS = "https://api.zoodata.ai/api-docs"   # API documentation URL
 MAX_RETRIES = 3       # Total attempt budget for ordinary failed requests
 RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
 RATE_LIMIT_RETRIES = 4  # Total attempt budget for 429 rate limits
+REALTIME_EMPTY_RETRIES = 3  # Total attempts when realtime/product returns a transient 200-empty (scrape miss)
 RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
 MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
@@ -570,7 +571,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_source = "asin_bsr"
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
-    # Priority 3: keyword → search → first product → realtime
+    # Priority 3: keyword → search → read categoryPath straight from the top product.
+    # products/search rows already carry categoryPath, so no extra realtime probe is
+    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
+    # bsrCategory, then to a realtime probe only as a last resort.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -578,23 +582,26 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
         }, "products (category probe)")
         prod_data = prod_result.get("data", [])
         if isinstance(prod_data, list) and prod_data:
-            probe_asin = prod_data[0].get("asin")
-            if probe_asin:
-                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+            top = prod_data[0]
+            if top.get("categoryPath"):
+                category_path = top["categoryPath"]
+                category_source = "inferred_from_search"
+                log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+            elif top.get("bsrCategory"):
+                cat_result = api_caller("categories", {"categoryKeyword": top["bsrCategory"]}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
+            elif top.get("asin"):
+                # Last resort only: realtime probe (flaky) with transient-empty retry.
+                rt = _fetch_realtime(api_caller, top["asin"])
                 rt_data = rt.get("data", {}) or {}
                 if rt_data.get("categoryPath"):
                     category_path = rt_data["categoryPath"]
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
-                elif rt_data.get("bestsellersRank"):
-                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
-                    if leaf:
-                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
-                        cat_data = cat_result.get("data", [])
-                        if cat_data:
-                            category_path = cat_data[0].get("categoryPath")
-                            category_source = "inferred_from_search"
-                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 
@@ -630,6 +637,50 @@ def _skipped_after_abort():
             "message": "skipped: an earlier call in this composite hit a terminal interface failure",
         },
     }
+
+
+REALTIME_FALLBACK_HINT = (
+    "Realtime data collection failed for one or more items after retries. Tell the "
+    "user realtime lookup is temporarily unavailable, then continue the analysis "
+    "using the offline snapshot data already gathered (products/search fields, "
+    "history, price/BSR/rating) — do not stall or fabricate the missing realtime detail."
+)
+
+
+def _is_empty_realtime(result):
+    """True when realtime/product returned a 200-success but empty payload
+    (`data.asin` blank) — a transient scrape miss, not a hard error."""
+    if not isinstance(result, dict):
+        return False
+    data = result.get("data")
+    return isinstance(data, dict) and not data.get("asin")
+
+
+def _fetch_realtime(caller, asin, marketplace="US", label=None, attempts=REALTIME_EMPTY_RETRIES):
+    """Fetch realtime/product for a known-good ASIN (it came from a search result),
+    retrying a transient 200-empty up to `attempts` total. `caller(endpoint, params,
+    label)` is the composite's safe_call or an api_call adapter. If still empty after
+    all attempts, stamps result['_realtimeStatus']='empty_after_retries' so callers
+    can surface the offline-fallback hint. Does NOT retry a terminal failure."""
+    params = {"asin": asin, "marketplace": marketplace}
+    lbl = label or f"realtime {asin}"
+    r = caller("realtime/product", params, lbl)
+    n = 1
+    while n < attempts and _is_empty_realtime(r) and not _is_terminal_failure(r):
+        n += 1
+        r = caller("realtime/product", params, lbl)
+    if _is_empty_realtime(r):
+        r["_realtimeStatus"] = "empty_after_retries"
+    return r
+
+
+def _note_realtime_fallback(results, result):
+    """If a realtime result came back empty after retries, bump the composite-level
+    counter and set the user-facing offline-fallback hint on results['meta']."""
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        m = results.setdefault("meta", {})
+        m["realtimeUnavailable"] = m.get("realtimeUnavailable", 0) + 1
+        m["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
 
 
 def _mark_cli_error():
@@ -1295,7 +1346,8 @@ def cmd_report(args):
         top_asin = product_data[0].get("asin")
         if top_asin:
             print(f"Step 4/4: Getting details for top ASIN {top_asin}...", file=sys.stderr)
-            detail_result = api_call("realtime/product", {"asin": top_asin, "marketplace": "US"})
+            detail_result = _fetch_realtime(_caller, top_asin)
+            _note_realtime_fallback(results, detail_result)
             results["topProductDetail"] = detail_result
     else:
         print("Step 4/4: No products found, skipping detail.", file=sys.stderr)
@@ -1356,7 +1408,9 @@ def cmd_opportunity(args):
         asin = p.get("asin")
         if asin:
             print(f"Step 4/4: Getting details for {asin}...", file=sys.stderr)
-            details.append(api_call("realtime/product", {"asin": asin, "marketplace": "US"}))
+            r = _fetch_realtime(_caller, asin)
+            _note_realtime_fallback(results, r)
+            details.append(r)
     results["topProductDetails"] = details
 
     print("Done.", file=sys.stderr)
@@ -1396,6 +1450,16 @@ def cmd_market_entry(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1653,6 +1717,16 @@ def cmd_competitor_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1829,6 +1903,16 @@ def cmd_pricing_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2032,6 +2116,16 @@ def cmd_daily_radar(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2193,6 +2287,16 @@ def cmd_listing_audit(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2420,6 +2524,16 @@ def cmd_opportunity_scan(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2623,6 +2737,16 @@ def cmd_review_deepdive(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):

--- a/amazon-pricing-command-center/scripts/zoodata.py
+++ b/amazon-pricing-command-center/scripts/zoodata.py
@@ -1283,11 +1283,17 @@ def cmd_product(args):
     if not args.asin:
         print("ERROR: --asin is required for product command.", file=sys.stderr)
         sys.exit(1)
-    params = {"asin": args.asin}
-    if args.marketplace:
-        params["marketplace"] = args.marketplace
-
-    result = api_call("realtime/product", params)
+    marketplace = args.marketplace or "US"
+    # realtime/product can return a transient 200-empty; retry like the composites do
+    # and, if still empty, surface the offline-fallback hint on the result's own meta so
+    # a per-ASIN poller (e.g. a Quick Check loop) gets the same signal to fall back to
+    # offline snapshot data instead of treating the empty payload as a real answer.
+    caller = lambda ep, p, label=None: api_call(ep, p)
+    result = _fetch_realtime(caller, args.asin, marketplace=marketplace)
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        meta = result.setdefault("meta", {})
+        meta["realtimeUnavailable"] = (meta.get("realtimeUnavailable") or 0) + 1
+        meta["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
     output(result, args.format)
 
 

--- a/amazon-pricing-command-center/scripts/zoodata.py
+++ b/amazon-pricing-command-center/scripts/zoodata.py
@@ -599,6 +599,39 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     return category_path, category_source
 
 
+def _has_scope(keyword, category_path):
+    """A category-scoped discovery call (products/search, products/competitors,
+    markets/search for leaders) needs at least one filter. With neither keyword
+    nor categoryPath the API returns unfiltered global top-sellers — a real bug
+    that benchmarks a listing against random products. Callers MUST gate such
+    calls on this."""
+    return bool(keyword or category_path)
+
+
+def _is_terminal_failure(result):
+    """True when a call returned an exhausted terminal interface failure
+    (transport retries used up). Once one happens inside a composite, the
+    remaining fan-out calls will almost certainly hit the same wall, so the
+    composite should stop rather than stack retry x timeout for every endpoint."""
+    if not isinstance(result, dict):
+        return False
+    err = result.get("error")
+    return isinstance(err, dict) and bool(err.get("retryExhausted"))
+
+
+def _skipped_after_abort():
+    """Envelope a composite's safe_call returns once the command has aborted
+    after a terminal failure — no network call, no credits consumed."""
+    return {
+        "success": False,
+        "data": None,
+        "error": {
+            "code": "ABORTED_AFTER_TERMINAL_FAILURE",
+            "message": "skipped: an earlier call in this composite hit a terminal interface failure",
+        },
+    }
+
+
 def _mark_cli_error():
     """Remember an API failure without interrupting a composite command."""
     global _cli_had_error
@@ -1227,16 +1260,14 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword like "yoga mat" with no direct category match still
+    # resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-
-    # Use the first matching category path
-    category_path = None
-    if cat_data:
-        category_path = cat_data[0].get("categoryPath")
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market data
     print("Step 2/4: Pulling market data...", file=sys.stderr)
@@ -1285,12 +1316,14 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword with no direct category match still resolves a
+    # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-    category_path = cat_data[0].get("categoryPath") if cat_data else None
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market validation
     print("Step 2/4: Validating market...", file=sys.stderr)
@@ -1358,9 +1391,16 @@ def cmd_market_entry(args):
 
     def safe_call(endpoint, params, label=""):
         """Call API and return result. Never exit on error."""
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # ── Step 0.5: Category Resolution ──
@@ -1608,9 +1648,16 @@ def cmd_competitor_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -1777,9 +1824,16 @@ def cmd_pricing_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 1: Current Price Snapshot
@@ -1973,9 +2027,16 @@ def cmd_daily_radar(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2127,9 +2188,16 @@ def cmd_listing_audit(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2144,22 +2212,50 @@ def cmd_listing_audit(args):
     results["target_realtime"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
     results["meta"]["steps_completed"].append("audit_target")
 
-    # Step 2: Category Leaders
-    log("Step 2/7: Finding category leaders...")
-    prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        prod_params["keyword"] = keyword
-    if category_path:
-        prod_params["categoryPath"] = category_path
-    results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+    # Step 1.5: Empty-target guard. If the target ASIN has no realtime data and no
+    # category resolved, the leader search below would run UNFILTERED and benchmark
+    # the listing against random global top-sellers. A missing target is not
+    # auditable — stop here rather than fabricate an audit against garbage peers.
+    _tgt = results["target_realtime"].get("data")
+    _tgt = _tgt if isinstance(_tgt, dict) else {}
+    if not _tgt.get("asin"):
+        results["meta"]["target_status"] = "empty"
+        results["meta"]["audit_status"] = "not_auditable"
+        results["meta"]["reason"] = (
+            "Target ASIN returned no realtime data (not indexed by ZooData or a "
+            "transient upstream failure). A listing audit cannot benchmark a missing "
+            "target; re-check the ASIN or retry later."
+        )
+        _mark_cli_error()
+        output(results, args.format)
+        return
+    results["meta"]["target_status"] = "ok"
 
-    comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
-                   "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        comp_params["keyword"] = keyword
-    if category_path:
-        comp_params["categoryPath"] = category_path
-    results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    # Step 2: Category Leaders — only with a scope, else the search is unfiltered.
+    log("Step 2/7: Finding category leaders...")
+    if _has_scope(keyword, category_path):
+        prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            prod_params["keyword"] = keyword
+        if category_path:
+            prod_params["categoryPath"] = category_path
+        results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+
+        comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
+                       "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            comp_params["keyword"] = keyword
+        if category_path:
+            comp_params["categoryPath"] = category_path
+        results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    else:
+        _no_scope = {"success": False, "data": [], "error": {
+            "code": "NO_CATEGORY_SCOPE",
+            "message": "skipped: no keyword or category to scope discovery (would return unfiltered global results)"}}
+        results["leader_products"] = _no_scope
+        results["competitors"] = _no_scope
+        results["meta"].setdefault("warnings", []).append(
+            "leader/competitor discovery skipped — target had no category and no keyword to scope on")
     results["meta"]["steps_completed"].append("category_leaders")
 
     # Step 3: Benchmark Realtime (Top 5 leaders, deduplicated)
@@ -2319,9 +2415,16 @@ def cmd_opportunity_scan(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -2515,9 +2618,16 @@ def cmd_review_deepdive(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution

--- a/amazon-pricing-command-center/scripts/zoodata.py
+++ b/amazon-pricing-command-center/scripts/zoodata.py
@@ -572,9 +572,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
     # Priority 3: keyword → search → read categoryPath straight from the top product.
-    # products/search rows already carry categoryPath, so no extra realtime probe is
-    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
-    # bsrCategory, then to a realtime probe only as a last resort.
+    # products/search rows already carry categoryPath, so category resolution needs NO
+    # realtime call here (realtime is a flaky scrape endpoint). Fall back to the
+    # product's bsrCategory; if even that is absent (a data anomaly), leave the category
+    # unresolved rather than gamble on a flaky realtime probe for one field we can't get.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -594,14 +595,6 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_path = cat_data[0].get("categoryPath")
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
-            elif top.get("asin"):
-                # Last resort only: realtime probe (flaky) with transient-empty retry.
-                rt = _fetch_realtime(api_caller, top["asin"])
-                rt_data = rt.get("data", {}) or {}
-                if rt_data.get("categoryPath"):
-                    category_path = rt_data["categoryPath"]
-                    category_source = "inferred_from_search"
-                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 

--- a/amazon-review-intelligence-extractor/references/cli-contract.md
+++ b/amazon-review-intelligence-extractor/references/cli-contract.md
@@ -66,6 +66,10 @@ The shared CLI owns transport retries. Once the execution-environment permission
 - If all failures are documented non-terminal business/coverage failures, a local skill may use its explicit fallback and the compatible successful sections. Label coverage precisely and never present the composite as fully successful.
 - Process exit status and JSON status must agree for a single-result command. A partial pagination failure must return `success=false` while preserving already collected rows under `data`.
 
+## Realtime unavailable — offline fallback
+
+`realtime/product` is a live scrape endpoint that can return a transient 200-success with an empty payload. Composites retry it a few times; if it is still empty, that item's result carries `_realtimeStatus="empty_after_retries"`, and the composite `meta` carries `realtimeUnavailable` (count) plus `realtimeFallbackHint`. When `realtimeFallbackHint` is present, tell the user realtime lookup is temporarily unavailable for those items, then continue the analysis using the offline snapshot data already gathered (products/search fields, history, price/BSR/rating). Do not stall, silently re-run, or fabricate the missing realtime detail.
+
 ## Partial review pagination
 
 When `reviews-raw` fails after one or more successful pages, it returns `success=false`, preserves collected reviews and page count under `data`, and exposes the failed page request through `_failedQuery`. Never treat that payload as a complete review sample.

--- a/amazon-review-intelligence-extractor/scripts/zoodata.py
+++ b/amazon-review-intelligence-extractor/scripts/zoodata.py
@@ -533,7 +533,8 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     Priority:
       1. keyword → categories API
       2. asin → realtime/product → categoryPath or bestsellersRank leaf
-      3. keyword → products/search → first result → realtime/product
+      3. keyword → products/search → top row's categoryPath (else its bsrCategory);
+         no realtime call — the search row already carries the category.
     """
     category_path = None
     category_source = "user"
@@ -1304,9 +1305,9 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword like "yoga mat" with no direct category match still
-    # resolves a categoryPath — otherwise the market step below returns empty).
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword like "yoga mat" with no direct category match
+    # still resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
     _log = lambda m: print(m, file=sys.stderr)
@@ -1361,8 +1362,8 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword with no direct category match still resolves a
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword with no direct category match still resolves a
     # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
@@ -2135,6 +2136,10 @@ def cmd_daily_radar(args):
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
     log(f"Step 1/7: Realtime snapshot ({len(tracked_asins)} ASINs)...")
+    # Note: unlike search-sourced composites, these ASINs are USER-SUPPLIED, so a
+    # persistent 200-empty may be a dead/typo ASIN rather than a transient miss. The
+    # empty-retry is still bounded (≤REALTIME_EMPTY_RETRIES fast calls per ASIN) and the
+    # offline-fallback hint surfaces it — a wrong ASIN costs a few extra credits, not a hang.
     realtime_snapshots = []
     for asin in tracked_asins:
         log(f"  → {asin}")

--- a/amazon-review-intelligence-extractor/scripts/zoodata.py
+++ b/amazon-review-intelligence-extractor/scripts/zoodata.py
@@ -88,6 +88,7 @@ API_DOCS = "https://api.zoodata.ai/api-docs"   # API documentation URL
 MAX_RETRIES = 3       # Total attempt budget for ordinary failed requests
 RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
 RATE_LIMIT_RETRIES = 4  # Total attempt budget for 429 rate limits
+REALTIME_EMPTY_RETRIES = 3  # Total attempts when realtime/product returns a transient 200-empty (scrape miss)
 RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
 MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
@@ -570,7 +571,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_source = "asin_bsr"
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
-    # Priority 3: keyword → search → first product → realtime
+    # Priority 3: keyword → search → read categoryPath straight from the top product.
+    # products/search rows already carry categoryPath, so no extra realtime probe is
+    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
+    # bsrCategory, then to a realtime probe only as a last resort.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -578,23 +582,26 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
         }, "products (category probe)")
         prod_data = prod_result.get("data", [])
         if isinstance(prod_data, list) and prod_data:
-            probe_asin = prod_data[0].get("asin")
-            if probe_asin:
-                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+            top = prod_data[0]
+            if top.get("categoryPath"):
+                category_path = top["categoryPath"]
+                category_source = "inferred_from_search"
+                log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+            elif top.get("bsrCategory"):
+                cat_result = api_caller("categories", {"categoryKeyword": top["bsrCategory"]}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
+            elif top.get("asin"):
+                # Last resort only: realtime probe (flaky) with transient-empty retry.
+                rt = _fetch_realtime(api_caller, top["asin"])
                 rt_data = rt.get("data", {}) or {}
                 if rt_data.get("categoryPath"):
                     category_path = rt_data["categoryPath"]
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
-                elif rt_data.get("bestsellersRank"):
-                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
-                    if leaf:
-                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
-                        cat_data = cat_result.get("data", [])
-                        if cat_data:
-                            category_path = cat_data[0].get("categoryPath")
-                            category_source = "inferred_from_search"
-                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 
@@ -630,6 +637,50 @@ def _skipped_after_abort():
             "message": "skipped: an earlier call in this composite hit a terminal interface failure",
         },
     }
+
+
+REALTIME_FALLBACK_HINT = (
+    "Realtime data collection failed for one or more items after retries. Tell the "
+    "user realtime lookup is temporarily unavailable, then continue the analysis "
+    "using the offline snapshot data already gathered (products/search fields, "
+    "history, price/BSR/rating) — do not stall or fabricate the missing realtime detail."
+)
+
+
+def _is_empty_realtime(result):
+    """True when realtime/product returned a 200-success but empty payload
+    (`data.asin` blank) — a transient scrape miss, not a hard error."""
+    if not isinstance(result, dict):
+        return False
+    data = result.get("data")
+    return isinstance(data, dict) and not data.get("asin")
+
+
+def _fetch_realtime(caller, asin, marketplace="US", label=None, attempts=REALTIME_EMPTY_RETRIES):
+    """Fetch realtime/product for a known-good ASIN (it came from a search result),
+    retrying a transient 200-empty up to `attempts` total. `caller(endpoint, params,
+    label)` is the composite's safe_call or an api_call adapter. If still empty after
+    all attempts, stamps result['_realtimeStatus']='empty_after_retries' so callers
+    can surface the offline-fallback hint. Does NOT retry a terminal failure."""
+    params = {"asin": asin, "marketplace": marketplace}
+    lbl = label or f"realtime {asin}"
+    r = caller("realtime/product", params, lbl)
+    n = 1
+    while n < attempts and _is_empty_realtime(r) and not _is_terminal_failure(r):
+        n += 1
+        r = caller("realtime/product", params, lbl)
+    if _is_empty_realtime(r):
+        r["_realtimeStatus"] = "empty_after_retries"
+    return r
+
+
+def _note_realtime_fallback(results, result):
+    """If a realtime result came back empty after retries, bump the composite-level
+    counter and set the user-facing offline-fallback hint on results['meta']."""
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        m = results.setdefault("meta", {})
+        m["realtimeUnavailable"] = m.get("realtimeUnavailable", 0) + 1
+        m["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
 
 
 def _mark_cli_error():
@@ -1295,7 +1346,8 @@ def cmd_report(args):
         top_asin = product_data[0].get("asin")
         if top_asin:
             print(f"Step 4/4: Getting details for top ASIN {top_asin}...", file=sys.stderr)
-            detail_result = api_call("realtime/product", {"asin": top_asin, "marketplace": "US"})
+            detail_result = _fetch_realtime(_caller, top_asin)
+            _note_realtime_fallback(results, detail_result)
             results["topProductDetail"] = detail_result
     else:
         print("Step 4/4: No products found, skipping detail.", file=sys.stderr)
@@ -1356,7 +1408,9 @@ def cmd_opportunity(args):
         asin = p.get("asin")
         if asin:
             print(f"Step 4/4: Getting details for {asin}...", file=sys.stderr)
-            details.append(api_call("realtime/product", {"asin": asin, "marketplace": "US"}))
+            r = _fetch_realtime(_caller, asin)
+            _note_realtime_fallback(results, r)
+            details.append(r)
     results["topProductDetails"] = details
 
     print("Done.", file=sys.stderr)
@@ -1396,6 +1450,16 @@ def cmd_market_entry(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1653,6 +1717,16 @@ def cmd_competitor_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1829,6 +1903,16 @@ def cmd_pricing_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2032,6 +2116,16 @@ def cmd_daily_radar(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2193,6 +2287,16 @@ def cmd_listing_audit(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2420,6 +2524,16 @@ def cmd_opportunity_scan(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2623,6 +2737,16 @@ def cmd_review_deepdive(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):

--- a/amazon-review-intelligence-extractor/scripts/zoodata.py
+++ b/amazon-review-intelligence-extractor/scripts/zoodata.py
@@ -1283,11 +1283,17 @@ def cmd_product(args):
     if not args.asin:
         print("ERROR: --asin is required for product command.", file=sys.stderr)
         sys.exit(1)
-    params = {"asin": args.asin}
-    if args.marketplace:
-        params["marketplace"] = args.marketplace
-
-    result = api_call("realtime/product", params)
+    marketplace = args.marketplace or "US"
+    # realtime/product can return a transient 200-empty; retry like the composites do
+    # and, if still empty, surface the offline-fallback hint on the result's own meta so
+    # a per-ASIN poller (e.g. a Quick Check loop) gets the same signal to fall back to
+    # offline snapshot data instead of treating the empty payload as a real answer.
+    caller = lambda ep, p, label=None: api_call(ep, p)
+    result = _fetch_realtime(caller, args.asin, marketplace=marketplace)
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        meta = result.setdefault("meta", {})
+        meta["realtimeUnavailable"] = (meta.get("realtimeUnavailable") or 0) + 1
+        meta["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
     output(result, args.format)
 
 

--- a/amazon-review-intelligence-extractor/scripts/zoodata.py
+++ b/amazon-review-intelligence-extractor/scripts/zoodata.py
@@ -599,6 +599,39 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     return category_path, category_source
 
 
+def _has_scope(keyword, category_path):
+    """A category-scoped discovery call (products/search, products/competitors,
+    markets/search for leaders) needs at least one filter. With neither keyword
+    nor categoryPath the API returns unfiltered global top-sellers — a real bug
+    that benchmarks a listing against random products. Callers MUST gate such
+    calls on this."""
+    return bool(keyword or category_path)
+
+
+def _is_terminal_failure(result):
+    """True when a call returned an exhausted terminal interface failure
+    (transport retries used up). Once one happens inside a composite, the
+    remaining fan-out calls will almost certainly hit the same wall, so the
+    composite should stop rather than stack retry x timeout for every endpoint."""
+    if not isinstance(result, dict):
+        return False
+    err = result.get("error")
+    return isinstance(err, dict) and bool(err.get("retryExhausted"))
+
+
+def _skipped_after_abort():
+    """Envelope a composite's safe_call returns once the command has aborted
+    after a terminal failure — no network call, no credits consumed."""
+    return {
+        "success": False,
+        "data": None,
+        "error": {
+            "code": "ABORTED_AFTER_TERMINAL_FAILURE",
+            "message": "skipped: an earlier call in this composite hit a terminal interface failure",
+        },
+    }
+
+
 def _mark_cli_error():
     """Remember an API failure without interrupting a composite command."""
     global _cli_had_error
@@ -1227,16 +1260,14 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword like "yoga mat" with no direct category match still
+    # resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-
-    # Use the first matching category path
-    category_path = None
-    if cat_data:
-        category_path = cat_data[0].get("categoryPath")
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market data
     print("Step 2/4: Pulling market data...", file=sys.stderr)
@@ -1285,12 +1316,14 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword with no direct category match still resolves a
+    # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-    category_path = cat_data[0].get("categoryPath") if cat_data else None
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market validation
     print("Step 2/4: Validating market...", file=sys.stderr)
@@ -1358,9 +1391,16 @@ def cmd_market_entry(args):
 
     def safe_call(endpoint, params, label=""):
         """Call API and return result. Never exit on error."""
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # ── Step 0.5: Category Resolution ──
@@ -1608,9 +1648,16 @@ def cmd_competitor_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -1777,9 +1824,16 @@ def cmd_pricing_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 1: Current Price Snapshot
@@ -1973,9 +2027,16 @@ def cmd_daily_radar(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2127,9 +2188,16 @@ def cmd_listing_audit(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2144,22 +2212,50 @@ def cmd_listing_audit(args):
     results["target_realtime"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
     results["meta"]["steps_completed"].append("audit_target")
 
-    # Step 2: Category Leaders
-    log("Step 2/7: Finding category leaders...")
-    prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        prod_params["keyword"] = keyword
-    if category_path:
-        prod_params["categoryPath"] = category_path
-    results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+    # Step 1.5: Empty-target guard. If the target ASIN has no realtime data and no
+    # category resolved, the leader search below would run UNFILTERED and benchmark
+    # the listing against random global top-sellers. A missing target is not
+    # auditable — stop here rather than fabricate an audit against garbage peers.
+    _tgt = results["target_realtime"].get("data")
+    _tgt = _tgt if isinstance(_tgt, dict) else {}
+    if not _tgt.get("asin"):
+        results["meta"]["target_status"] = "empty"
+        results["meta"]["audit_status"] = "not_auditable"
+        results["meta"]["reason"] = (
+            "Target ASIN returned no realtime data (not indexed by ZooData or a "
+            "transient upstream failure). A listing audit cannot benchmark a missing "
+            "target; re-check the ASIN or retry later."
+        )
+        _mark_cli_error()
+        output(results, args.format)
+        return
+    results["meta"]["target_status"] = "ok"
 
-    comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
-                   "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        comp_params["keyword"] = keyword
-    if category_path:
-        comp_params["categoryPath"] = category_path
-    results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    # Step 2: Category Leaders — only with a scope, else the search is unfiltered.
+    log("Step 2/7: Finding category leaders...")
+    if _has_scope(keyword, category_path):
+        prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            prod_params["keyword"] = keyword
+        if category_path:
+            prod_params["categoryPath"] = category_path
+        results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+
+        comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
+                       "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            comp_params["keyword"] = keyword
+        if category_path:
+            comp_params["categoryPath"] = category_path
+        results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    else:
+        _no_scope = {"success": False, "data": [], "error": {
+            "code": "NO_CATEGORY_SCOPE",
+            "message": "skipped: no keyword or category to scope discovery (would return unfiltered global results)"}}
+        results["leader_products"] = _no_scope
+        results["competitors"] = _no_scope
+        results["meta"].setdefault("warnings", []).append(
+            "leader/competitor discovery skipped — target had no category and no keyword to scope on")
     results["meta"]["steps_completed"].append("category_leaders")
 
     # Step 3: Benchmark Realtime (Top 5 leaders, deduplicated)
@@ -2319,9 +2415,16 @@ def cmd_opportunity_scan(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -2515,9 +2618,16 @@ def cmd_review_deepdive(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution

--- a/amazon-review-intelligence-extractor/scripts/zoodata.py
+++ b/amazon-review-intelligence-extractor/scripts/zoodata.py
@@ -572,9 +572,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
     # Priority 3: keyword → search → read categoryPath straight from the top product.
-    # products/search rows already carry categoryPath, so no extra realtime probe is
-    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
-    # bsrCategory, then to a realtime probe only as a last resort.
+    # products/search rows already carry categoryPath, so category resolution needs NO
+    # realtime call here (realtime is a flaky scrape endpoint). Fall back to the
+    # product's bsrCategory; if even that is absent (a data anomaly), leave the category
+    # unresolved rather than gamble on a flaky realtime probe for one field we can't get.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -594,14 +595,6 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_path = cat_data[0].get("categoryPath")
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
-            elif top.get("asin"):
-                # Last resort only: realtime probe (flaky) with transient-empty retry.
-                rt = _fetch_realtime(api_caller, top["asin"])
-                rt_data = rt.get("data", {}) or {}
-                if rt_data.get("categoryPath"):
-                    category_path = rt_data["categoryPath"]
-                    category_source = "inferred_from_search"
-                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 

--- a/tests/test_zoodata.py
+++ b/tests/test_zoodata.py
@@ -1507,6 +1507,109 @@ class TestCreditAggregation(unittest.TestCase):
         self.assertNotIn("creditsConsumed", payload["meta"])
 
 
+class TestCompositeRobustness(unittest.TestCase):
+    """Composite fail-fast + scope guards (fixes for keyword->category self-heal,
+    terminal-failure abort, and listing-audit empty-target)."""
+
+    def _run(self, argv, router):
+        """Run a composite with a per-endpoint api_call router.
+        Returns (calls, results) where calls is a list of (endpoint, params)
+        actually sent to api_call, and results is what output() received."""
+        calls = []
+        captured = {}
+
+        def fake_api_call(endpoint, params):
+            calls.append((endpoint, dict(params)))
+            resp = dict(router(endpoint, dict(params), calls))
+            resp.setdefault("_query", {"endpoint": endpoint, "params": params})
+            return resp
+
+        def fake_output(data, fmt="json"):
+            captured["results"] = data
+
+        with patch.object(zoodata, "api_call", side_effect=fake_api_call), \
+             patch.object(zoodata, "output", side_effect=fake_output), \
+             patch.object(sys, "argv", ["zoodata.py", *argv]):
+            try:
+                zoodata.main()
+            except SystemExit:
+                pass
+        return calls, captured.get("results", {})
+
+    # --- Fix: listing-audit empty-target guard ---
+    def test_listing_audit_empty_target_is_not_auditable(self):
+        def router(endpoint, params, calls):
+            if endpoint == "realtime/product":
+                return {"success": True, "data": {"asin": ""}}   # empty target
+            return {"success": True, "data": []}
+        calls, results = self._run(["listing-audit", "--my-asin", "B00EMPTY000"], router)
+        self.assertEqual(results.get("meta", {}).get("target_status"), "empty")
+        self.assertEqual(results.get("meta", {}).get("audit_status"), "not_auditable")
+        # must NOT have issued an unfiltered products/search (no keyword, no categoryPath)
+        for ep, p in calls:
+            if ep == "products/search":
+                self.assertTrue(p.get("keyword") or p.get("categoryPath"),
+                                f"unfiltered products/search issued: {p}")
+
+    def test_listing_audit_valid_target_proceeds(self):
+        def router(endpoint, params, calls):
+            if endpoint == "realtime/product":
+                return {"success": True, "data": {"asin": params.get("asin"),
+                        "categoryPath": ["Sports & Outdoors", "Yoga", "Mats"]}}
+            return {"success": True, "data": []}
+        calls, results = self._run(["listing-audit", "--my-asin", "B08373YJTB"], router)
+        self.assertEqual(results.get("meta", {}).get("target_status"), "ok")
+        self.assertNotEqual(results.get("meta", {}).get("audit_status"), "not_auditable")
+
+    def test_has_scope_helper(self):
+        self.assertFalse(zoodata._has_scope(None, None))
+        self.assertTrue(zoodata._has_scope("yoga mat", None))
+        self.assertTrue(zoodata._has_scope(None, ["A", "B"]))
+
+    # --- Fix: report/opportunity self-heal category for a product keyword ---
+    def test_report_self_heals_category_for_product_keyword(self):
+        def router(endpoint, params, calls):
+            if endpoint == "categories":
+                return {"success": True, "data": []}            # no direct category match
+            if endpoint == "products/search":
+                return {"success": True, "data": [{"asin": "B0PROBE001"}]}
+            if endpoint == "realtime/product":
+                return {"success": True, "data": {"asin": "B0PROBE001",
+                        "categoryPath": ["Sports & Outdoors", "Yoga", "Mats"]}}
+            if endpoint == "markets/search":
+                return {"success": True, "data": [{"totalSkuCount": 100}]}
+            return {"success": True, "data": []}
+        calls, results = self._run(["report", "--keyword", "yoga mat"], router)
+        market_calls = [p for ep, p in calls if ep == "markets/search"]
+        self.assertTrue(market_calls, "markets/search was not called")
+        # self-heal: market must be scoped by the resolved categoryPath, not categoryKeyword
+        self.assertEqual(market_calls[0].get("categoryPath"),
+                         ["Sports & Outdoors", "Yoga", "Mats"])
+        self.assertNotIn("categoryKeyword", market_calls[0])
+
+    # --- Fix: terminal failure aborts composite fan-out ---
+    def test_is_terminal_failure_helper(self):
+        self.assertTrue(zoodata._is_terminal_failure(
+            {"success": False, "error": {"retryExhausted": True}}))
+        self.assertFalse(zoodata._is_terminal_failure(
+            {"success": False, "error": {"code": "EMPTY"}}))
+        self.assertFalse(zoodata._is_terminal_failure({"success": True, "data": []}))
+
+    def test_composite_aborts_after_terminal_failure(self):
+        def router(endpoint, params, calls):
+            # first call resolves category; the next real call is a terminal failure
+            if len(calls) >= 2:
+                return {"success": False, "error": {
+                    "code": "HTTP_503", "message": "unavailable", "retryExhausted": True}}
+            return {"success": True, "data": [{"categoryPath": ["Sports", "Yoga"]}]}
+        calls, results = self._run(["market-entry", "--keyword", "yoga mat"], router)
+        self.assertTrue(results.get("meta", {}).get("aborted"),
+                        "composite did not set aborted flag after terminal failure")
+        # a full market-entry issues 20+ calls; abort must bound real network calls
+        self.assertLess(len(calls), 10,
+                        f"composite kept calling after terminal failure: {len(calls)} calls")
+
+
 # Standalone runner
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":

--- a/tests/test_zoodata.py
+++ b/tests/test_zoodata.py
@@ -1572,10 +1572,9 @@ class TestCompositeRobustness(unittest.TestCase):
             if endpoint == "categories":
                 return {"success": True, "data": []}            # no direct category match
             if endpoint == "products/search":
-                return {"success": True, "data": [{"asin": "B0PROBE001"}]}
-            if endpoint == "realtime/product":
-                return {"success": True, "data": {"asin": "B0PROBE001",
-                        "categoryPath": ["Sports & Outdoors", "Yoga", "Mats"]}}
+                # real products/search rows carry categoryPath — resolution reads it directly
+                return {"success": True, "data": [{"asin": "B0PROBE001",
+                        "categoryPath": ["Sports & Outdoors", "Yoga", "Mats"]}]}
             if endpoint == "markets/search":
                 return {"success": True, "data": [{"totalSkuCount": 100}]}
             return {"success": True, "data": []}
@@ -1691,6 +1690,36 @@ class TestCompositeRobustness(unittest.TestCase):
         self.assertEqual(results.get("meta", {}).get("category_source"), "inferred_from_search")
         market = [p for ep, p in calls if ep == "markets/search"]
         self.assertEqual(market[0].get("categoryPath"), ["Sports & Outdoors", "Yoga", "Mats"])
+
+    def test_resolve_category_never_calls_realtime(self):
+        """Category resolution reads categoryPath from the products/search row and
+        must NOT fall back to a flaky realtime probe."""
+        eps = []
+        def caller(endpoint, params, label=None):
+            eps.append(endpoint)
+            if endpoint == "categories":
+                return {"success": True, "data": []}
+            if endpoint == "products/search":
+                return {"success": True, "data": [{"asin": "B01", "categoryPath": ["A", "B", "C"]}]}
+            return {"success": True, "data": []}
+        cp, src = zoodata._resolve_category(caller, lambda m: None, keyword="yoga mat")
+        self.assertEqual(cp, ["A", "B", "C"])
+        self.assertEqual(src, "inferred_from_search")
+        self.assertNotIn("realtime/product", eps)
+
+    def test_resolve_category_bsr_fallback_still_no_realtime(self):
+        """If categoryPath is absent, fall back to bsrCategory — still no realtime."""
+        eps = []
+        def caller(endpoint, params, label=None):
+            eps.append(endpoint)
+            if endpoint == "products/search":
+                return {"success": True, "data": [{"asin": "B01", "bsrCategory": "Yoga Mats"}]}
+            if endpoint == "categories":
+                return {"success": True, "data": [{"categoryPath": ["Sports", "Yoga", "Mats"]}]}
+            return {"success": True, "data": []}
+        cp, src = zoodata._resolve_category(caller, lambda m: None, keyword="yoga mat")
+        self.assertEqual(cp, ["Sports", "Yoga", "Mats"])
+        self.assertNotIn("realtime/product", eps)
 
     def test_composite_sets_offline_fallback_hint_when_realtime_stays_empty(self):
         def router(endpoint, params, calls):

--- a/tests/test_zoodata.py
+++ b/tests/test_zoodata.py
@@ -1609,6 +1609,35 @@ class TestCompositeRobustness(unittest.TestCase):
         self.assertLess(len(calls), 10,
                         f"composite kept calling after terminal failure: {len(calls)} calls")
 
+    def test_composite_does_NOT_abort_on_business_failure(self):
+        """Safety property: a per-endpoint business failure WITHOUT retryExhausted
+        (404/422/empty-but-success) must NOT abort the whole composite."""
+        def router(endpoint, params, calls):
+            if endpoint == "categories":
+                return {"success": True, "data": [{"categoryPath": ["Sports", "Yoga"]}]}
+            if endpoint == "markets/search":
+                # non-terminal business failure mid fan-out — must be tolerated, not abort
+                return {"success": False, "error": {"code": "HTTP_422", "message": "validation"}}
+            return {"success": True, "data": []}
+        calls, results = self._run(["market-entry", "--keyword", "yoga mat"], router)
+        self.assertFalse(results.get("meta", {}).get("aborted"),
+                         "composite wrongly aborted on a non-terminal business failure")
+        # composite must have continued PAST the failing markets/search to other endpoints
+        endpoints = {ep for ep, _ in calls}
+        self.assertTrue(endpoints - {"categories", "markets/search"},
+                        f"composite stopped after the non-terminal failure; only hit {endpoints}")
+
+    def test_listing_audit_empty_target_null_data(self):
+        """Empty target detected regardless of realtime data shape (None / list)."""
+        for empty in (None, []):
+            def router(endpoint, params, calls, _e=empty):
+                if endpoint == "realtime/product":
+                    return {"success": True, "data": _e}
+                return {"success": True, "data": []}
+            calls, results = self._run(["listing-audit", "--my-asin", "B00X"], router)
+            self.assertEqual(results.get("meta", {}).get("audit_status"),
+                             "not_auditable", f"data={empty!r} not treated as empty target")
+
 
 # Standalone runner
 # ---------------------------------------------------------------------------

--- a/tests/test_zoodata.py
+++ b/tests/test_zoodata.py
@@ -1638,6 +1638,74 @@ class TestCompositeRobustness(unittest.TestCase):
             self.assertEqual(results.get("meta", {}).get("audit_status"),
                              "not_auditable", f"data={empty!r} not treated as empty target")
 
+    # --- realtime empty-retry + offline fallback ---
+    def test_is_empty_realtime_helper(self):
+        self.assertTrue(zoodata._is_empty_realtime({"success": True, "data": {"asin": ""}}))
+        self.assertTrue(zoodata._is_empty_realtime({"success": True, "data": {}}))
+        self.assertFalse(zoodata._is_empty_realtime({"success": True, "data": {"asin": "B01"}}))
+        self.assertFalse(zoodata._is_empty_realtime({"success": True, "data": []}))
+        self.assertFalse(zoodata._is_empty_realtime({"success": False, "data": None}))
+
+    def test_fetch_realtime_retries_transient_empty_then_succeeds(self):
+        seq = [
+            {"success": True, "data": {"asin": ""}},
+            {"success": True, "data": {"asin": ""}},
+            {"success": True, "data": {"asin": "B01", "categoryPath": ["A"]}},
+        ]
+        state = {"n": 0}
+        def caller(ep, params, label=None):
+            r = seq[state["n"]]; state["n"] += 1; return r
+        r = zoodata._fetch_realtime(caller, "B01")
+        self.assertEqual(state["n"], 3)               # retried until data arrived
+        self.assertEqual(r["data"]["asin"], "B01")
+        self.assertNotIn("_realtimeStatus", r)        # succeeded → no fallback mark
+
+    def test_fetch_realtime_gives_up_after_attempts(self):
+        state = {"n": 0}
+        def caller(ep, params, label=None):
+            state["n"] += 1
+            return {"success": True, "data": {"asin": ""}}
+        r = zoodata._fetch_realtime(caller, "B01")
+        self.assertEqual(state["n"], zoodata.REALTIME_EMPTY_RETRIES)   # bounded, not infinite
+        self.assertEqual(r.get("_realtimeStatus"), "empty_after_retries")
+
+    def test_fetch_realtime_does_not_retry_terminal_failure(self):
+        state = {"n": 0}
+        def caller(ep, params, label=None):
+            state["n"] += 1
+            return {"success": False, "error": {"retryExhausted": True}}
+        zoodata._fetch_realtime(caller, "B01")
+        self.assertEqual(state["n"], 1)               # terminal → hand off to ②, no retry
+
+    def test_report_category_resolves_from_products_not_realtime_probe(self):
+        def router(endpoint, params, calls):
+            if endpoint == "categories":
+                return {"success": True, "data": []}
+            if endpoint == "products/search":
+                return {"success": True, "data": [{"asin": "B01",
+                        "categoryPath": ["Sports & Outdoors", "Yoga", "Mats"]}]}
+            if endpoint == "markets/search":
+                return {"success": True, "data": [{"totalSkuCount": 1}]}
+            return {"success": True, "data": []}   # realtime (Step 4 detail) returns no category
+        calls, results = self._run(["report", "--keyword", "yoga mat"], router)
+        self.assertEqual(results.get("meta", {}).get("category_source"), "inferred_from_search")
+        market = [p for ep, p in calls if ep == "markets/search"]
+        self.assertEqual(market[0].get("categoryPath"), ["Sports & Outdoors", "Yoga", "Mats"])
+
+    def test_composite_sets_offline_fallback_hint_when_realtime_stays_empty(self):
+        def router(endpoint, params, calls):
+            if endpoint == "realtime/product":
+                return {"success": True, "data": {"asin": ""}}      # always transient-empty
+            if endpoint in ("categories", "products/search"):
+                return {"success": True, "data": [{"asin": "B01", "categoryPath": ["A", "B"]}]}
+            return {"success": True, "data": []}
+        calls, results = self._run(["opportunity", "--keyword", "yoga mat"], router)
+        meta = results.get("meta", {})
+        self.assertIn("realtimeFallbackHint", meta)
+        self.assertGreaterEqual(meta.get("realtimeUnavailable", 0), 1)
+        rt_calls = [ep for ep, _ in calls if ep == "realtime/product"]
+        self.assertGreaterEqual(len(rt_calls), zoodata.REALTIME_EMPTY_RETRIES)  # did retry
+
 
 # Standalone runner
 # ---------------------------------------------------------------------------

--- a/tests/test_zoodata.py
+++ b/tests/test_zoodata.py
@@ -1735,6 +1735,26 @@ class TestCompositeRobustness(unittest.TestCase):
         rt_calls = [ep for ep, _ in calls if ep == "realtime/product"]
         self.assertGreaterEqual(len(rt_calls), zoodata.REALTIME_EMPTY_RETRIES)  # did retry
 
+    def test_product_command_retries_and_sets_fallback(self):
+        """Granular `product` retries transient-empty realtime and, if still empty,
+        stamps the offline-fallback hint on meta (parity with composites / Quick Check)."""
+        def router(endpoint, params, calls):
+            return {"success": True, "data": {"asin": ""}, "meta": {"creditsConsumed": 1}}
+        calls, result = self._run(["product", "--asin", "B0DEAD0000"], router)
+        rt_calls = [ep for ep, _ in calls if ep == "realtime/product"]
+        self.assertEqual(len(rt_calls), zoodata.REALTIME_EMPTY_RETRIES)   # retried, not single-shot
+        self.assertEqual(result.get("_realtimeStatus"), "empty_after_retries")
+        self.assertIn("realtimeFallbackHint", result.get("meta", {}))
+
+    def test_product_command_success_no_retry_no_fallback(self):
+        def router(endpoint, params, calls):
+            return {"success": True, "data": {"asin": params["asin"], "title": "X"},
+                    "meta": {"creditsConsumed": 1}}
+        calls, result = self._run(["product", "--asin", "B01LP0U5X0"], router)
+        rt_calls = [ep for ep, _ in calls if ep == "realtime/product"]
+        self.assertEqual(len(rt_calls), 1)                    # data present → no retry
+        self.assertNotIn("realtimeFallbackHint", result.get("meta", {}))
+
 
 # Standalone runner
 # ---------------------------------------------------------------------------

--- a/zoodata/references/cli-contract.md
+++ b/zoodata/references/cli-contract.md
@@ -66,6 +66,10 @@ The shared CLI owns transport retries. Once the execution-environment permission
 - If all failures are documented non-terminal business/coverage failures, a local skill may use its explicit fallback and the compatible successful sections. Label coverage precisely and never present the composite as fully successful.
 - Process exit status and JSON status must agree for a single-result command. A partial pagination failure must return `success=false` while preserving already collected rows under `data`.
 
+## Realtime unavailable — offline fallback
+
+`realtime/product` is a live scrape endpoint that can return a transient 200-success with an empty payload. Composites retry it a few times; if it is still empty, that item's result carries `_realtimeStatus="empty_after_retries"`, and the composite `meta` carries `realtimeUnavailable` (count) plus `realtimeFallbackHint`. When `realtimeFallbackHint` is present, tell the user realtime lookup is temporarily unavailable for those items, then continue the analysis using the offline snapshot data already gathered (products/search fields, history, price/BSR/rating). Do not stall, silently re-run, or fabricate the missing realtime detail.
+
 ## Partial review pagination
 
 When `reviews-raw` fails after one or more successful pages, it returns `success=false`, preserves collected reviews and page count under `data`, and exposes the failed page request through `_failedQuery`. Never treat that payload as a complete review sample.

--- a/zoodata/references/openapi-reference.md
+++ b/zoodata/references/openapi-reference.md
@@ -621,3 +621,5 @@ Boundary note:
 | fulfillment | String | FBA/FBM/AMZ |
 | listingDate | String | |
 | buyBoxSellerName | String | |
+| categoryPath | List | Full category path root→leaf; always present — lets a keyword→category lookup resolve from the search row without a realtime call |
+| bsrCategory | String | BSR category name (root); fallback when `categoryPath` is absent |

--- a/zoodata/references/reference.md
+++ b/zoodata/references/reference.md
@@ -103,6 +103,8 @@ All endpoints return: `{success, data, error, meta}` with `meta.creditsRemaining
 | `listingDate` | string | When listed |
 | `salesGrowthRate` | float | Growth rate |
 | `variantCount` | int | Variants |
+| `categoryPath` | list | Full category path (root→leaf); always present — used to self-heal a keyword→category lookup without a realtime call |
+| `bsrCategory` | string | BSR category name (root); fallback when `categoryPath` is unexpectedly absent |
 
 ---
 

--- a/zoodata/scripts/zoodata.py
+++ b/zoodata/scripts/zoodata.py
@@ -533,7 +533,8 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     Priority:
       1. keyword → categories API
       2. asin → realtime/product → categoryPath or bestsellersRank leaf
-      3. keyword → products/search → first result → realtime/product
+      3. keyword → products/search → top row's categoryPath (else its bsrCategory);
+         no realtime call — the search row already carries the category.
     """
     category_path = None
     category_source = "user"
@@ -1304,9 +1305,9 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword like "yoga mat" with no direct category match still
-    # resolves a categoryPath — otherwise the market step below returns empty).
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword like "yoga mat" with no direct category match
+    # still resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
     _log = lambda m: print(m, file=sys.stderr)
@@ -1361,8 +1362,8 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
-    # fallback, so a product keyword with no direct category match still resolves a
+    # Step 1: Confirm category (self-healing: categories -> products/search row's
+    # categoryPath, so a product keyword with no direct category match still resolves a
     # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
     _caller = lambda ep, p, label=None: api_call(ep, p)
@@ -2135,6 +2136,10 @@ def cmd_daily_radar(args):
 
     # Step 1: Realtime Snapshot for All Tracked ASINs
     log(f"Step 1/7: Realtime snapshot ({len(tracked_asins)} ASINs)...")
+    # Note: unlike search-sourced composites, these ASINs are USER-SUPPLIED, so a
+    # persistent 200-empty may be a dead/typo ASIN rather than a transient miss. The
+    # empty-retry is still bounded (≤REALTIME_EMPTY_RETRIES fast calls per ASIN) and the
+    # offline-fallback hint surfaces it — a wrong ASIN costs a few extra credits, not a hang.
     realtime_snapshots = []
     for asin in tracked_asins:
         log(f"  → {asin}")

--- a/zoodata/scripts/zoodata.py
+++ b/zoodata/scripts/zoodata.py
@@ -88,6 +88,7 @@ API_DOCS = "https://api.zoodata.ai/api-docs"   # API documentation URL
 MAX_RETRIES = 3       # Total attempt budget for ordinary failed requests
 RETRY_DELAY = 2       # Initial retry delay in seconds; doubles on each retry
 RATE_LIMIT_RETRIES = 4  # Total attempt budget for 429 rate limits
+REALTIME_EMPTY_RETRIES = 3  # Total attempts when realtime/product returns a transient 200-empty (scrape miss)
 RATE_LIMIT_DELAY = 5    # Initial delay for 429 retries (seconds); doubles each time
 MIN_REQUEST_INTERVAL = 0.6  # Minimum seconds between requests (100 req/min = 0.6s)
 REQUEST_TIMEOUT = 60  # Request timeout in seconds; realtime/product can be slow (up to 30s)
@@ -570,7 +571,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_source = "asin_bsr"
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
-    # Priority 3: keyword → search → first product → realtime
+    # Priority 3: keyword → search → read categoryPath straight from the top product.
+    # products/search rows already carry categoryPath, so no extra realtime probe is
+    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
+    # bsrCategory, then to a realtime probe only as a last resort.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -578,23 +582,26 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
         }, "products (category probe)")
         prod_data = prod_result.get("data", [])
         if isinstance(prod_data, list) and prod_data:
-            probe_asin = prod_data[0].get("asin")
-            if probe_asin:
-                rt = api_caller("realtime/product", {"asin": probe_asin, "marketplace": "US"}, f"realtime {probe_asin}")
+            top = prod_data[0]
+            if top.get("categoryPath"):
+                category_path = top["categoryPath"]
+                category_source = "inferred_from_search"
+                log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
+            elif top.get("bsrCategory"):
+                cat_result = api_caller("categories", {"categoryKeyword": top["bsrCategory"]}, "categories")
+                cat_data = cat_result.get("data", [])
+                if cat_data:
+                    category_path = cat_data[0].get("categoryPath")
+                    category_source = "inferred_from_search"
+                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
+            elif top.get("asin"):
+                # Last resort only: realtime probe (flaky) with transient-empty retry.
+                rt = _fetch_realtime(api_caller, top["asin"])
                 rt_data = rt.get("data", {}) or {}
                 if rt_data.get("categoryPath"):
                     category_path = rt_data["categoryPath"]
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
-                elif rt_data.get("bestsellersRank"):
-                    leaf = rt_data["bestsellersRank"][-1].get("category", "")
-                    if leaf:
-                        cat_result = api_caller("categories", {"categoryKeyword": leaf}, "categories")
-                        cat_data = cat_result.get("data", [])
-                        if cat_data:
-                            category_path = cat_data[0].get("categoryPath")
-                            category_source = "inferred_from_search"
-                            log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 
@@ -630,6 +637,50 @@ def _skipped_after_abort():
             "message": "skipped: an earlier call in this composite hit a terminal interface failure",
         },
     }
+
+
+REALTIME_FALLBACK_HINT = (
+    "Realtime data collection failed for one or more items after retries. Tell the "
+    "user realtime lookup is temporarily unavailable, then continue the analysis "
+    "using the offline snapshot data already gathered (products/search fields, "
+    "history, price/BSR/rating) — do not stall or fabricate the missing realtime detail."
+)
+
+
+def _is_empty_realtime(result):
+    """True when realtime/product returned a 200-success but empty payload
+    (`data.asin` blank) — a transient scrape miss, not a hard error."""
+    if not isinstance(result, dict):
+        return False
+    data = result.get("data")
+    return isinstance(data, dict) and not data.get("asin")
+
+
+def _fetch_realtime(caller, asin, marketplace="US", label=None, attempts=REALTIME_EMPTY_RETRIES):
+    """Fetch realtime/product for a known-good ASIN (it came from a search result),
+    retrying a transient 200-empty up to `attempts` total. `caller(endpoint, params,
+    label)` is the composite's safe_call or an api_call adapter. If still empty after
+    all attempts, stamps result['_realtimeStatus']='empty_after_retries' so callers
+    can surface the offline-fallback hint. Does NOT retry a terminal failure."""
+    params = {"asin": asin, "marketplace": marketplace}
+    lbl = label or f"realtime {asin}"
+    r = caller("realtime/product", params, lbl)
+    n = 1
+    while n < attempts and _is_empty_realtime(r) and not _is_terminal_failure(r):
+        n += 1
+        r = caller("realtime/product", params, lbl)
+    if _is_empty_realtime(r):
+        r["_realtimeStatus"] = "empty_after_retries"
+    return r
+
+
+def _note_realtime_fallback(results, result):
+    """If a realtime result came back empty after retries, bump the composite-level
+    counter and set the user-facing offline-fallback hint on results['meta']."""
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        m = results.setdefault("meta", {})
+        m["realtimeUnavailable"] = m.get("realtimeUnavailable", 0) + 1
+        m["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
 
 
 def _mark_cli_error():
@@ -1295,7 +1346,8 @@ def cmd_report(args):
         top_asin = product_data[0].get("asin")
         if top_asin:
             print(f"Step 4/4: Getting details for top ASIN {top_asin}...", file=sys.stderr)
-            detail_result = api_call("realtime/product", {"asin": top_asin, "marketplace": "US"})
+            detail_result = _fetch_realtime(_caller, top_asin)
+            _note_realtime_fallback(results, detail_result)
             results["topProductDetail"] = detail_result
     else:
         print("Step 4/4: No products found, skipping detail.", file=sys.stderr)
@@ -1356,7 +1408,9 @@ def cmd_opportunity(args):
         asin = p.get("asin")
         if asin:
             print(f"Step 4/4: Getting details for {asin}...", file=sys.stderr)
-            details.append(api_call("realtime/product", {"asin": asin, "marketplace": "US"}))
+            r = _fetch_realtime(_caller, asin)
+            _note_realtime_fallback(results, r)
+            details.append(r)
     results["topProductDetails"] = details
 
     print("Done.", file=sys.stderr)
@@ -1396,6 +1450,16 @@ def cmd_market_entry(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1653,6 +1717,16 @@ def cmd_competitor_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -1829,6 +1903,16 @@ def cmd_pricing_analysis(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2032,6 +2116,16 @@ def cmd_daily_radar(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2193,6 +2287,16 @@ def cmd_listing_audit(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2420,6 +2524,16 @@ def cmd_opportunity_scan(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):
@@ -2623,6 +2737,16 @@ def cmd_review_deepdive(args):
         if results.get("meta", {}).get("aborted"):
             return _skipped_after_abort()
         r = api_call(endpoint, params)
+        # realtime/product is a scrape endpoint that can return a transient 200-empty;
+        # the ASIN is known-good in a composite, so retry, then hint offline fallback.
+        if endpoint == "realtime/product":
+            n = 1
+            while n < REALTIME_EMPTY_RETRIES and _is_empty_realtime(r) and not _is_terminal_failure(r):
+                n += 1
+                r = api_call(endpoint, params)
+            if _is_empty_realtime(r):
+                r["_realtimeStatus"] = "empty_after_retries"
+                _note_realtime_fallback(results, r)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
             if _is_terminal_failure(r):

--- a/zoodata/scripts/zoodata.py
+++ b/zoodata/scripts/zoodata.py
@@ -1283,11 +1283,17 @@ def cmd_product(args):
     if not args.asin:
         print("ERROR: --asin is required for product command.", file=sys.stderr)
         sys.exit(1)
-    params = {"asin": args.asin}
-    if args.marketplace:
-        params["marketplace"] = args.marketplace
-
-    result = api_call("realtime/product", params)
+    marketplace = args.marketplace or "US"
+    # realtime/product can return a transient 200-empty; retry like the composites do
+    # and, if still empty, surface the offline-fallback hint on the result's own meta so
+    # a per-ASIN poller (e.g. a Quick Check loop) gets the same signal to fall back to
+    # offline snapshot data instead of treating the empty payload as a real answer.
+    caller = lambda ep, p, label=None: api_call(ep, p)
+    result = _fetch_realtime(caller, args.asin, marketplace=marketplace)
+    if isinstance(result, dict) and result.get("_realtimeStatus") == "empty_after_retries":
+        meta = result.setdefault("meta", {})
+        meta["realtimeUnavailable"] = (meta.get("realtimeUnavailable") or 0) + 1
+        meta["realtimeFallbackHint"] = REALTIME_FALLBACK_HINT
     output(result, args.format)
 
 

--- a/zoodata/scripts/zoodata.py
+++ b/zoodata/scripts/zoodata.py
@@ -599,6 +599,39 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
     return category_path, category_source
 
 
+def _has_scope(keyword, category_path):
+    """A category-scoped discovery call (products/search, products/competitors,
+    markets/search for leaders) needs at least one filter. With neither keyword
+    nor categoryPath the API returns unfiltered global top-sellers — a real bug
+    that benchmarks a listing against random products. Callers MUST gate such
+    calls on this."""
+    return bool(keyword or category_path)
+
+
+def _is_terminal_failure(result):
+    """True when a call returned an exhausted terminal interface failure
+    (transport retries used up). Once one happens inside a composite, the
+    remaining fan-out calls will almost certainly hit the same wall, so the
+    composite should stop rather than stack retry x timeout for every endpoint."""
+    if not isinstance(result, dict):
+        return False
+    err = result.get("error")
+    return isinstance(err, dict) and bool(err.get("retryExhausted"))
+
+
+def _skipped_after_abort():
+    """Envelope a composite's safe_call returns once the command has aborted
+    after a terminal failure — no network call, no credits consumed."""
+    return {
+        "success": False,
+        "data": None,
+        "error": {
+            "code": "ABORTED_AFTER_TERMINAL_FAILURE",
+            "message": "skipped: an earlier call in this composite hit a terminal interface failure",
+        },
+    }
+
+
 def _mark_cli_error():
     """Remember an API failure without interrupting a composite command."""
     global _cli_had_error
@@ -1227,16 +1260,14 @@ def cmd_report(args):
     topn = str(args.topn or 10)
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword like "yoga mat" with no direct category match still
+    # resolves a categoryPath — otherwise the market step below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-
-    # Use the first matching category path
-    category_path = None
-    if cat_data:
-        category_path = cat_data[0].get("categoryPath")
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market data
     print("Step 2/4: Pulling market data...", file=sys.stderr)
@@ -1285,12 +1316,14 @@ def cmd_opportunity(args):
 
     results = {}
 
-    # Step 1: Confirm category
+    # Step 1: Confirm category (self-healing: categories -> products/search -> realtime
+    # fallback, so a product keyword with no direct category match still resolves a
+    # categoryPath — otherwise the market validation below returns empty).
     print("Step 1/4: Confirming category...", file=sys.stderr)
-    cat_result = api_call("categories", {"categoryKeyword": keyword})
-    results["categories"] = cat_result
-    cat_data = cat_result.get("data", [])
-    category_path = cat_data[0].get("categoryPath") if cat_data else None
+    _caller = lambda ep, p, label=None: api_call(ep, p)
+    _log = lambda m: print(m, file=sys.stderr)
+    category_path, category_source = _resolve_category(_caller, _log, keyword=keyword, results=results)
+    results.setdefault("meta", {})["category_source"] = category_source
 
     # Step 2: Market validation
     print("Step 2/4: Validating market...", file=sys.stderr)
@@ -1358,9 +1391,16 @@ def cmd_market_entry(args):
 
     def safe_call(endpoint, params, label=""):
         """Call API and return result. Never exit on error."""
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # ── Step 0.5: Category Resolution ──
@@ -1608,9 +1648,16 @@ def cmd_competitor_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -1777,9 +1824,16 @@ def cmd_pricing_analysis(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 1: Current Price Snapshot
@@ -1973,9 +2027,16 @@ def cmd_daily_radar(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2127,9 +2188,16 @@ def cmd_listing_audit(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Step 0.5: Category Resolution
@@ -2144,22 +2212,50 @@ def cmd_listing_audit(args):
     results["target_realtime"] = safe_call("realtime/product", {"asin": my_asin, "marketplace": "US"}, f"realtime {my_asin}")
     results["meta"]["steps_completed"].append("audit_target")
 
-    # Step 2: Category Leaders
-    log("Step 2/7: Finding category leaders...")
-    prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        prod_params["keyword"] = keyword
-    if category_path:
-        prod_params["categoryPath"] = category_path
-    results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+    # Step 1.5: Empty-target guard. If the target ASIN has no realtime data and no
+    # category resolved, the leader search below would run UNFILTERED and benchmark
+    # the listing against random global top-sellers. A missing target is not
+    # auditable — stop here rather than fabricate an audit against garbage peers.
+    _tgt = results["target_realtime"].get("data")
+    _tgt = _tgt if isinstance(_tgt, dict) else {}
+    if not _tgt.get("asin"):
+        results["meta"]["target_status"] = "empty"
+        results["meta"]["audit_status"] = "not_auditable"
+        results["meta"]["reason"] = (
+            "Target ASIN returned no realtime data (not indexed by ZooData or a "
+            "transient upstream failure). A listing audit cannot benchmark a missing "
+            "target; re-check the ASIN or retry later."
+        )
+        _mark_cli_error()
+        output(results, args.format)
+        return
+    results["meta"]["target_status"] = "ok"
 
-    comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
-                   "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
-    if keyword:
-        comp_params["keyword"] = keyword
-    if category_path:
-        comp_params["categoryPath"] = category_path
-    results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    # Step 2: Category Leaders — only with a scope, else the search is unfiltered.
+    log("Step 2/7: Finding category leaders...")
+    if _has_scope(keyword, category_path):
+        prod_params = {"pageSize": 20, "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            prod_params["keyword"] = keyword
+        if category_path:
+            prod_params["categoryPath"] = category_path
+        results["leader_products"] = safe_call("products/search", prod_params, "products leaders")
+
+        comp_params = {"pageSize": 20, "dateRange": "30d", "marketplace": "US", "page": 1,
+                       "sortBy": "monthlySalesFloor", "sortOrder": "desc"}
+        if keyword:
+            comp_params["keyword"] = keyword
+        if category_path:
+            comp_params["categoryPath"] = category_path
+        results["competitors"] = safe_call("products/competitors", comp_params, "competitors")
+    else:
+        _no_scope = {"success": False, "data": [], "error": {
+            "code": "NO_CATEGORY_SCOPE",
+            "message": "skipped: no keyword or category to scope discovery (would return unfiltered global results)"}}
+        results["leader_products"] = _no_scope
+        results["competitors"] = _no_scope
+        results["meta"].setdefault("warnings", []).append(
+            "leader/competitor discovery skipped — target had no category and no keyword to scope on")
     results["meta"]["steps_completed"].append("category_leaders")
 
     # Step 3: Benchmark Realtime (Top 5 leaders, deduplicated)
@@ -2319,9 +2415,16 @@ def cmd_opportunity_scan(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution
@@ -2515,9 +2618,16 @@ def cmd_review_deepdive(args):
         print(msg, file=sys.stderr)
 
     def safe_call(endpoint, params, label=""):
+        # Fail-fast: once a terminal interface failure trips this composite,
+        # skip remaining fan-out calls instead of stacking retry x timeout.
+        if results.get("meta", {}).get("aborted"):
+            return _skipped_after_abort()
         r = api_call(endpoint, params)
         if r.get("success") is False:
             log(f"  ⚠️ {label or endpoint}: {r.get('error', {}).get('message', 'failed')}")
+            if _is_terminal_failure(r):
+                results.setdefault("meta", {})["aborted"] = True
+                results["meta"]["abort_reason"] = f"terminal interface failure on {label or endpoint}"
         return r
 
     # Category Resolution

--- a/zoodata/scripts/zoodata.py
+++ b/zoodata/scripts/zoodata.py
@@ -572,9 +572,10 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     log_fn(f"  → Auto-detected category: {' > '.join(category_path)}")
 
     # Priority 3: keyword → search → read categoryPath straight from the top product.
-    # products/search rows already carry categoryPath, so no extra realtime probe is
-    # needed (realtime is a flaky scrape endpoint). Fall back to the product's
-    # bsrCategory, then to a realtime probe only as a last resort.
+    # products/search rows already carry categoryPath, so category resolution needs NO
+    # realtime call here (realtime is a flaky scrape endpoint). Fall back to the
+    # product's bsrCategory; if even that is absent (a data anomaly), leave the category
+    # unresolved rather than gamble on a flaky realtime probe for one field we can't get.
     if not category_path and keyword:
         log_fn("  → Resolving category from top search result...")
         prod_result = api_caller("products/search", {
@@ -594,14 +595,6 @@ def _resolve_category(api_caller, log_fn, keyword=None, asin=None, results=None)
                     category_path = cat_data[0].get("categoryPath")
                     category_source = "inferred_from_search"
                     log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path or [])} — AI should confirm with user")
-            elif top.get("asin"):
-                # Last resort only: realtime probe (flaky) with transient-empty retry.
-                rt = _fetch_realtime(api_caller, top["asin"])
-                rt_data = rt.get("data", {}) or {}
-                if rt_data.get("categoryPath"):
-                    category_path = rt_data["categoryPath"]
-                    category_source = "inferred_from_search"
-                    log_fn(f"  ⚠️ Auto-inferred category: {' > '.join(category_path)} — AI should confirm with user")
 
     return category_path, category_source
 


### PR DESCRIPTION
## Why

Live per-skill effectiveness testing (all 12 skills, real API) surfaced three confirmed gaps in the shared `zoodata.py` CLI, plus realtime/product scrape flakiness. All fixes live in the canonical `zoodata/scripts/zoodata.py`, synced byte-identical to the 10 `amazon-*/scripts/zoodata.py` copies.

## What

**③ listing-audit empty-target guard**
When the target ASIN's realtime returns empty (`data.asin == ""`) and no category resolves, the old code ran an **unfiltered** `products/search` and benchmarked the listing against random global top-sellers (Sharpie markers, cat litter, avocados as "yoga mat competitors"). Now short-circuits with `meta.audit_status="not_auditable"`. Added `_has_scope()` so no discovery call ever runs without a keyword or categoryPath.

**① report / opportunity category self-heal**
`cmd_report` / `cmd_opportunity` gave up when a product keyword ("yoga mat") had no direct category match, leaving the market dimension empty. Now route through `_resolve_category` and read `categoryPath` straight from the products/search row.

**② composite terminal-failure fail-fast**
Fan-out composites never short-circuited: on a terminal failure they kept hitting every remaining endpoint, stacking retry×timeout into multi-minute hangs on degenerate input. Now, once a call returns `retryExhausted`, the composite sets `meta.aborted` and skips the rest. Applied to all 7 fan-out composites via the shared `safe_call`. **Only genuine terminal failures trip it** — business-empty (`success:true, data:[]`) never does.

**realtime retry-on-empty + offline fallback**
`realtime/product` is a scrape endpoint that returns transient 200-empty payloads. Composite validation retries a transient empty up to `REALTIME_EMPTY_RETRIES=3` (candidate ASINs come from search → known to exist). If still empty after 3, sets `meta.realtimeUnavailable` + `meta.realtimeFallbackHint` so the agent tells the user realtime is unavailable and continues with offline snapshot data. Documented in `cli-contract.md`.

**category resolution no longer uses realtime**
`_resolve_category` priority-3 reads `categoryPath` from the products/search row (+ `bsrCategory` fallback), dropping the flaky realtime probe entirely — makes keyword→category self-heal deterministic.

## Verification

- **Full suite: 218 passed / 2 skipped** (+20 new tests: `TestCompositeRobustness`). 10 copies byte-identical (`sync-scripts.sh --check`).
- **Live (real API):**
  - ③ before/after on empty ASIN: main benchmarks Sharpie/cat-litter as competitors; fix returns `not_auditable`, stops at `audit_target`.
  - ① `report --keyword "yoga mat"` market went from **empty → 4466 SKUs**; deterministic across runs.
  - offline fallback fired live (`realtimeUnavailable=1`, hint set) when a candidate's realtime stayed empty.
  - `categoryPath`/`bsrCategory` present on **10/10** products rows (yoga) and **5/5** (coffee) — losslessness confirmed; both fields now documented in `reference.md`/`openapi-reference.md`.

## Review

Two rounds of plan + code review (composite robustness, then realtime/category changes): all requirements MET, degenerate-input latency SAFE (retry only fires on fast 200-empty, never on slow/terminal), no security/#92 transport regression, category rewrite lossless. The one blocking item (undocumented product fields) was resolved via live verification + docs.

## Commits
1. `10e2318` composite robustness (empty-target guard, category self-heal, terminal fail-fast)
2. `071fce4` non-abort boundary tests + doc precision
3. `54fe50d` realtime retry + offline-fallback hint + category self-heal without realtime
4. `99dd0c3` drop realtime last-resort from category resolution
5. `4e5e9b3` document categoryPath/bsrCategory + fix stale comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)