### PR TITLE
ci: notify ZooData Launch Tracking Group on production release (Lark)

### DIFF
--- a/.github/workflows/release-notify-lark.yml
+++ b/.github/workflows/release-notify-lark.yml
@@ -70,13 +70,17 @@ jobs:
           REF_NAME:   ${{ github.ref_name }}
           PUSH_SHA:   ${{ github.sha }}
           INPUT_TAG:  ${{ github.event.inputs.tag }}
+          DRY_RUN:    ${{ github.event.inputs.dry_run }}
           GH_ACTOR:   ${{ github.actor }}
         run: |
           set -euo pipefail
 
-          # vars.LARK_CHAT_RELEASE_GROUP unset -> fail-fast (avoid posting to the wrong group).
-          if [ -z "$RELEASE_CHAT_ID" ]; then
-            echo "::error::vars.LARK_CHAT_RELEASE_GROUP is empty; set it to the ZooData Launch Tracking Group chat_id before enabling release notify."
+          # chat_id only matters for an actual send. A dry_run dispatch (notes preview)
+          # is allowed to run before the group is configured; a real send (tag push, or
+          # dispatch with dry_run=false) fails fast when the target group is unset rather
+          # than posting to the wrong group.
+          if [ -z "$RELEASE_CHAT_ID" ] && [ "$DRY_RUN" != "true" ]; then
+            echo "::error::vars.LARK_CHAT_RELEASE_GROUP is empty; set it to the ZooData Launch Tracking Group chat_id before a real release notify (a dry_run preview does not need it)."
             exit 1
           fi
 

--- a/.github/workflows/release-notify-lark.yml
+++ b/.github/workflows/release-notify-lark.yml
@@ -1,0 +1,129 @@
+name: Release notify (Lark)
+
+# Sends a "Launch Tracking" Lark message to the ZooData Launch Tracking Group when a
+# production publish is tagged. ZooData-Skills publishes its skills to ClawHub manually
+# via `clawhub sync`; a production release is marked by pushing a
+# `zoodata-skills-v*-release` tag, which fires this workflow.
+#
+# The heavy lifting — baseline / rollback detection, PR changelog, Claude-generated
+# release notes, and the Lark send — is delegated to the shared reusable workflow
+# SerendipityOneInc/srp-actions/.github/workflows/release-notify-lark.yml@main, the same
+# one hermes-workspace uses. So the message format matches hermes exactly.
+#
+# Config prerequisites (see docs/release-notify.md):
+#   - repo variable  LARK_CHAT_RELEASE_GROUP  = ZooData Launch Tracking Group chat_id (oc_...)
+#   - repo variable  USER_MAPPING_JSON        = optional GitHub-login -> feishu open_id JSONL
+#   - inherited org/repo secrets: LARKSUITE_CLI_APP_ID, LARKSUITE_CLI_APP_SECRET,
+#     APP_ID, APP_PRIVATE_KEY, AWS_ROLE_TO_ASSUME  (the Lark bot must be a member of the group)
+#
+# Security: every github.event.* string input is injected via env: and double-quoted in
+# the shell to avoid command injection.
+
+on:
+  push:
+    tags:
+      - 'zoodata-skills-v*-release'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag, e.g. zoodata-skills-v1.2.3-release'
+        required: true
+      dry_run:
+        description: 'Only generate release notes, do NOT send the Lark message'
+        type: boolean
+        default: true
+      is_test:
+        description: 'Mark as a test message (false = manual resend of a real release)'
+        type: boolean
+        default: true
+
+# The reusable workflow requires these four; a caller may not grant fewer.
+permissions:
+  contents: read
+  pull-requests: read
+  id-token: write
+  actions: read
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    env:
+      # Target group = ZooData Launch Tracking. The repo variable LARK_CHAT_RELEASE_GROUP
+      # must be set; resolve fails fast when it is empty (safer than a hardcoded fallback
+      # chat_id that could silently post to the wrong group).
+      RELEASE_CHAT_ID: ${{ vars.LARK_CHAT_RELEASE_GROUP }}
+    outputs:
+      tag:           ${{ steps.ctx.outputs.tag }}
+      sha:           ${{ steps.ctx.outputs.sha }}
+      release_actor: ${{ steps.ctx.outputs.release_actor }}
+      should_notify: ${{ steps.ctx.outputs.should_notify }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full tag history: dispatch resolves the input tag to a commit SHA.
+          fetch-depth: 0
+
+      - name: Resolve context (tag / sha / actor)
+        id: ctx
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME:   ${{ github.ref_name }}
+          PUSH_SHA:   ${{ github.sha }}
+          INPUT_TAG:  ${{ github.event.inputs.tag }}
+          GH_ACTOR:   ${{ github.actor }}
+        run: |
+          set -euo pipefail
+
+          # vars.LARK_CHAT_RELEASE_GROUP unset -> fail-fast (avoid posting to the wrong group).
+          if [ -z "$RELEASE_CHAT_ID" ]; then
+            echo "::error::vars.LARK_CHAT_RELEASE_GROUP is empty; set it to the ZooData Launch Tracking Group chat_id before enabling release notify."
+            exit 1
+          fi
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+            # ^{commit} peels an annotated tag to its commit SHA so the reusable's
+            # changelog/baseline range compares against a real commit, not a tag object.
+            SHA="$(git rev-parse "${TAG}^{commit}" 2>/dev/null)" || {
+              echo "::error::Tag '${TAG}' not found in repo"; exit 1; }
+          else
+            TAG="$REF_NAME"
+            SHA="$PUSH_SHA"
+          fi
+
+          case "$TAG" in
+            zoodata-skills-v*-release) : ;;
+            *)
+              echo "::error::Unsupported tag: ${TAG} (expected zoodata-skills-v*-release)"
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "should_notify=true"
+            echo "tag=$TAG"
+            echo "sha=$SHA"
+            echo "release_actor=$GH_ACTOR"
+          } >> "$GITHUB_OUTPUT"
+          echo "Context: tag=$TAG sha=$SHA actor=$GH_ACTOR"
+
+  notify:
+    needs: resolve
+    if: needs.resolve.outputs.should_notify == 'true'
+    uses: SerendipityOneInc/srp-actions/.github/workflows/release-notify-lark.yml@main
+    with:
+      tag:                  ${{ needs.resolve.outputs.tag }}
+      head_sha:             ${{ needs.resolve.outputs.sha }}
+      project_name:         ZooData-Skills
+      # Whole-repo: skills are published together, no per-service path prefix.
+      path_filter:          ''
+      # No k8s deploy workflow; baseline lookup degrades to git-tag / root-commit.
+      deploy_workflow_file: shared-files-distribution.yml
+      tag_prefix:           zoodata-skills
+      chat_id:              ${{ vars.LARK_CHAT_RELEASE_GROUP }}
+      triggering_event:     ${{ github.event_name }}
+      is_test:              ${{ inputs.is_test || false }}
+      dry_run:              ${{ inputs.dry_run || false }}
+      release_actor:        ${{ needs.resolve.outputs.release_actor }}
+      user_mapping_json:    ${{ vars.USER_MAPPING_JSON }}
+    secrets: inherit

--- a/.github/workflows/release-notify-lark.yml
+++ b/.github/workflows/release-notify-lark.yml
@@ -1,9 +1,13 @@
 name: Release notify (Lark)
 
-# Sends a "Launch Tracking" Lark message to the ZooData Launch Tracking Group when a
-# production publish is tagged. ZooData-Skills publishes its skills to ClawHub manually
-# via `clawhub sync`; a production release is marked by pushing a
-# `zoodata-skills-v*-release` tag, which fires this workflow.
+# Sends a "Launch Tracking" Lark message to the ZooData Launch Tracking Group on each
+# repo-level production release. ZooData-Skills publishes its skills to ClawHub manually
+# via `clawhub sync`; a release is a repo-level milestone (0, 1, or many skills) cut as a
+# GitHub Release. Publishing this Release fires the notification.
+#
+# The release TAG must end in `-release` (e.g. v1.2.3-release) — the shared reusable's
+# changelog baseline detection matches production tags by a `release$` suffix. A normal
+# vX.Y.Z release (no suffix) is skipped, not an error.
 #
 # The heavy lifting — baseline / rollback detection, PR changelog, Claude-generated
 # release notes, and the Lark send — is delegated to the shared reusable workflow
@@ -20,13 +24,12 @@ name: Release notify (Lark)
 # the shell to avoid command injection.
 
 on:
-  push:
-    tags:
-      - 'zoodata-skills-v*-release'
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag, e.g. zoodata-skills-v1.2.3-release'
+        description: 'Release tag, e.g. v1.2.3-release'
         required: true
       dry_run:
         description: 'Only generate release notes, do NOT send the Lark message'
@@ -60,56 +63,59 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Full tag history: dispatch resolves the input tag to a commit SHA.
+          # Full tag history so the tag can be resolved to a commit SHA.
           fetch-depth: 0
 
       - name: Resolve context (tag / sha / actor)
         id: ctx
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          REF_NAME:   ${{ github.ref_name }}
-          PUSH_SHA:   ${{ github.sha }}
-          INPUT_TAG:  ${{ github.event.inputs.tag }}
-          DRY_RUN:    ${{ github.event.inputs.dry_run }}
-          GH_ACTOR:   ${{ github.actor }}
+          EVENT_NAME:          ${{ github.event_name }}
+          RELEASE_TAG:         ${{ github.event.release.tag_name }}
+          RELEASE_ACTOR_LOGIN: ${{ github.event.release.author.login }}
+          INPUT_TAG:           ${{ github.event.inputs.tag }}
+          DRY_RUN:             ${{ github.event.inputs.dry_run }}
+          GH_ACTOR:            ${{ github.actor }}
         run: |
           set -euo pipefail
 
-          # chat_id only matters for an actual send. A dry_run dispatch (notes preview)
-          # is allowed to run before the group is configured; a real send (tag push, or
-          # dispatch with dry_run=false) fails fast when the target group is unset rather
-          # than posting to the wrong group.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+            ACTOR="$GH_ACTOR"
+          else
+            TAG="$RELEASE_TAG"
+            ACTOR="${RELEASE_ACTOR_LOGIN:-$GH_ACTOR}"
+          fi
+
+          # Only production release tags (must end in -release, matching the reusable's
+          # baseline detection). A plain vX.Y.Z release is skipped quietly, not an error.
+          case "$TAG" in
+            v*-release) : ;;
+            *)
+              echo "::notice::Release tag '${TAG:-<empty>}' is not a v*-release production tag; skipping notify."
+              echo "should_notify=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          # chat_id only matters for an actual send. A dry_run dispatch (notes preview) is
+          # allowed before the group is configured; a real send fails fast when unset.
           if [ -z "$RELEASE_CHAT_ID" ] && [ "$DRY_RUN" != "true" ]; then
             echo "::error::vars.LARK_CHAT_RELEASE_GROUP is empty; set it to the ZooData Launch Tracking Group chat_id before a real release notify (a dry_run preview does not need it)."
             exit 1
           fi
 
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            TAG="$INPUT_TAG"
-            # ^{commit} peels an annotated tag to its commit SHA so the reusable's
-            # changelog/baseline range compares against a real commit, not a tag object.
-            SHA="$(git rev-parse "${TAG}^{commit}" 2>/dev/null)" || {
-              echo "::error::Tag '${TAG}' not found in repo"; exit 1; }
-          else
-            TAG="$REF_NAME"
-            SHA="$PUSH_SHA"
-          fi
-
-          case "$TAG" in
-            zoodata-skills-v*-release) : ;;
-            *)
-              echo "::error::Unsupported tag: ${TAG} (expected zoodata-skills-v*-release)"
-              exit 1
-              ;;
-          esac
+          # ^{commit} peels an annotated tag to its commit SHA so the reusable's
+          # changelog/baseline range compares against a real commit, not a tag object.
+          SHA="$(git rev-parse "${TAG}^{commit}" 2>/dev/null)" || {
+            echo "::error::Tag '${TAG}' not found in repo"; exit 1; }
 
           {
             echo "should_notify=true"
             echo "tag=$TAG"
             echo "sha=$SHA"
-            echo "release_actor=$GH_ACTOR"
+            echo "release_actor=$ACTOR"
           } >> "$GITHUB_OUTPUT"
-          echo "Context: tag=$TAG sha=$SHA actor=$GH_ACTOR"
+          echo "Context: tag=$TAG sha=$SHA actor=$ACTOR"
 
   notify:
     needs: resolve
@@ -119,11 +125,12 @@ jobs:
       tag:                  ${{ needs.resolve.outputs.tag }}
       head_sha:             ${{ needs.resolve.outputs.sha }}
       project_name:         ZooData-Skills
-      # Whole-repo: skills are published together, no per-service path prefix.
+      # Whole-repo: a release is a repo-level milestone across all skills.
       path_filter:          ''
       # No k8s deploy workflow; baseline lookup degrades to git-tag / root-commit.
       deploy_workflow_file: shared-files-distribution.yml
-      tag_prefix:           zoodata-skills
+      # Empty prefix -> reusable matches bare `v*-release` tags (this repo's convention).
+      tag_prefix:           ''
       chat_id:              ${{ vars.LARK_CHAT_RELEASE_GROUP }}
       triggering_event:     ${{ github.event_name }}
       is_test:              ${{ inputs.is_test || false }}

--- a/.github/workflows/release-notify-lark.yml
+++ b/.github/workflows/release-notify-lark.yml
@@ -127,12 +127,17 @@ jobs:
       project_name:         ZooData-Skills
       # Whole-repo: a release is a repo-level milestone across all skills.
       path_filter:          ''
-      # No k8s deploy workflow; baseline lookup degrades to git-tag / root-commit.
-      deploy_workflow_file: shared-files-distribution.yml
+      # No deploy workflow exists; this is an intentional non-matching placeholder so the
+      # reusable's baseline lookup degrades to git-tag / root-commit (it does NOT gate releases).
+      deploy_workflow_file: no-deploy.yml
       # Empty prefix -> reusable matches bare `v*-release` tags (this repo's convention).
       tag_prefix:           ''
       chat_id:              ${{ vars.LARK_CHAT_RELEASE_GROUP }}
-      triggering_event:     ${{ github.event_name }}
+      # A GitHub Release is an automatic production release (hermes gets this via
+      # workflow_run after deploy); map it to workflow_run so the reusable emits the clean
+      # "正式发布" label instead of "正式发布（手动重发）". A manual dispatch keeps its own
+      # event so it still labels as a test / manual resend.
+      triggering_event:     ${{ github.event_name == 'release' && 'workflow_run' || github.event_name }}
       is_test:              ${{ inputs.is_test || false }}
       dry_run:              ${{ inputs.dry_run || false }}
       release_actor:        ${{ needs.resolve.outputs.release_actor }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,5 +6,12 @@ affected skill's `SKILL.md` and review its modules against the responsibility
 map declared there. Run the relevant consistency tests before completing the
 change.
 
+## Releasing / publishing
+
+Skills are published to ClawHub **manually** via `clawhub sync` (the ClawHub key stays
+local — never in CI). A release is a repo-level milestone cut as a GitHub Release whose
+tag ends in `-release` (e.g. `v1.2.3-release`); publishing that Release fires the Lark
+launch-tracking notification. See `docs/release-notify.md`.
+
 Keep this file as an instruction bridge. Do not copy skill-specific contracts,
 module policies, or runtime rules into it.

--- a/docs/release-notify.md
+++ b/docs/release-notify.md
@@ -1,0 +1,74 @@
+# Production release → Lark notification
+
+When ZooData-Skills is published to production, a "Launch Tracking" message is posted to
+the **ZooData Launch Tracking Group** on Lark/Feishu. The message format (Chinese release
+notes generated from the PR changelog, per-item source links and @mentions, rollback /
+redeploy detection) is identical to hermes — both delegate to the same shared reusable
+workflow `SerendipityOneInc/srp-actions/.github/workflows/release-notify-lark.yml`.
+
+Workflow: [`.github/workflows/release-notify-lark.yml`](../.github/workflows/release-notify-lark.yml).
+
+## How a release fires the notification
+
+ZooData-Skills publishes its skills to ClawHub **manually** (`clawhub sync`). A production
+release is marked by pushing a release **tag**, which triggers the notification:
+
+```bash
+# 1. Publish to production as usual
+clawhub --dir . sync --all --owner apiclaw
+
+# 2. Tag the released commit and push the tag
+git tag zoodata-skills-v1.2.3-release
+git push origin zoodata-skills-v1.2.3-release
+```
+
+The tag pattern is `zoodata-skills-v*-release`. Pushing it runs `release-notify-lark.yml`,
+which resolves the tag/commit/actor and delegates to the shared reusable workflow to build
+and send the Lark message. The changelog covers PRs merged since the previous
+`zoodata-skills-v*-release` tag (first release ⇒ since the repo root commit).
+
+## Manual run / testing (`workflow_dispatch`)
+
+Run **Actions → Release notify (Lark) → Run workflow** with:
+
+| Input | Default | Meaning |
+|-------|---------|---------|
+| `tag` | — (required) | An existing `zoodata-skills-v*-release` tag to (re)notify for |
+| `dry_run` | `true` | Generate the release notes but **do not** send to Lark — use this to preview |
+| `is_test` | `true` | Label the message as a test (`false` = manual resend of a real release) |
+
+Recommended first run: `dry_run: true` to verify the notes render, then `dry_run: false`.
+
+## Configuration prerequisites (one-time, ops)
+
+The workflow itself is committed, but it needs the following configured on the repo /
+org before it can send. Until `LARK_CHAT_RELEASE_GROUP` is set, the `resolve` job
+**fails fast** on purpose (rather than posting to the wrong group).
+
+### Repository variables (Settings → Secrets and variables → Actions → Variables)
+
+| Variable | Required | Value |
+|----------|----------|-------|
+| `LARK_CHAT_RELEASE_GROUP` | **yes** | The ZooData Launch Tracking Group `chat_id` (`oc_…`). Create the group if it does not exist and add the notifier bot to it. |
+| `USER_MAPPING_JSON` | no | JSONL mapping GitHub login → Feishu `open_id` for @mentions. Empty ⇒ mentions degrade to literal `@login` text. |
+
+### Inherited secrets (org or repo level; passed via `secrets: inherit`)
+
+The reusable workflow needs the same secrets hermes uses. Ensure they are available to
+ZooData-Skills (org-level secrets cover all repos; otherwise add them to this repo):
+
+| Secret | Used for |
+|--------|----------|
+| `LARKSUITE_CLI_APP_ID` / `LARKSUITE_CLI_APP_SECRET` | Lark bot app credentials (mint tenant token, send the message). **The bot must be a member of the target group.** |
+| `APP_ID` / `APP_PRIVATE_KEY` | GitHub App token for the Claude Code release-notes step |
+| `AWS_ROLE_TO_ASSUME` | AWS OIDC role → Bedrock (Claude generates the notes) |
+
+## Notes
+
+- **No ClawHub key in CI.** Publishing stays a manual `clawhub sync`; this workflow only
+  *notifies* on the release tag. It never handles the ClawHub API key.
+- **Baseline detection degrades gracefully.** ZooData-Skills has no k8s deploy workflow;
+  the reusable falls back from deploy-run history → previous release tag → repo root
+  commit, so the changelog range is always well-defined.
+- To change the message format, update the shared reusable in `srp-actions` — both hermes
+  and ZooData-Skills pick it up.

--- a/docs/release-notify.md
+++ b/docs/release-notify.md
@@ -29,6 +29,11 @@ and send the Lark message. The changelog covers PRs merged since the previous
 
 ## Manual run / testing (`workflow_dispatch`)
 
+> `workflow_dispatch` only becomes available **after this workflow is on the default
+> branch (`main`)** — GitHub does not expose the "Run workflow" button (or the
+> `gh workflow run` API) for a workflow that exists only on a feature branch. So merge
+> the PR first, then dispatch.
+
 Run **Actions → Release notify (Lark) → Run workflow** with:
 
 | Input | Default | Meaning |
@@ -38,6 +43,22 @@ Run **Actions → Release notify (Lark) → Run workflow** with:
 | `is_test` | `true` | Label the message as a test (`false` = manual resend of a real release) |
 
 Recommended first run: `dry_run: true` to verify the notes render, then `dry_run: false`.
+
+**A `dry_run: true` preview does not need the group configured** — `resolve` skips the
+`LARK_CHAT_RELEASE_GROUP` fail-fast, and the Lark send is skipped, so
+`LARK_CHAT_RELEASE_GROUP` and the `LARKSUITE_CLI_*` secrets are not required. It **does**
+still run Claude release-notes generation, so the `APP_ID` / `APP_PRIVATE_KEY` /
+`AWS_ROLE_TO_ASSUME` secrets must be available. A real send (`dry_run: false` or a tag
+push) needs everything in the tables below.
+
+To dispatch a dry-run against a throwaway tag:
+
+```bash
+git tag zoodata-skills-v0.0.0-release <some-commit> && git push origin zoodata-skills-v0.0.0-release
+gh workflow run "Release notify (Lark)" -f tag=zoodata-skills-v0.0.0-release -f dry_run=true -f is_test=true
+# inspect the run logs for the rendered release-notes.md, then delete the throwaway tag
+git push origin :zoodata-skills-v0.0.0-release
+```
 
 ## Configuration prerequisites (one-time, ops)
 

--- a/docs/release-notify.md
+++ b/docs/release-notify.md
@@ -10,22 +10,35 @@ Workflow: [`.github/workflows/release-notify-lark.yml`](../.github/workflows/rel
 
 ## How a release fires the notification
 
-ZooData-Skills publishes its skills to ClawHub **manually** (`clawhub sync`). A production
-release is marked by pushing a release **tag**, which triggers the notification:
+A release is a **repo-level milestone** — one release may publish 0, 1, or many skills.
+ZooData-Skills publishes its skills to ClawHub **manually** (`clawhub sync`); the release
+is then cut as a **GitHub Release**, and publishing that Release fires the notification
+(`on: release: [published]`). One release ⇒ one message.
 
 ```bash
-# 1. Publish to production as usual
+# 1. Publish to production as usual (manual; may touch 0, 1, or many skills)
 clawhub --dir . sync --all --owner apiclaw
 
-# 2. Tag the released commit and push the tag
-git tag zoodata-skills-v1.2.3-release
-git push origin zoodata-skills-v1.2.3-release
+# 2. Cut a GitHub Release whose tag ends in `-release`
+gh release create v1.2.3-release --title "v1.2.3 — <headline>" --notes "..."
+#   (or via the GitHub UI — Releases → Draft a new release)
 ```
 
-The tag pattern is `zoodata-skills-v*-release`. Pushing it runs `release-notify-lark.yml`,
-which resolves the tag/commit/actor and delegates to the shared reusable workflow to build
-and send the Lark message. The changelog covers PRs merged since the previous
-`zoodata-skills-v*-release` tag (first release ⇒ since the repo root commit).
+### Tag convention: the tag must end in `-release`
+
+The shared reusable matches the previous production release by a **`release$` tag suffix**
+(the same rule hermes uses). So release tags **must** be `v*-release` (e.g.
+`v1.2.3-release`), not the bare `v1.2.2` this repo used historically. A plain `vX.Y.Z`
+release (no `-release` suffix) is **skipped, not an error** — `resolve` logs a notice and
+sets `should_notify=false`.
+
+The changelog covers PRs merged since the previous `v*-release` tag. The **first** release
+under this convention has no prior `-release` tag, so its changelog falls back to the repo
+root commit (a one-time full history); every release after that is scoped correctly.
+
+> `clawhub sync` itself does **not** trigger anything — it is a local CLI call with no
+> GitHub event. The GitHub Release is the release signal; the workflow only *notifies* and
+> never handles the ClawHub key.
 
 ## Manual run / testing (`workflow_dispatch`)
 
@@ -38,7 +51,7 @@ Run **Actions → Release notify (Lark) → Run workflow** with:
 
 | Input | Default | Meaning |
 |-------|---------|---------|
-| `tag` | — (required) | An existing `zoodata-skills-v*-release` tag to (re)notify for |
+| `tag` | — (required) | An existing `v*-release` tag to (re)notify for |
 | `dry_run` | `true` | Generate the release notes but **do not** send to Lark — use this to preview |
 | `is_test` | `true` | Label the message as a test (`false` = manual resend of a real release) |
 
@@ -54,10 +67,10 @@ push) needs everything in the tables below.
 To dispatch a dry-run against a throwaway tag:
 
 ```bash
-git tag zoodata-skills-v0.0.0-release <some-commit> && git push origin zoodata-skills-v0.0.0-release
-gh workflow run "Release notify (Lark)" -f tag=zoodata-skills-v0.0.0-release -f dry_run=true -f is_test=true
+git tag v0.0.0-release <some-commit> && git push origin v0.0.0-release
+gh workflow run "Release notify (Lark)" -f tag=v0.0.0-release -f dry_run=true -f is_test=true
 # inspect the run logs for the rendered release-notes.md, then delete the throwaway tag
-git push origin :zoodata-skills-v0.0.0-release
+git push origin :v0.0.0-release
 ```
 
 ## Configuration prerequisites (one-time, ops)


### PR DESCRIPTION
## Why

When ZooData-Skills is released to production, the team should get a Launch Tracking message in Lark — same as hermes-workspace. This reuses the **exact reusable workflow hermes uses**, so the message format is identical.

## What

New workflow `.github/workflows/release-notify-lark.yml` + docs `docs/release-notify.md` + a CLAUDE.md pointer.

- **Trigger**: `on: release: [published]` — fires when a **GitHub Release** is published (this repo already releases via GitHub Releases: v1.1.0–v1.2.2). Plus `workflow_dispatch` (`tag` / `dry_run` / `is_test`) for manual/test/resend.
- **Repo-level**: one release = one message, covering whatever changed (0, 1, or many skills). Skills are published to ClawHub **manually** via `clawhub sync`; the GitHub Release is the release signal.
- **Tag convention**: the release tag must end in **`-release`** (e.g. `v1.2.3-release`). The shared reusable matches the previous production release by a `release$` suffix, so a bare `vX.Y.Z` release is **skipped (notice, not error)**.
- **`resolve` job**: reads tag/sha/actor from the release event, resolves tag→commit SHA, fail-fasts if `vars.LARK_CHAT_RELEASE_GROUP` is unset (unless `dry_run`); all `github.event.*` inputs injected via `env:` and double-quoted (no command injection).
- **`notify` job**: delegates to `SerendipityOneInc/srp-actions/.github/workflows/release-notify-lark.yml@main` (the same reusable hermes calls) with `secrets: inherit`.

### Design notes
- **No ClawHub key in CI.** Publishing stays a manual `clawhub sync`; this workflow only *notifies*.
- **A GitHub Release maps to `triggering_event: workflow_run`** for the reusable so it emits the clean "正式发布" label; manual dispatch keeps its own event for test/resend labels.
- **Baseline degrades gracefully** without a deploy workflow (`deploy_workflow_file` is an inert placeholder → git-tag / root-commit baseline). First `-release` release has a one-time full-history changelog; subsequent ones scoped correctly.

## Release flow (documented in `docs/release-notify.md`)
```bash
clawhub --dir . sync --all --owner apiclaw                 # publish to prod (manual, as today)
gh release create v1.2.3-release --title "v1.2.3 — ..." --notes "..."   # -> fires the notify
```

## ⚠️ One-time config required before it can send (ops)
- repo var **`LARK_CHAT_RELEASE_GROUP`** = ZooData Launch Tracking Group `chat_id` (create the group + add the notifier bot if needed). Until set, `resolve` fails fast by design.
- optional repo var `USER_MAPPING_JSON` (GitHub login -> Feishu open_id for @mentions).
- inherited org secrets: `LARKSUITE_CLI_APP_ID` / `LARKSUITE_CLI_APP_SECRET`, `APP_ID`, `APP_PRIVATE_KEY`, `AWS_ROLE_TO_ASSUME`. The Lark bot must be a member of the group.

Recommended validation: after merge, `workflow_dispatch` with `dry_run: true` against a throwaway `v0.0.0-release` tag (renders notes, no send), then real releases.

## Review
Plan + code review (both safe-to-merge, no blocking bugs): requirement met (repo-level, hermes format, correct group), injection SAFE, all 7 required reusable inputs present & correct, `tag_prefix:'' + production` verified to match `v*-release`. Fixed from review: release->workflow_run label mapping, inert deploy_workflow_file placeholder, this description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)