### PR TITLE
docs(AGENTS.md): mirror the CLAUDE.md release/publish pointer (fix bridge test)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,5 +6,12 @@ affected skill's `SKILL.md` and review its modules against the responsibility
 map declared there. Run the relevant consistency tests before completing the
 change.
 
+## Releasing / publishing
+
+Skills are published to ClawHub **manually** via `clawhub sync` (the ClawHub key stays
+local — never in CI). A release is a repo-level milestone cut as a GitHub Release whose
+tag ends in `-release` (e.g. `v1.2.3-release`); publishing that Release fires the Lark
+launch-tracking notification. See `docs/release-notify.md`.
+
 Keep this file as an instruction bridge. Do not copy skill-specific contracts,
 module policies, or runtime rules into it.


### PR DESCRIPTION
## Why

`test_agent_instruction_bridges` requires the two repository instruction bridges — `CLAUDE.md` (for Claude Code) and `AGENTS.md` (for other AI agents) — to be **byte-identical apart from the title**. PR #96 added a "Releasing / publishing" pointer to `CLAUDE.md` but did not mirror it into `AGENTS.md`, so the test currently **fails on `main`**.

## What

Add the same "Releasing / publishing" paragraph to `AGENTS.md`, restoring the mirror. One file, +7 lines.

- Both files now carry the pointer (skills publish to ClawHub manually via `clawhub sync`; a release is a GitHub Release with a `-release` tag that fires the Lark notification — details in `docs/release-notify.md`).
- These are **repo-root developer/agent instruction files** — not part of any skill bundle, so this does not affect published skills.

## Verification
`python -m pytest tests/test_agent_instruction_bridges.py` → passes. Full suite green (220 passed / 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
