### PR TITLE
test: pin composite-command output-envelope shape

### DIFF
--- a/tests/test_zoodata.py
+++ b/tests/test_zoodata.py
@@ -1756,6 +1756,92 @@ class TestCompositeRobustness(unittest.TestCase):
         self.assertNotIn("realtimeFallbackHint", result.get("meta", {}))
 
 
+class TestCompositeEnvelopeShape(unittest.TestCase):
+    """Shape contract for composite commands: output is a dict of NAMED
+    SECTIONS plus a top-level `meta` total, with NO top-level `success`/`data`
+    key. cli-contract.md requires a consumer to "inspect nested endpoint
+    results before classifying the whole workflow" — i.e. classify a composite
+    by its sections, never by a flat top-level success flag. This guard pins
+    that shape so a refactor can't silently flatten a composite into one
+    envelope: a naive `result["success"]` reader would then mistake a
+    multi-section bundle for a single pass/fail. (Section VALUES vary
+    legitimately — envelope / list / dict — so only the top-level invariant is
+    asserted, not per-section structure.)
+    """
+
+    # Every fan-out command: one invocation dispatches to multiple endpoints.
+    COMPOSITES = {
+        "report":              ["report", "--keyword", "yoga mat"],
+        "opportunity":         ["opportunity", "--keyword", "yoga mat"],
+        "market-entry":        ["market-entry", "--keyword", "yoga mat", "--category", "A > B"],
+        "competitor-analysis": ["competitor-analysis", "--keyword", "yoga mat", "--category", "A > B", "--my-asin", "B0TEST0001"],
+        "pricing-analysis":    ["pricing-analysis", "--keyword", "yoga mat", "--category", "A > B", "--my-asin", "B0TEST0001"],
+        "daily-radar":         ["daily-radar", "--asins", "B0TEST0001", "--category", "A > B"],
+        "listing-audit":       ["listing-audit", "--my-asin", "B0TEST0001", "--category", "A > B"],
+        "opportunity-scan":    ["opportunity-scan", "--keyword", "yoga mat", "--category", "A > B"],
+    }
+
+    def _run(self, argv, router):
+        captured = {}
+
+        def fake_api_call(endpoint, params):
+            resp = dict(router(endpoint, dict(params)))
+            resp.setdefault("_query", {"endpoint": endpoint, "params": params})
+            return resp
+
+        def fake_output(data, fmt="json"):
+            captured["results"] = data
+
+        with patch.object(zoodata, "api_call", side_effect=fake_api_call), \
+             patch.object(zoodata, "output", side_effect=fake_output), \
+             patch.object(sys, "argv", ["zoodata.py", *argv]):
+            try:
+                zoodata.main()
+            except SystemExit:
+                pass
+        return captured.get("results", {})
+
+    # The real API returns object-shaped `data` for these endpoints and
+    # list-shaped `data` for collection endpoints; composites read them with
+    # the matching access pattern, so the stub must mirror the real shape.
+    _DICT_DATA_ENDPOINTS = {
+        "realtime/product", "products/brand-overview", "products/brand-detail",
+        "products/price-band-overview", "products/price-band-detail",
+        "reviews/analysis", "products/history",
+    }
+
+    @classmethod
+    def _router(cls, endpoint, params):
+        # One generous row carrying every field the composites read to fan out
+        # and summarize (categoryPath for self-heal, brand/price-band/review
+        # fields for the object endpoints).
+        row = {"asin": params.get("asin") or "B0TEST0001",
+               "categoryPath": ["Sports & Outdoors", "Yoga", "Mats"],
+               "title": "Test", "bsr": 10, "rating": 4.5, "ratingCount": 100,
+               "sampleAvgMonthlyRevenue": 1000, "monthlySalesFloor": 100,
+               "sampleBrandCount": 3, "sampleTop10BrandSalesRate": 0.4,
+               "sampleAvgPrice": 25.0, "hottestBand": {"bandLabel": "$20-$25"},
+               "ratingBreakdown": {}, "consumerInsights": []}
+        data = dict(row) if endpoint in cls._DICT_DATA_ENDPOINTS else [dict(row)]
+        return {"success": True, "data": data, "meta": {"creditsConsumed": 1}}
+
+    def test_composites_emit_named_sections_not_a_top_level_envelope(self):
+        for name, argv in self.COMPOSITES.items():
+            out = self._run(argv, self._router)
+            with self.subTest(composite=name):
+                self.assertIsInstance(out, dict, f"{name}: non-dict output")
+                # THE invariant consumers rely on — and the exact shape a naive
+                # top-level-success reader gets wrong:
+                self.assertNotIn("success", out,
+                    f"{name}: composite grew a top-level 'success' — consumers "
+                    "must classify by section, not a flat flag")
+                self.assertNotIn("data", out,
+                    f"{name}: composite grew a top-level 'data' key")
+                self.assertIn("meta", out, f"{name}: missing composite meta total")
+                sections = [k for k in out if k != "meta"]
+                self.assertTrue(sections, f"{name}: produced no named sections")
+
+
 # Standalone runner
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":

--- a/tests/test_zoodata.py
+++ b/tests/test_zoodata.py
@@ -1770,6 +1770,14 @@ class TestCompositeEnvelopeShape(unittest.TestCase):
     """
 
     # Every fan-out command: one invocation dispatches to multiple endpoints.
+    # Curated by hand, NOT auto-derived: the CLI help text is not a reliable
+    # composite marker (e.g. `daily-radar` says "runs all tracking endpoints"
+    # with no "composite" keyword, while single-endpoint `keyword-market-profile`
+    # / `review-deepdive` mention "multidimensional"/"Full ... analysis"). A
+    # renamed or removed composite is already caught — a stale key becomes an
+    # unknown subcommand, argparse exits, `_run` returns {}, and the
+    # `assertIn("meta", out)` below fails loudly. Only a BRAND-NEW composite is
+    # invisible here; add its row when you add the command.
     COMPOSITES = {
         "report":              ["report", "--keyword", "yoga mat"],
         "opportunity":         ["opportunity", "--keyword", "yoga mat"],
@@ -1804,6 +1812,10 @@ class TestCompositeEnvelopeShape(unittest.TestCase):
     # The real API returns object-shaped `data` for these endpoints and
     # list-shaped `data` for collection endpoints; composites read them with
     # the matching access pattern, so the stub must mirror the real shape.
+    # WARNING: removing an entry (reclassifying a dict endpoint as list) makes
+    # the composite's `.get()` chain hit a list -> AttributeError, which
+    # surfaces as a test ERROR, not a clean shape assertion. Keep this in sync
+    # with the real per-endpoint shapes (characterized against live output).
     _DICT_DATA_ENDPOINTS = {
         "realtime/product", "products/brand-overview", "products/brand-detail",
         "products/price-band-overview", "products/price-band-detail",


### PR DESCRIPTION
## Description

Pins the **output-envelope shape of composite commands** so a refactor can't silently break section-aware consumers.

Composite commands (`report`, `opportunity`, `market-entry`, `competitor-analysis`, `pricing-analysis`, `daily-radar`, `listing-audit`, `opportunity-scan`) emit a dict of **named sections** plus a top-level `meta` total, with **no** top-level `success`/`data` key. `cli-contract.md` already requires consumers to *"inspect nested endpoint results before classifying the whole workflow"* — i.e. classify a composite by its sections, never by a flat top-level flag. That contract was documented but **not test-guarded**: a refactor could flatten a composite into a single envelope and every section-aware consumer would break silently (a naive `result["success"]` reader would treat a multi-section bundle as one pass/fail).

This is a pre-existing structural gap, independent of the ClawHub remediation in #99 — hence a separate, test-only PR off `main`.

## What it adds

`TestCompositeEnvelopeShape` in `tests/test_zoodata.py`:
- Runs each of the 8 composites through the existing stub-router harness (**no credits, no network**).
- Asserts the **top-level invariant only**: output is a dict, has `meta`, has ≥1 named section, and has **no** top-level `success`/`data`. Section *values* vary legitimately (envelope / list / dict), so per-section structure is deliberately not asserted.
- The stub router mirrors the **real per-endpoint data shape** (object-shaped `data` for `realtime`/`brand-*`/`price-band-*`/`reviews`/`history`; list-shaped for `categories`/`markets`/`products`/`competitors`) — characterized against live API output.

## Verification

- Full suite: **221 passed, 2 skipped, 512 subtests**.
- **Seed-verified** (not vacuous): injecting a top-level `success` into a composite's `results` dict makes the guard fail at the `assertNotIn("success")` assertion; removing it restores green.

## Type of Change
- [x] Test only (no production code touched)

## Checklist
- [x] I have tested my changes
- [x] My code follows the project style guidelines (reuses the `TestCompositeRobustness` stub-router pattern)
- [x] I have read CONTRIBUTING.md
