### PR TITLE
chore: align 5 skill frontmatter versions to ClawHub registry+patch

### DIFF
--- a/amazon-analysis/SKILL.md
+++ b/amazon-analysis/SKILL.md
@@ -13,7 +13,7 @@ description: >
     deliverable in mind
   Uses {skill_base_dir}/scripts/zoodata.py. Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.1.14"
+  version: "1.1.13"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-daily-market-radar/SKILL.md
+++ b/amazon-daily-market-radar/SKILL.md
@@ -19,7 +19,7 @@ description: >
   vague update questions.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.10"
+  version: "1.0.9"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-keyword-traffic-analysis/SKILL.md
+++ b/amazon-keyword-traffic-analysis/SKILL.md
@@ -8,7 +8,7 @@ description: >
   does not make direct bid, budget, pause, or negative-keyword decisions without
   seller ABA-SQP and Amazon Ads data. Requires ZOODATA_API_KEY.
 metadata:
-  version: "0.1.7"
+  version: "0.1.6"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-opportunity-discoverer/SKILL.md
+++ b/amazon-opportunity-discoverer/SKILL.md
@@ -13,7 +13,7 @@ description: >
   category trends over time, use amazon-market-trend-scanner.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.10"
+  version: "1.0.9"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}

--- a/amazon-review-intelligence-extractor/SKILL.md
+++ b/amazon-review-intelligence-extractor/SKILL.md
@@ -11,7 +11,7 @@ description: >
   review comparison, negative reviews, customer complaints, buying factors, user profile.
   Requires ZOODATA_API_KEY.
 metadata:
-  version: "1.0.10"
+  version: "1.0.9"
   author: SerendipityOneInc
   homepage: https://github.com/SerendipityOneInc/ZooData-Skills
   openclaw: {"requires": {"env": ["ZOODATA_API_KEY"]}, "primaryEnv": "ZOODATA_API_KEY"}


### PR DESCRIPTION
## What

`clawhub sync` computes the publish version as `registry_latest + patch` and does **not** read the frontmatter `version`. Five skills' frontmatter had drifted ahead of the ClawHub registry (prior PRs bumped them faster than republishes happened); the batch bump in #99 then left them 2 ahead of what clawhub actually publishes. This aligns each to the exact version clawhub published, so the shipped bundle's frontmatter matches the registry.

| skill | was | now (= published) |
|---|---|---|
| amazon-analysis | 1.1.14 | 1.1.13 |
| amazon-daily-market-radar | 1.0.10 | 1.0.9 |
| amazon-keyword-traffic-analysis | 0.1.7 | 0.1.6 |
| amazon-opportunity-discoverer | 1.0.10 | 1.0.9 |
| amazon-review-intelligence-extractor | 1.0.10 | 1.0.9 |

The other 7 skills already matched and are unchanged.

## Provenance

This branch's commit `11de0ac` is the exact source published to ClawHub (all 12 skills submitted, pending security scans) via `clawhub sync --all --source-commit 11de0ac`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)